### PR TITLE
Radio + playlist intelligence for Listen

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -101,6 +101,11 @@ dev-test: ## Correr tests en el contenedor dev
 regression-api: ## Contratos backend criticos (Explore/search/system playlists)
 	@$(DC_DEV) exec worker pytest tests/test_explore_contracts.py tests/test_upload_contracts.py -q
 
+.PHONY: regression-radio
+regression-radio: ## Contratos de radio usando una imagen efimera del backend del branch actual
+	@docker build -t crate-radio-tests ./app
+	@docker run --rm --entrypoint pytest crate-radio-tests tests/test_radio_contracts.py -q
+
 .PHONY: regression-smoke
 regression-smoke: ## Smoke real contra el entorno dev autenticado
 	@python3 scripts/regression_smoke.py

--- a/app/crate/api/__init__.py
+++ b/app/crate/api/__init__.py
@@ -67,11 +67,13 @@ def create_app() -> FastAPI:
     from crate.api.tidal import router as tidal_router
     from crate.api.acquisition import router as acquisition_router
     from crate.api.me import router as me_router
+    from crate.api.radio import router as radio_router
 
     # Auth + management + settings + enrichment + audiomuse BEFORE browse (browse has {name:path} catch-all)
     app.include_router(setup_router)
     app.include_router(auth_router)
     app.include_router(me_router)
+    app.include_router(radio_router)
     app.include_router(management_router)
     app.include_router(settings_router)
     app.include_router(playlists_router)

--- a/app/crate/api/radio.py
+++ b/app/crate/api/radio.py
@@ -2,7 +2,12 @@ from fastapi import APIRouter, HTTPException, Request
 from fastapi.responses import JSONResponse
 
 from crate.api.auth import _require_auth
-from crate.bliss import generate_artist_radio, generate_track_radio
+from crate.bliss import (
+    generate_album_radio,
+    generate_artist_radio,
+    generate_playlist_radio,
+    generate_track_radio,
+)
 from crate.db import get_db_ctx
 
 router = APIRouter()
@@ -70,6 +75,61 @@ def api_track_radio(request: Request, track_id: int = 0, path: str = "", limit: 
                 "track_path": seed_track.get("track_path"),
                 "title": seed_track.get("title"),
                 "artist": seed_track.get("artist"),
+            },
+        },
+        "tracks": tracks,
+    }
+
+
+@router.get("/api/radio/album/{album_id}")
+def api_album_radio(request: Request, album_id: int, limit: int = 50):
+    _require_auth(request)
+    with get_db_ctx() as cur:
+        cur.execute("SELECT artist, name FROM library_albums WHERE id = %s", (album_id,))
+        row = cur.fetchone()
+    if not row:
+        raise HTTPException(status_code=404, detail="Album not found")
+
+    tracks = generate_album_radio(album_id, limit=limit)
+    if not tracks:
+        return JSONResponse({"error": "No radio data available yet"}, status_code=404)
+
+    return {
+        "session": {
+            "type": "album",
+            "name": f"{row['name']} Radio",
+            "seed": {
+                "album_id": album_id,
+                "artist": row["artist"],
+                "album": row["name"],
+            },
+        },
+        "tracks": tracks,
+    }
+
+
+@router.get("/api/radio/playlist/{playlist_id}")
+def api_playlist_radio(request: Request, playlist_id: int, limit: int = 50):
+    user = _require_auth(request)
+    with get_db_ctx() as cur:
+        cur.execute("SELECT id, name, scope, user_id FROM playlists WHERE id = %s", (playlist_id,))
+        row = cur.fetchone()
+    if not row:
+        raise HTTPException(status_code=404, detail="Playlist not found")
+    if row.get("scope") != "system" and row.get("user_id") != user["id"] and user.get("role") != "admin":
+        raise HTTPException(status_code=403, detail="Not your playlist")
+
+    tracks = generate_playlist_radio(playlist_id, limit=limit)
+    if not tracks:
+        return JSONResponse({"error": "No radio data available yet"}, status_code=404)
+
+    return {
+        "session": {
+            "type": "playlist",
+            "name": f"{row['name']} Radio",
+            "seed": {
+                "playlist_id": playlist_id,
+                "name": row["name"],
             },
         },
         "tracks": tracks,

--- a/app/crate/api/radio.py
+++ b/app/crate/api/radio.py
@@ -1,0 +1,76 @@
+from fastapi import APIRouter, HTTPException, Request
+from fastapi.responses import JSONResponse
+
+from crate.api.auth import _require_auth
+from crate.bliss import generate_artist_radio, generate_track_radio
+from crate.db import get_db_ctx
+
+router = APIRouter()
+
+
+def _resolve_track_path(track_id: int = 0, path: str = "") -> str | None:
+    if track_id:
+        with get_db_ctx() as cur:
+            cur.execute("SELECT path FROM library_tracks WHERE id = %s", (track_id,))
+            row = cur.fetchone()
+        return row["path"] if row else None
+
+    if not path:
+        return None
+
+    with get_db_ctx() as cur:
+        cur.execute(
+            """
+            SELECT path
+            FROM library_tracks
+            WHERE path = %s OR path LIKE %s
+            ORDER BY CASE WHEN path = %s THEN 0 ELSE 1 END, path ASC
+            LIMIT 1
+            """,
+            (path, f"%{path}", path),
+        )
+        row = cur.fetchone()
+    return row["path"] if row else None
+
+
+@router.get("/api/radio/artist/{name:path}")
+def api_artist_radio(request: Request, name: str, limit: int = 50):
+    _require_auth(request)
+    tracks = generate_artist_radio(name, limit=limit)
+    if not tracks:
+        return JSONResponse({"error": "No radio data available yet"}, status_code=404)
+    return {
+        "session": {
+            "type": "artist",
+            "name": f"{name} Radio",
+            "seed": {"artist_name": name},
+        },
+        "tracks": tracks,
+    }
+
+
+@router.get("/api/radio/track")
+def api_track_radio(request: Request, track_id: int = 0, path: str = "", limit: int = 50):
+    _require_auth(request)
+    resolved_path = _resolve_track_path(track_id=track_id, path=path)
+    if not resolved_path:
+        raise HTTPException(status_code=404, detail="Track not found")
+
+    tracks = generate_track_radio(resolved_path, limit=limit)
+    if not tracks:
+        return JSONResponse({"error": "No radio data available yet"}, status_code=404)
+
+    seed_track = tracks[0]
+    return {
+        "session": {
+            "type": "track",
+            "name": f"{seed_track.get('title') or 'Track'} Radio",
+            "seed": {
+                "track_id": seed_track.get("track_id"),
+                "track_path": seed_track.get("track_path"),
+                "title": seed_track.get("title"),
+                "artist": seed_track.get("artist"),
+            },
+        },
+        "tracks": tracks,
+    }

--- a/app/crate/api/radio.py
+++ b/app/crate/api/radio.py
@@ -1,4 +1,4 @@
-from fastapi import APIRouter, HTTPException, Request
+from fastapi import APIRouter, HTTPException, Query, Request
 from fastapi.responses import JSONResponse
 
 from crate.api.auth import _require_auth
@@ -8,9 +8,23 @@ from crate.bliss import (
     generate_playlist_radio,
     generate_track_radio,
 )
-from crate.db import get_db_ctx
+from crate.db import get_db_ctx, get_user_by_email
 
 router = APIRouter()
+
+
+def _escape_like(value: str) -> str:
+    return value.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
+
+
+def _effective_user_id(user: dict) -> int | None:
+    if user.get("id") is not None:
+        return user["id"]
+    email = user.get("email")
+    if not email:
+        return None
+    existing = get_user_by_email(email)
+    return existing["id"] if existing else None
 
 
 def _resolve_track_path(track_id: int = 0, path: str = "") -> str | None:
@@ -24,22 +38,23 @@ def _resolve_track_path(track_id: int = 0, path: str = "") -> str | None:
         return None
 
     with get_db_ctx() as cur:
+        escaped_path = _escape_like(path)
         cur.execute(
             """
             SELECT path
             FROM library_tracks
-            WHERE path = %s OR path LIKE %s
+            WHERE path = %s OR path LIKE %s ESCAPE '\\'
             ORDER BY CASE WHEN path = %s THEN 0 ELSE 1 END, path ASC
             LIMIT 1
             """,
-            (path, f"%{path}", path),
+            (path, f"%{escaped_path}", path),
         )
         row = cur.fetchone()
     return row["path"] if row else None
 
 
 @router.get("/api/radio/artist/{name:path}")
-def api_artist_radio(request: Request, name: str, limit: int = 50):
+def api_artist_radio(request: Request, name: str, limit: int = Query(50, ge=1, le=100)):
     _require_auth(request)
     tracks = generate_artist_radio(name, limit=limit)
     if not tracks:
@@ -55,7 +70,12 @@ def api_artist_radio(request: Request, name: str, limit: int = 50):
 
 
 @router.get("/api/radio/track")
-def api_track_radio(request: Request, track_id: int = 0, path: str = "", limit: int = 50):
+def api_track_radio(
+    request: Request,
+    track_id: int = 0,
+    path: str = "",
+    limit: int = Query(50, ge=1, le=100),
+):
     _require_auth(request)
     resolved_path = _resolve_track_path(track_id=track_id, path=path)
     if not resolved_path:
@@ -82,7 +102,7 @@ def api_track_radio(request: Request, track_id: int = 0, path: str = "", limit: 
 
 
 @router.get("/api/radio/album/{album_id}")
-def api_album_radio(request: Request, album_id: int, limit: int = 50):
+def api_album_radio(request: Request, album_id: int, limit: int = Query(50, ge=1, le=100)):
     _require_auth(request)
     with get_db_ctx() as cur:
         cur.execute("SELECT artist, name FROM library_albums WHERE id = %s", (album_id,))
@@ -109,16 +129,21 @@ def api_album_radio(request: Request, album_id: int, limit: int = 50):
 
 
 @router.get("/api/radio/playlist/{playlist_id}")
-def api_playlist_radio(request: Request, playlist_id: int, limit: int = 50):
+def api_playlist_radio(request: Request, playlist_id: int, limit: int = Query(50, ge=1, le=100)):
     user = _require_auth(request)
+    effective_user_id = _effective_user_id(user)
     with get_db_ctx() as cur:
         cur.execute("SELECT id, name, scope, user_id, is_active FROM playlists WHERE id = %s", (playlist_id,))
         row = cur.fetchone()
     if not row:
         raise HTTPException(status_code=404, detail="Playlist not found")
-    if row.get("scope") == "system" and not row.get("is_active", True):
+    if row.get("scope") == "system" and not row.get("is_active", False):
         raise HTTPException(status_code=404, detail="Playlist not found")
-    if row.get("scope") != "system" and row.get("user_id") != user["id"] and user.get("role") != "admin":
+    if (
+        row.get("scope") != "system"
+        and row.get("user_id") != effective_user_id
+        and user.get("role") != "admin"
+    ):
         raise HTTPException(status_code=403, detail="Not your playlist")
 
     tracks = generate_playlist_radio(playlist_id, limit=limit)

--- a/app/crate/api/radio.py
+++ b/app/crate/api/radio.py
@@ -112,9 +112,11 @@ def api_album_radio(request: Request, album_id: int, limit: int = 50):
 def api_playlist_radio(request: Request, playlist_id: int, limit: int = 50):
     user = _require_auth(request)
     with get_db_ctx() as cur:
-        cur.execute("SELECT id, name, scope, user_id FROM playlists WHERE id = %s", (playlist_id,))
+        cur.execute("SELECT id, name, scope, user_id, is_active FROM playlists WHERE id = %s", (playlist_id,))
         row = cur.fetchone()
     if not row:
+        raise HTTPException(status_code=404, detail="Playlist not found")
+    if row.get("scope") == "system" and not row.get("is_active", True):
         raise HTTPException(status_code=404, detail="Playlist not found")
     if row.get("scope") != "system" and row.get("user_id") != user["id"] and user.get("role") != "admin":
         raise HTTPException(status_code=403, detail="Not your playlist")

--- a/app/crate/bliss.py
+++ b/app/crate/bliss.py
@@ -242,7 +242,7 @@ def _radio_track_payload(track: dict) -> dict:
         "artist": track.get("artist"),
         "album": track.get("album"),
         "duration": track.get("duration", 0),
-        "score": track.get("score") if track.get("score") is not None else track.get("_score"),
+        "score": track.get("score"),
     }
 
 
@@ -408,36 +408,10 @@ def get_similar_from_db(track_path: str, limit: int = 20) -> list[dict]:
     for c in candidates:
         c["_genres"] = list(artist_genre_map.get(c["artist"], set()))
 
-    scored = []
-    for c in candidates:
-        score = 0.0
-
-        # Bliss cosine similarity (weight 0.3)
-        score += 0.3 * _cosine_similarity(source["bliss_vector"], c["bliss_vector"])
-
-        # BPM proximity (weight 0.15)
-        if source.get("bpm") and c.get("bpm"):
-            diff = abs(source["bpm"] - c["bpm"])
-            score += 0.15 * max(0.0, 1.0 - diff / 40.0)
-
-        # Key compatibility (weight 0.1)
-        score += 0.1 * _key_compatibility(
-            source.get("audio_key"), source.get("audio_scale"),
-            c.get("audio_key"), c.get("audio_scale"),
-        )
-
-        # Energy proximity (weight 0.1)
-        if source.get("energy") is not None and c.get("energy") is not None:
-            score += 0.1 * (1.0 - abs(source["energy"] - c["energy"]))
-
-        # Genre overlap (weight 0.15)
-        score += 0.15 * _genre_jaccard(source_genres, set(c["_genres"]))
-
-        # Similar artist bonus (weight 0.2)
-        if c.get("artist") in similar_artist_names:
-            score += 0.2
-
-        scored.append((score, c))
+    scored = [
+        (_score_candidate(c, [source], source_genres, similar_artist_names), c)
+        for c in candidates
+    ]
 
     scored.sort(key=lambda x: x[0], reverse=True)
 
@@ -520,17 +494,133 @@ def generate_track_radio(track_path: str, limit: int = 50, mix_ratio: float = 0.
 
 
 def _aggregate_similar_candidates(seed_paths: list[str], *, per_seed_limit: int = 40) -> list[dict]:
+    if not seed_paths:
+        return []
+
+    with get_db_ctx() as cur:
+        cur.execute(
+            """
+            SELECT
+                t.id AS track_id,
+                t.path,
+                t.title,
+                t.artist,
+                a.name AS album,
+                t.duration,
+                t.navidrome_id,
+                t.bliss_vector,
+                t.bpm,
+                t.audio_key,
+                t.audio_scale,
+                t.energy
+            FROM library_tracks t
+            JOIN library_albums a ON t.album_id = a.id
+            WHERE t.path = ANY(%s) AND t.bliss_vector IS NOT NULL
+            """,
+            (seed_paths,),
+        )
+        seeds = [dict(row) for row in cur.fetchall()]
+
+        if not seeds:
+            return []
+
+        cur.execute(
+            """
+            WITH seeds AS (
+                SELECT
+                    t.path AS seed_path,
+                    t.bliss_vector AS seed_bliss_vector
+                FROM library_tracks t
+                WHERE t.path = ANY(%s) AND t.bliss_vector IS NOT NULL
+            ),
+            ranked AS (
+                SELECT
+                    s.seed_path,
+                    t.id AS track_id,
+                    t.path,
+                    t.title,
+                    t.artist,
+                    a.name AS album,
+                    t.duration,
+                    t.navidrome_id,
+                    t.bliss_vector,
+                    t.bpm,
+                    t.audio_key,
+                    t.audio_scale,
+                    t.energy,
+                    ROW_NUMBER() OVER (
+                        PARTITION BY s.seed_path
+                        ORDER BY SQRT(
+                            (
+                                SELECT SUM(POW(x - y, 2))
+                                FROM UNNEST(t.bliss_vector, s.seed_bliss_vector) AS v(x, y)
+                            )
+                        ) ASC
+                    ) AS seed_rank
+                FROM seeds s
+                JOIN library_tracks t
+                  ON t.bliss_vector IS NOT NULL
+                 AND t.path <> s.seed_path
+                 AND t.path <> ALL(%s)
+                JOIN library_albums a ON t.album_id = a.id
+            )
+            SELECT *
+            FROM ranked
+            WHERE seed_rank <= %s
+            """,
+            (seed_paths, seed_paths, per_seed_limit),
+        )
+        candidate_rows = [dict(row) for row in cur.fetchall()]
+
+        seed_artists = {seed["artist"] for seed in seeds}
+        candidate_artists = {row["artist"] for row in candidate_rows}
+        seed_genre_map = _get_artist_genre_map(cur, seed_artists)
+        candidate_genre_map = _get_artist_genre_map(cur, candidate_artists)
+        similar_artist_map = {
+            artist_name: _get_similar_artist_names(cur, artist_name)
+            for artist_name in seed_artists
+        }
+
+    if not candidate_rows:
+        return []
+
+    seed_map = {seed["path"]: {**seed, "_genres": list(seed_genre_map.get(seed["artist"], set()))} for seed in seeds}
+
     aggregated: dict[str, dict] = {}
-    for seed_path in seed_paths:
-        for index, track in enumerate(get_similar_from_db(seed_path, limit=per_seed_limit)):
-            track_path = track.get("track_path")
-            if not track_path:
-                continue
-            entry = aggregated.setdefault(track_path, {**track, "_aggregate_score": 0.0, "_hits": 0})
-            score = float(track.get("score") or 0.0)
-            # Small position bias so earlier matches win ties more often.
-            entry["_aggregate_score"] += score + max(0.0, (per_seed_limit - index) / (per_seed_limit * 100))
-            entry["_hits"] += 1
+    for candidate_row in candidate_rows:
+        seed = seed_map.get(candidate_row["seed_path"])
+        if not seed:
+            continue
+
+        candidate = {
+            key: value
+            for key, value in candidate_row.items()
+            if key not in {"seed_path", "seed_rank"}
+        }
+        candidate["_genres"] = list(candidate_genre_map.get(candidate["artist"], set()))
+
+        score = _score_candidate(
+            candidate,
+            [seed],
+            set(seed.get("_genres") or []),
+            similar_artist_map.get(seed["artist"], set()),
+        )
+
+        track_path = candidate.get("path")
+        if not track_path:
+            continue
+
+        entry = aggregated.setdefault(
+            track_path,
+            {
+                **_radio_track_payload(candidate),
+                "_aggregate_score": 0.0,
+                "_hits": 0,
+            },
+        )
+        rank = int(candidate_row.get("seed_rank") or per_seed_limit)
+        entry["_aggregate_score"] += score + max(0.0, (per_seed_limit - rank) / (per_seed_limit * 100))
+        entry["_hits"] += 1
 
     ranked = sorted(
         aggregated.values(),

--- a/app/crate/bliss.py
+++ b/app/crate/bliss.py
@@ -210,6 +210,23 @@ def store_vectors(vectors: dict[str, list[float]]):
             )
 
 
+def _radio_track_payload(track: dict) -> dict:
+    track_path = track.get("path") or ""
+    if track_path.startswith("/music/"):
+        track_path = track_path[len("/music/") :]
+
+    return {
+        "track_id": track.get("track_id") or track.get("id"),
+        "navidrome_id": track.get("navidrome_id"),
+        "track_path": track_path,
+        "title": track.get("title"),
+        "artist": track.get("artist"),
+        "album": track.get("album"),
+        "duration": track.get("duration", 0),
+        "score": track.get("score") if track.get("score") is not None else track.get("_score"),
+    }
+
+
 def generate_artist_radio(artist_name: str, limit: int = 50, mix_ratio: float = 0.4) -> list[dict]:
     """Generate an Artist Radio playlist using multi-signal scoring.
 
@@ -218,8 +235,8 @@ def generate_artist_radio(artist_name: str, limit: int = 50, mix_ratio: float = 
     with get_db_ctx() as cur:
         # Fetch artist tracks (with or without bliss vectors)
         cur.execute("""
-            SELECT t.path, t.title, t.artist, a.name AS album, t.duration,
-                   t.bliss_vector, t.bpm, t.audio_key, t.audio_scale, t.energy
+            SELECT t.id AS track_id, t.path, t.title, t.artist, a.name AS album, t.duration,
+                   t.navidrome_id, t.bliss_vector, t.bpm, t.audio_key, t.audio_scale, t.energy
             FROM library_tracks t
             JOIN library_albums a ON t.album_id = a.id
             WHERE a.artist = %s
@@ -250,8 +267,8 @@ def generate_artist_radio(artist_name: str, limit: int = 50, mix_ratio: float = 
         candidate_limit = 2000
         if similar_artist_names:
             cur.execute("""
-                SELECT t.path, t.title, t.artist, a.name AS album, t.duration,
-                       t.bliss_vector, t.bpm, t.audio_key, t.audio_scale, t.energy
+                SELECT t.id AS track_id, t.path, t.title, t.artist, a.name AS album, t.duration,
+                       t.navidrome_id, t.bliss_vector, t.bpm, t.audio_key, t.audio_scale, t.energy
                 FROM library_tracks t
                 JOIN library_albums a ON t.album_id = a.id
                 WHERE t.bliss_vector IS NOT NULL
@@ -265,8 +282,8 @@ def generate_artist_radio(artist_name: str, limit: int = 50, mix_ratio: float = 
             """, (artist_name, list(similar_artist_names), candidate_limit))
         else:
             cur.execute("""
-                SELECT t.path, t.title, t.artist, a.name AS album, t.duration,
-                       t.bliss_vector, t.bpm, t.audio_key, t.audio_scale, t.energy
+                SELECT t.id AS track_id, t.path, t.title, t.artist, a.name AS album, t.duration,
+                       t.navidrome_id, t.bliss_vector, t.bpm, t.audio_key, t.audio_scale, t.energy
                 FROM library_tracks t
                 JOIN library_albums a ON t.album_id = a.id
                 WHERE t.bliss_vector IS NOT NULL AND a.artist != %s
@@ -317,17 +334,7 @@ def generate_artist_radio(artist_name: str, limit: int = 50, mix_ratio: float = 
             s_idx += 1
         else:
             break
-        track_path = t["path"]
-        if track_path.startswith("/music/"):
-            track_path = track_path[len("/music/"):]
-        playlist.append({
-            "path": track_path,
-            "title": t["title"],
-            "artist": t["artist"],
-            "album": t["album"],
-            "duration": t.get("duration", 0),
-            "score": t.get("_score"),
-        })
+        playlist.append(_radio_track_payload(t))
 
     return playlist
 
@@ -336,8 +343,8 @@ def get_similar_from_db(track_path: str, limit: int = 20) -> list[dict]:
     """Find similar tracks using pre-computed vectors stored in DB (multi-signal scoring)."""
     with get_db_ctx() as cur:
         cur.execute("""
-            SELECT t.path, t.title, t.artist, a.name AS album, t.duration,
-                   t.bliss_vector, t.bpm, t.audio_key, t.audio_scale, t.energy
+            SELECT t.id AS track_id, t.path, t.title, t.artist, a.name AS album, t.duration,
+                   t.navidrome_id, t.bliss_vector, t.bpm, t.audio_key, t.audio_scale, t.energy
             FROM library_tracks t
             JOIN library_albums a ON t.album_id = a.id
             WHERE t.path = %s
@@ -356,8 +363,8 @@ def get_similar_from_db(track_path: str, limit: int = 20) -> list[dict]:
 
         # Get candidates via broad bliss distance (top 200), then re-rank in Python
         cur.execute("""
-            SELECT t.path, t.title, t.artist, a.name AS album, t.duration,
-                   t.bliss_vector, t.bpm, t.audio_key, t.audio_scale, t.energy,
+            SELECT t.id AS track_id, t.path, t.title, t.artist, a.name AS album, t.duration,
+                   t.navidrome_id, t.bliss_vector, t.bpm, t.audio_key, t.audio_scale, t.energy,
                    SQRT(
                        (SELECT SUM(POW(x - y, 2))
                         FROM UNNEST(t.bliss_vector, %s::float8[]) AS v(x, y))
@@ -421,15 +428,76 @@ def get_similar_from_db(track_path: str, limit: int = 20) -> list[dict]:
 
     result = []
     for score, t in scored[:limit]:
-        track_path_out = t["path"]
-        if track_path_out.startswith("/music/"):
-            track_path_out = track_path_out[len("/music/"):]
         result.append({
-            "path": track_path_out,
-            "title": t["title"],
-            "artist": t["artist"],
-            "album": t["album"],
-            "duration": t.get("duration", 0),
+            **_radio_track_payload(t),
             "score": round(score, 4),
         })
     return result
+
+
+def generate_track_radio(track_path: str, limit: int = 50, mix_ratio: float = 0.25) -> list[dict]:
+    """Generate a Track Radio queue based on a source track."""
+    with get_db_ctx() as cur:
+        cur.execute("""
+            SELECT t.id AS track_id, t.path, t.title, t.artist, a.name AS album, t.duration,
+                   t.navidrome_id, t.bliss_vector, t.bpm, t.audio_key, t.audio_scale, t.energy
+            FROM library_tracks t
+            JOIN library_albums a ON t.album_id = a.id
+            WHERE t.path = %s
+        """, (track_path,))
+        row = cur.fetchone()
+        if not row:
+            return []
+
+        seed = dict(row)
+        cur.execute("""
+            SELECT t.id AS track_id, t.path, t.title, t.artist, a.name AS album, t.duration, t.navidrome_id
+            FROM library_tracks t
+            JOIN library_albums a ON t.album_id = a.id
+            WHERE a.artist = %s AND t.path != %s
+            ORDER BY RANDOM()
+            LIMIT %s
+        """, (seed["artist"], track_path, max(limit, 24)))
+        same_artist_tracks = [dict(r) for r in cur.fetchall()]
+
+    similar_tracks = get_similar_from_db(track_path, limit=max(limit * 3, 60))
+    seen_paths = {seed["path"]}
+    unique_similar: list[dict] = []
+    for track in similar_tracks:
+        relative_path = track.get("track_path")
+        if not relative_path or relative_path in seen_paths:
+            continue
+        seen_paths.add(relative_path)
+        unique_similar.append(track)
+
+    same_artist_count = max(1, int(limit * mix_ratio))
+    picked_same_artist = same_artist_tracks[:same_artist_count]
+
+    playlist = [_radio_track_payload(seed)]
+    playlist_paths = {playlist[0]["track_path"]}
+    artist_index = 0
+    similar_index = 0
+    max_items = max(limit, 1)
+
+    while len(playlist) < max_items:
+        should_insert_artist = (
+            artist_index < len(picked_same_artist)
+            and (similar_index >= len(unique_similar) or len(playlist) % 4 == 0)
+        )
+        if should_insert_artist:
+            candidate = _radio_track_payload(picked_same_artist[artist_index])
+            artist_index += 1
+        elif similar_index < len(unique_similar):
+            candidate = unique_similar[similar_index]
+            similar_index += 1
+        else:
+            break
+
+        candidate_path = candidate.get("track_path")
+        if not candidate_path or candidate_path in playlist_paths:
+            continue
+
+        playlist_paths.add(candidate_path)
+        playlist.append(candidate)
+
+    return playlist[:limit]

--- a/app/crate/bliss.py
+++ b/app/crate/bliss.py
@@ -146,6 +146,25 @@ def _get_artist_genre_ids(cur, artist_name: str) -> set[str]:
     return {r["name"] for r in cur.fetchall()}
 
 
+def _get_artist_genre_map(cur, artist_names: set[str]) -> dict[str, set[str]]:
+    if not artist_names:
+        return {}
+
+    cur.execute(
+        """
+        SELECT ag.artist_name, g.name
+        FROM artist_genres ag
+        JOIN genres g ON ag.genre_id = g.id
+        WHERE ag.artist_name = ANY(%s)
+        """,
+        (list(artist_names),),
+    )
+    genre_map: dict[str, set[str]] = {name: set() for name in artist_names}
+    for row in cur.fetchall():
+        genre_map.setdefault(row["artist_name"], set()).add(row["name"])
+    return genre_map
+
+
 def _apply_diversity(scored: list[tuple[float, dict]], max_consecutive: int = 3) -> list[dict]:
     """Sort by score and ensure no more than max_consecutive tracks from same artist."""
     scored.sort(key=lambda x: x[0], reverse=True)
@@ -211,7 +230,7 @@ def store_vectors(vectors: dict[str, list[float]]):
 
 
 def _radio_track_payload(track: dict) -> dict:
-    track_path = track.get("path") or ""
+    track_path = track.get("track_path") or track.get("path") or ""
     if track_path.startswith("/music/"):
         track_path = track_path[len("/music/") :]
 
@@ -298,9 +317,7 @@ def generate_artist_radio(artist_name: str, limit: int = 50, mix_ratio: float = 
 
         # Fetch genre names for each unique candidate artist
         candidate_artists = {c["artist"] for c in candidates}
-        artist_genre_map: dict[str, set[str]] = {}
-        for ca in candidate_artists:
-            artist_genre_map[ca] = _get_artist_genre_ids(cur, ca)
+        artist_genre_map = _get_artist_genre_map(cur, candidate_artists)
 
     # Attach genres to candidates
     for c in candidates:
@@ -382,9 +399,7 @@ def get_similar_from_db(track_path: str, limit: int = 20) -> list[dict]:
 
         # Fetch genres for unique candidate artists
         candidate_artists = {c["artist"] for c in candidates}
-        artist_genre_map: dict[str, set[str]] = {}
-        for ca in candidate_artists:
-            artist_genre_map[ca] = _get_artist_genre_ids(cur, ca)
+        artist_genre_map = _get_artist_genre_map(cur, candidate_artists)
 
         # Get similar artist names for source artist
         similar_artist_names = _get_similar_artist_names(cur, source["artist"])
@@ -460,8 +475,9 @@ def generate_track_radio(track_path: str, limit: int = 50, mix_ratio: float = 0.
         """, (seed["artist"], track_path, max(limit, 24)))
         same_artist_tracks = [dict(r) for r in cur.fetchall()]
 
+    seed_payload = _radio_track_payload(seed)
     similar_tracks = get_similar_from_db(track_path, limit=max(limit * 3, 60))
-    seen_paths = {seed["path"]}
+    seen_paths = {seed_payload["track_path"]}
     unique_similar: list[dict] = []
     for track in similar_tracks:
         relative_path = track.get("track_path")
@@ -473,7 +489,7 @@ def generate_track_radio(track_path: str, limit: int = 50, mix_ratio: float = 0.
     same_artist_count = max(1, int(limit * mix_ratio))
     picked_same_artist = same_artist_tracks[:same_artist_count]
 
-    playlist = [_radio_track_payload(seed)]
+    playlist = [seed_payload]
     playlist_paths = {playlist[0]["track_path"]}
     artist_index = 0
     similar_index = 0
@@ -545,7 +561,9 @@ def _interleave_radio_queue(
             and (recommended_index >= len(recommended_tracks) or len(playlist) % 4 == 0)
         )
         if should_insert_source:
-            candidate = _radio_track_payload(picked_source[source_index])
+            candidate = picked_source[source_index]
+            if not candidate.get("track_path"):
+                candidate = _radio_track_payload(candidate)
             source_index += 1
         elif recommended_index < len(recommended_tracks):
             candidate = recommended_tracks[recommended_index]
@@ -553,7 +571,7 @@ def _interleave_radio_queue(
         else:
             break
 
-        candidate_path = candidate.get("track_path")
+        candidate_path = candidate.get("track_path") or candidate.get("path")
         if not candidate_path or candidate_path in seen_paths:
             continue
 

--- a/app/crate/bliss.py
+++ b/app/crate/bliss.py
@@ -501,3 +501,137 @@ def generate_track_radio(track_path: str, limit: int = 50, mix_ratio: float = 0.
         playlist.append(candidate)
 
     return playlist[:limit]
+
+
+def _aggregate_similar_candidates(seed_paths: list[str], *, per_seed_limit: int = 40) -> list[dict]:
+    aggregated: dict[str, dict] = {}
+    for seed_path in seed_paths:
+        for index, track in enumerate(get_similar_from_db(seed_path, limit=per_seed_limit)):
+            track_path = track.get("track_path")
+            if not track_path:
+                continue
+            entry = aggregated.setdefault(track_path, {**track, "_aggregate_score": 0.0, "_hits": 0})
+            score = float(track.get("score") or 0.0)
+            # Small position bias so earlier matches win ties more often.
+            entry["_aggregate_score"] += score + max(0.0, (per_seed_limit - index) / (per_seed_limit * 100))
+            entry["_hits"] += 1
+
+    ranked = sorted(
+        aggregated.values(),
+        key=lambda item: (item["_aggregate_score"], item["_hits"]),
+        reverse=True,
+    )
+    return ranked
+
+
+def _interleave_radio_queue(
+    source_tracks: list[dict],
+    recommended_tracks: list[dict],
+    *,
+    limit: int,
+    source_mix_ratio: float,
+) -> list[dict]:
+    source_count = max(1, int(limit * source_mix_ratio)) if source_tracks else 0
+    picked_source = source_tracks[:source_count]
+
+    playlist: list[dict] = []
+    seen_paths: set[str] = set()
+    source_index = 0
+    recommended_index = 0
+
+    while len(playlist) < limit:
+        should_insert_source = (
+            source_index < len(picked_source)
+            and (recommended_index >= len(recommended_tracks) or len(playlist) % 4 == 0)
+        )
+        if should_insert_source:
+            candidate = _radio_track_payload(picked_source[source_index])
+            source_index += 1
+        elif recommended_index < len(recommended_tracks):
+            candidate = recommended_tracks[recommended_index]
+            recommended_index += 1
+        else:
+            break
+
+        candidate_path = candidate.get("track_path")
+        if not candidate_path or candidate_path in seen_paths:
+            continue
+
+        seen_paths.add(candidate_path)
+        playlist.append(candidate)
+
+    return playlist[:limit]
+
+
+def generate_album_radio(album_id: int, limit: int = 50, source_mix_ratio: float = 0.25) -> list[dict]:
+    with get_db_ctx() as cur:
+        cur.execute("""
+            SELECT t.id AS track_id, t.path, t.title, t.artist, a.name AS album, t.duration,
+                   t.navidrome_id, t.bliss_vector
+            FROM library_tracks t
+            JOIN library_albums a ON t.album_id = a.id
+            WHERE a.id = %s
+            ORDER BY t.disc_number, t.track_number
+        """, (album_id,))
+        album_tracks = [dict(row) for row in cur.fetchall()]
+
+    if not album_tracks:
+        return []
+
+    source_tracks = [_radio_track_payload(track) for track in album_tracks]
+    seed_paths = [track["path"] for track in album_tracks if track.get("path") and track.get("bliss_vector")]
+    if not seed_paths:
+        seed_paths = [track["path"] for track in album_tracks if track.get("path")]
+    seed_paths = seed_paths[: min(4, len(seed_paths))]
+    recommended_tracks = _aggregate_similar_candidates(seed_paths, per_seed_limit=max(limit, 40))
+
+    return _interleave_radio_queue(
+        source_tracks,
+        recommended_tracks,
+        limit=limit,
+        source_mix_ratio=source_mix_ratio,
+    )
+
+
+def generate_playlist_radio(playlist_id: int, limit: int = 50, source_mix_ratio: float = 0.3) -> list[dict]:
+    with get_db_ctx() as cur:
+        cur.execute("""
+            SELECT
+                lt.id AS track_id,
+                lt.path,
+                COALESCE(pt.title, lt.title) AS title,
+                COALESCE(pt.artist, lt.artist) AS artist,
+                COALESCE(pt.album, lt.album) AS album,
+                COALESCE(pt.duration, lt.duration, 0) AS duration,
+                lt.navidrome_id,
+                lt.bliss_vector
+            FROM playlist_tracks pt
+            LEFT JOIN LATERAL (
+                SELECT id, path, title, artist, album, duration, navidrome_id, bliss_vector
+                FROM library_tracks lt
+                WHERE lt.path = pt.track_path
+                   OR lt.path LIKE ('%%/' || pt.track_path)
+                ORDER BY CASE WHEN lt.path = pt.track_path THEN 0 ELSE 1 END
+                LIMIT 1
+            ) lt ON TRUE
+            WHERE pt.playlist_id = %s
+            ORDER BY pt.position
+        """, (playlist_id,))
+        playlist_tracks = [dict(row) for row in cur.fetchall()]
+
+    source_tracks = [_radio_track_payload(track) for track in playlist_tracks if track.get("path")]
+    if not source_tracks:
+        return []
+
+    seed_paths = [track["path"] for track in playlist_tracks if track.get("path") and track.get("bliss_vector")]
+    if not seed_paths:
+        seed_paths = [track["path"] for track in playlist_tracks if track.get("path")]
+    seed_paths = seed_paths[: min(5, len(seed_paths))]
+    recommended_tracks = _aggregate_similar_candidates(seed_paths, per_seed_limit=max(limit, 40))
+
+    return _interleave_radio_queue(
+        source_tracks,
+        recommended_tracks,
+        limit=limit,
+        source_mix_ratio=source_mix_ratio,
+    )

--- a/app/listen/src/components/cards/AlbumCard.tsx
+++ b/app/listen/src/components/cards/AlbumCard.tsx
@@ -54,7 +54,11 @@ export function AlbumCard({ artist, album, albumId, year, cover, compact }: Albu
         libraryTrackId: track.id,
       }));
       if (playerTracks.length > 0) {
-        playAll(playerTracks, 0, { type: "album", name: `${artist} - ${album}` });
+        playAll(playerTracks, 0, {
+          type: "album",
+          name: `${artist} - ${album}`,
+          radio: albumId != null ? { seedType: "album", seedId: albumId } : undefined,
+        });
       }
     } finally {
       setPlaying(false);

--- a/app/listen/src/components/player/ExtendedPlayer.tsx
+++ b/app/listen/src/components/player/ExtendedPlayer.tsx
@@ -242,7 +242,10 @@ function SuggestedTab() {
         path: currentTrack.path ?? null,
         title: currentTrack.title,
       });
-      if (!radio.tracks.length) return;
+      if (!radio.tracks.length) {
+        toast.info("Track radio is not available yet");
+        return;
+      }
       playAll(radio.tracks, 0, radio.source);
     } catch {
       toast.error("Failed to start track radio");
@@ -284,7 +287,7 @@ function SuggestedTab() {
           key={`${t.path}-${i}`}
           onClick={() =>
             play(
-              { id: t.path, title: t.title, artist: t.artist, album: t.album },
+              { id: t.path, path: t.path, title: t.title, artist: t.artist, album: t.album },
               { type: "radio", name: `Similar to ${currentTrack?.title}` },
             )
           }
@@ -638,7 +641,6 @@ const TABS: { id: TabId; label: string }[] = [
 const VIZ_DEFAULTS = DEFAULT_VISUALIZER_SETTINGS;
 
 export function ExtendedPlayer({ open, onClose }: ExtendedPlayerProps) {
-  usePlayer(); // subscribe to state updates for child components
   const { currentTrack, audioElement } = usePlayerActions();
   const [tab, setTab] = useState<TabId>("queue");
   const [showVizSettings, setShowVizSettings] = useState(false);

--- a/app/listen/src/components/player/ExtendedPlayer.tsx
+++ b/app/listen/src/components/player/ExtendedPlayer.tsx
@@ -117,7 +117,14 @@ function QueueTab() {
               >
                 <span className="text-[10px] text-white/15 w-4 text-right tabular-nums shrink-0">{realIdx + 1}</span>
                 <div className="min-w-0 flex-1">
-                  <p className="text-[12px] text-white/50 truncate">{track.title}</p>
+                  <div className="flex items-center gap-2">
+                    <p className="min-w-0 flex-1 truncate text-[12px] text-white/50">{track.title}</p>
+                    {track.isSuggested ? (
+                      <span className="rounded-full border border-cyan-400/20 bg-cyan-400/10 px-1.5 py-0.5 text-[9px] font-medium uppercase tracking-wide text-cyan-300">
+                        Suggested
+                      </span>
+                    ) : null}
+                  </div>
                   <p className="text-[10px] text-white/25 truncate">{track.artist}</p>
                 </div>
               </button>
@@ -170,7 +177,14 @@ function QueueTab() {
               >
                 <span className="text-[10px] text-white/20 w-4 text-right tabular-nums shrink-0">{i + 1}</span>
                 <div className="min-w-0 flex-1">
-                  <p className="text-[12px] text-white/80 truncate">{track.title}</p>
+                  <div className="flex items-center gap-2">
+                    <p className="min-w-0 flex-1 truncate text-[12px] text-white/80">{track.title}</p>
+                    {track.isSuggested ? (
+                      <span className="rounded-full border border-cyan-400/20 bg-cyan-400/10 px-1.5 py-0.5 text-[9px] font-medium uppercase tracking-wide text-cyan-300">
+                        Suggested
+                      </span>
+                    ) : null}
+                  </div>
                   <p className="text-[10px] text-white/40 truncate">{track.artist}</p>
                 </div>
                 <button

--- a/app/listen/src/components/player/ExtendedPlayer.tsx
+++ b/app/listen/src/components/player/ExtendedPlayer.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, useRef, useCallback } from "react";
 import { ChevronDown, X, Loader2, Star, Settings } from "lucide-react";
+import { toast } from "sonner";
 import { usePlayer, usePlayerActions } from "@/contexts/PlayerContext";
 import { useMusicVisualizer } from "@/components/player/visualizer/useMusicVisualizer";
 import { api } from "@/lib/api";
@@ -16,6 +17,7 @@ import {
 } from "@/lib/player-visualizer-prefs";
 import { AppPopover } from "@/components/ui/AppPopover";
 import { useDismissibleLayer } from "@/hooks/use-dismissible-layer";
+import { fetchTrackRadio } from "@/lib/radio";
 import { formatDuration, formatCompact } from "@/lib/utils";
 import { useEscapeKey } from "@/hooks/use-escape-key";
 
@@ -192,19 +194,48 @@ function QueueTab() {
 }
 
 function SuggestedTab() {
-  const { currentTrack, play } = usePlayerActions();
+  const { currentTrack, play, playAll } = usePlayerActions();
   const [tracks, setTracks] = useState<SimilarTrack[]>([]);
   const [loading, setLoading] = useState(false);
+  const [startingRadio, setStartingRadio] = useState(false);
 
   useEffect(() => {
     if (!currentTrack) return;
     setLoading(true);
     setTracks([]);
-    api<{ tracks: SimilarTrack[] }>(`/api/similar-tracks?path=${encodeURIComponent(currentTrack.id)}&limit=15`)
+    const params = new URLSearchParams({ limit: "15" });
+    if (currentTrack.libraryTrackId != null) {
+      params.set("track_id", String(currentTrack.libraryTrackId));
+    } else if (currentTrack.path) {
+      params.set("path", currentTrack.path);
+    } else {
+      setTracks([]);
+      setLoading(false);
+      return;
+    }
+    api<{ tracks: SimilarTrack[] }>(`/api/similar-tracks?${params.toString()}`)
       .then((data) => setTracks(data.tracks || []))
       .catch(() => setTracks([]))
       .finally(() => setLoading(false));
-  }, [currentTrack?.id]);
+  }, [currentTrack?.id, currentTrack?.libraryTrackId, currentTrack?.path]);
+
+  async function handleStartTrackRadio() {
+    if (!currentTrack) return;
+    try {
+      setStartingRadio(true);
+      const radio = await fetchTrackRadio({
+        libraryTrackId: currentTrack.libraryTrackId ?? null,
+        path: currentTrack.path ?? null,
+        title: currentTrack.title,
+      });
+      if (!radio.tracks.length) return;
+      playAll(radio.tracks, 0, radio.source);
+    } catch {
+      toast.error("Failed to start track radio");
+    } finally {
+      setStartingRadio(false);
+    }
+  }
 
   if (loading) {
     return (
@@ -224,6 +255,16 @@ function SuggestedTab() {
 
   return (
     <div className="flex-1 overflow-y-auto pr-1">
+      <div className="mb-3 px-1">
+        <button
+          onClick={handleStartTrackRadio}
+          disabled={startingRadio || (!currentTrack?.libraryTrackId && !currentTrack?.path)}
+          className="inline-flex items-center gap-2 rounded-full border border-white/10 bg-white/5 px-3 py-1.5 text-[11px] font-medium text-white/80 transition hover:bg-white/10 disabled:cursor-not-allowed disabled:opacity-50"
+        >
+          {startingRadio ? <Loader2 size={12} className="animate-spin" /> : <Star size={12} />}
+          Start track radio
+        </button>
+      </div>
       {tracks.map((t, i) => (
         <button
           key={`${t.path}-${i}`}

--- a/app/listen/src/components/player/FullscreenPlayer.tsx
+++ b/app/listen/src/components/player/FullscreenPlayer.tsx
@@ -316,7 +316,14 @@ export function FullscreenPlayer({ open, onClose }: FullscreenPlayerProps) {
                     <div className="w-8 h-8 rounded bg-white/10 shrink-0" />
                   )}
                   <div className="min-w-0 flex-1">
-                    <p className="text-sm text-white truncate">{track.title}</p>
+                    <div className="flex items-center gap-2">
+                      <p className="min-w-0 flex-1 truncate text-sm text-white">{track.title}</p>
+                      {track.isSuggested ? (
+                        <span className="rounded-full border border-cyan-400/20 bg-cyan-400/10 px-1.5 py-0.5 text-[9px] font-medium uppercase tracking-wide text-cyan-300">
+                          Suggested
+                        </span>
+                      ) : null}
+                    </div>
                     <p className="text-xs text-white/40 truncate">
                       {track.artist}
                     </p>

--- a/app/listen/src/components/player/QueuePanel.tsx
+++ b/app/listen/src/components/player/QueuePanel.tsx
@@ -74,7 +74,14 @@ export function QueuePanel({ open, onClose }: QueuePanelProps) {
                 <div className="w-8 h-8 rounded bg-white/10 shrink-0" />
               )}
               <div className="min-w-0 flex-1">
-                <p className="text-[12px] text-white/80 truncate">{track.title}</p>
+                <div className="flex items-center gap-2">
+                  <p className="min-w-0 flex-1 truncate text-[12px] text-white/80">{track.title}</p>
+                  {track.isSuggested ? (
+                    <span className="rounded-full border border-cyan-400/20 bg-cyan-400/10 px-1.5 py-0.5 text-[9px] font-medium uppercase tracking-wide text-cyan-300">
+                      Suggested
+                    </span>
+                  ) : null}
+                </div>
                 <p className="text-[10px] text-white/40 truncate">{track.artist}</p>
               </div>
               <button
@@ -110,7 +117,14 @@ export function QueuePanel({ open, onClose }: QueuePanelProps) {
               >
                 <span className="text-[11px] text-white/15 w-5 text-right tabular-nums shrink-0">{i + 1}</span>
                 <div className="min-w-0 flex-1">
-                  <p className="text-[12px] text-white/50 truncate">{track.title}</p>
+                  <div className="flex items-center gap-2">
+                    <p className="min-w-0 flex-1 truncate text-[12px] text-white/50">{track.title}</p>
+                    {track.isSuggested ? (
+                      <span className="rounded-full border border-cyan-400/20 bg-cyan-400/10 px-1.5 py-0.5 text-[9px] font-medium uppercase tracking-wide text-cyan-300">
+                        Suggested
+                      </span>
+                    ) : null}
+                  </div>
                   <p className="text-[10px] text-white/30 truncate">{track.artist}</p>
                 </div>
               </button>

--- a/app/listen/src/components/playlists/PlaylistListRow.tsx
+++ b/app/listen/src/components/playlists/PlaylistListRow.tsx
@@ -23,6 +23,7 @@ interface PlaylistDetailResponse {
 }
 
 interface PlaylistListRowProps {
+  playlistId?: number;
   name: string;
   description?: string;
   coverDataUrl?: string | null;
@@ -74,6 +75,7 @@ function toPlayerTracks(tracks: PlaylistTrackResponse[]): Track[] {
 }
 
 export function PlaylistListRow({
+  playlistId,
   name,
   description,
   coverDataUrl,
@@ -102,11 +104,10 @@ export function PlaylistListRow({
         return;
       }
       const queue = mode === "shuffle" ? shuffleArray(tracks) : tracks;
-      const playlistId = detailEndpoint.match(/\/(\d+)(?:\?.*)?$/)?.[1];
       playAll(queue, 0, {
         type: "playlist",
         name,
-        radio: playlistId ? { seedType: "playlist", seedId: Number(playlistId) } : undefined,
+        radio: playlistId != null ? { seedType: "playlist", seedId: playlistId } : undefined,
       });
     } catch {
       toast.error("Failed to load playlist");

--- a/app/listen/src/components/playlists/PlaylistListRow.tsx
+++ b/app/listen/src/components/playlists/PlaylistListRow.tsx
@@ -102,7 +102,12 @@ export function PlaylistListRow({
         return;
       }
       const queue = mode === "shuffle" ? shuffleArray(tracks) : tracks;
-      playAll(queue, 0, { type: "playlist", name });
+      const playlistId = detailEndpoint.match(/\/(\d+)(?:\?.*)?$/)?.[1];
+      playAll(queue, 0, {
+        type: "playlist",
+        name,
+        radio: playlistId ? { seedType: "playlist", seedId: Number(playlistId) } : undefined,
+      });
     } catch {
       toast.error("Failed to load playlist");
     } finally {

--- a/app/listen/src/contexts/PlayerContext.tsx
+++ b/app/listen/src/contexts/PlayerContext.tsx
@@ -264,6 +264,8 @@ export function PlayerProvider({ children }: { children: ReactNode }) {
   const continuationSignatureRef = useRef<string | null>(null);
   const playlistSuggestionInFlightRef = useRef(false);
   const playlistSuggestionSignatureRef = useRef<string | null>(null);
+  const currentIndexRef = useRef(currentIndex);
+  const playSourceRef = useRef(playSource);
 
   if (!audioRef.current) {
     audioRef.current = getSharedAudio(PLAYER_AUDIO_KEY);
@@ -275,6 +277,11 @@ export function PlayerProvider({ children }: { children: ReactNode }) {
     preloadAudioRef.current.preload = "auto";
   }
   const audio = audioRef.current;
+
+  useEffect(() => {
+    currentIndexRef.current = currentIndex;
+    playSourceRef.current = playSource;
+  }, [currentIndex, playSource]);
 
   useEffect(() => {
     saveQueue(queue, currentIndex);
@@ -622,7 +629,19 @@ export function PlayerProvider({ children }: { children: ReactNode }) {
     fetchInfiniteContinuation(playSource!, SMART_PLAYLIST_SUGGESTION_BATCH_SIZE)
       .then((tracks) => {
         if (!tracks.length) return;
+        const expectedSeedId = playSource?.radio?.seedId ?? null;
         setQueue((prev) => {
+          const latestSource = playSourceRef.current;
+          const insertionIndex = currentIndexRef.current + 1;
+          if (
+            latestSource?.type !== "playlist" ||
+            latestSource?.radio?.seedId !== expectedSeedId ||
+            insertionIndex <= 0 ||
+            insertionIndex > prev.length
+          ) {
+            return prev;
+          }
+
           const existingKeys = new Set(
             [...prev, ...recentlyPlayed].map((track) => getTrackCacheKey(track)),
           );
@@ -632,9 +651,10 @@ export function PlayerProvider({ children }: { children: ReactNode }) {
             return true;
           });
           if (!suggestion) return prev;
+          if (prev[insertionIndex]?.isSuggested) return prev;
 
           const nextQueue = [...prev];
-          nextQueue.splice(currentIndex + 1, 0, {
+          nextQueue.splice(insertionIndex, 0, {
             ...suggestion,
             isSuggested: true,
             suggestionSource: "playlist",
@@ -657,6 +677,64 @@ export function PlayerProvider({ children }: { children: ReactNode }) {
     smartPlaylistSuggestionsCadence,
     smartPlaylistSuggestionsEnabled,
   ]);
+
+  const continueInfinitePlayback = useCallback(() => {
+    if (
+      !infinitePlaybackEnabled ||
+      shuffle ||
+      (playSource?.type !== "album" && playSource?.type !== "playlist") ||
+      !playSource?.radio?.seedId
+    ) {
+      return false;
+    }
+
+    shouldAutoplayRef.current = false;
+    setIsPlaying(false);
+    setIsBuffering(true);
+    continuationInFlightRef.current = true;
+
+    fetchInfiniteContinuation(playSource, RADIO_REFILL_BATCH_SIZE)
+      .then((tracks) => {
+        if (!tracks.length) {
+          setIsBuffering(false);
+          return;
+        }
+
+        let appended = false;
+        setQueue((prev) => {
+          const existingKeys = new Set(
+            [...prev, ...recentlyPlayed].map((track) => getTrackCacheKey(track)),
+          );
+          const uniqueTracks = tracks.filter((track) => {
+            const key = getTrackCacheKey(track);
+            if (!key || existingKeys.has(key)) return false;
+            existingKeys.add(key);
+            return true;
+          });
+          if (uniqueTracks.length === 0) return prev;
+          appended = true;
+          return [...prev, ...uniqueTracks];
+        });
+
+        if (appended) {
+          shouldAutoplayRef.current = true;
+          setCurrentIndex((i) => i + 1);
+          setCurrentTime(0);
+          setDuration(0);
+        } else {
+          setIsBuffering(false);
+        }
+      })
+      .catch((error) => {
+        console.warn("[player] continuation after end failed:", error);
+        setIsBuffering(false);
+      })
+      .finally(() => {
+        continuationInFlightRef.current = false;
+      });
+
+    return true;
+  }, [infinitePlaybackEnabled, playSource, recentlyPlayed, shuffle]);
 
   useEffect(() => {
     const onTimeUpdate = () => setCurrentTime(audio.currentTime);
@@ -720,56 +798,8 @@ export function PlayerProvider({ children }: { children: ReactNode }) {
         setCurrentIndex((i) => i + 1);
       } else if (repeat === "all") {
         setCurrentIndex(0);
-      } else if (
-        infinitePlaybackEnabled &&
-        !shuffle &&
-        (playSource?.type === "album" || playSource?.type === "playlist") &&
-        playSource?.radio?.seedId
-      ) {
-        shouldAutoplayRef.current = false;
-        setIsPlaying(false);
-        setIsBuffering(true);
-        continuationInFlightRef.current = true;
-
-        fetchInfiniteContinuation(playSource, RADIO_REFILL_BATCH_SIZE)
-          .then((tracks) => {
-            if (!tracks.length) {
-              setIsBuffering(false);
-              return;
-            }
-
-            let appended = false;
-            setQueue((prev) => {
-              const existingKeys = new Set(
-                [...prev, ...recentlyPlayed].map((track) => getTrackCacheKey(track)),
-              );
-              const uniqueTracks = tracks.filter((track) => {
-                const key = getTrackCacheKey(track);
-                if (!key || existingKeys.has(key)) return false;
-                existingKeys.add(key);
-                return true;
-              });
-              if (uniqueTracks.length === 0) return prev;
-              appended = true;
-              return [...prev, ...uniqueTracks];
-            });
-
-            if (appended) {
-              shouldAutoplayRef.current = true;
-              setCurrentIndex((i) => i + 1);
-              setCurrentTime(0);
-              setDuration(0);
-            } else {
-              setIsBuffering(false);
-            }
-          })
-          .catch((error) => {
-            console.warn("[player] continuation after end failed:", error);
-            setIsBuffering(false);
-          })
-          .finally(() => {
-            continuationInFlightRef.current = false;
-          });
+      } else if (continueInfinitePlayback()) {
+        return;
       } else {
         shouldAutoplayRef.current = false;
         setIsPlaying(false);
@@ -823,7 +853,7 @@ export function PlayerProvider({ children }: { children: ReactNode }) {
       audio.removeEventListener("seeked", onSeeked);
       audio.removeEventListener("error", onError);
     };
-  }, [audio, crossfadeSeconds, currentIndex, infinitePlaybackEnabled, playSource, queue, recentlyPlayed, repeat, shuffle]);
+  }, [audio, continueInfinitePlayback, crossfadeSeconds, currentIndex, queue, repeat, shuffle]);
 
   const play = useCallback((track: Track, source?: PlaySource) => {
     try {
@@ -908,8 +938,12 @@ export function PlayerProvider({ children }: { children: ReactNode }) {
       setCurrentIndex(0);
       setCurrentTime(0);
       setDuration(0);
+    } else if (!continueInfinitePlayback()) {
+      shouldAutoplayRef.current = false;
+      setIsPlaying(false);
+      setIsBuffering(false);
     }
-  }, [clearPreloadedTrack, currentIndex, queue.length, repeat, shuffle]);
+  }, [clearPreloadedTrack, continueInfinitePlayback, currentIndex, queue.length, repeat, shuffle]);
 
   const prev = useCallback(() => {
     if (audio.currentTime > 3) {

--- a/app/listen/src/contexts/PlayerContext.tsx
+++ b/app/listen/src/contexts/PlayerContext.tsx
@@ -11,6 +11,8 @@ import {
 import {
   getCrossfadeDurationPreference,
   getInfinitePlaybackPreference,
+  getSmartPlaylistSuggestionsCadencePreference,
+  getSmartPlaylistSuggestionsPreference,
   PLAYER_PLAYBACK_PREFS_EVENT,
 } from "@/lib/player-playback-prefs";
 import { fetchInfiniteContinuation, fetchRadioContinuation } from "@/lib/radio";
@@ -24,6 +26,8 @@ export interface Track {
   path?: string;
   navidromeId?: string;
   libraryTrackId?: number;
+  isSuggested?: boolean;
+  suggestionSource?: "playlist";
 }
 
 type RepeatMode = "off" | "one" | "all";
@@ -105,6 +109,7 @@ const MAX_RECENT = 10;
 const NEXT_TRACK_PRELOAD_WINDOW_SECONDS = 15;
 const RADIO_REFILL_THRESHOLD = 3;
 const RADIO_REFILL_BATCH_SIZE = 30;
+const SMART_PLAYLIST_SUGGESTION_BATCH_SIZE = 12;
 const PLAYER_AUDIO_KEY = "__listenPlayerAudio";
 const PLAYER_PRELOAD_AUDIO_KEY = "__listenPlayerPreloadAudio";
 
@@ -213,6 +218,18 @@ function isContinuousAlbumTransition(
   );
 }
 
+function isLikelyContinuousAlbumBlock(currentTrack: Track | undefined, nextTrack: Track | undefined): boolean {
+  if (!currentTrack || !nextTrack) return false;
+  return (
+    !!currentTrack.album &&
+    !!nextTrack.album &&
+    !!currentTrack.artist &&
+    !!nextTrack.artist &&
+    currentTrack.album === nextTrack.album &&
+    currentTrack.artist === nextTrack.artist
+  );
+}
+
 export function PlayerProvider({ children }: { children: ReactNode }) {
   const audioRef = useRef<HTMLAudioElement | null>(null);
   const preloadAudioRef = useRef<HTMLAudioElement | null>(null);
@@ -232,6 +249,12 @@ export function PlayerProvider({ children }: { children: ReactNode }) {
   const [recentlyPlayed, setRecentlyPlayed] = useState<Track[]>(getStoredRecentlyPlayed);
   const [crossfadeSeconds, setCrossfadeSeconds] = useState(getCrossfadeDurationPreference);
   const [infinitePlaybackEnabled, setInfinitePlaybackEnabled] = useState(getInfinitePlaybackPreference);
+  const [smartPlaylistSuggestionsEnabled, setSmartPlaylistSuggestionsEnabled] = useState(
+    getSmartPlaylistSuggestionsPreference,
+  );
+  const [smartPlaylistSuggestionsCadence, setSmartPlaylistSuggestionsCadence] = useState(
+    getSmartPlaylistSuggestionsCadencePreference,
+  );
   const restoredRef = useRef(stored.current.queue.length > 0);
   const shouldAutoplayRef = useRef(false);
   const lastNonZeroVolumeRef = useRef(Math.max(getStoredVolume(), 0.5));
@@ -239,6 +262,8 @@ export function PlayerProvider({ children }: { children: ReactNode }) {
   const radioRefillSignatureRef = useRef<string | null>(null);
   const continuationInFlightRef = useRef(false);
   const continuationSignatureRef = useRef<string | null>(null);
+  const playlistSuggestionInFlightRef = useRef(false);
+  const playlistSuggestionSignatureRef = useRef<string | null>(null);
 
   if (!audioRef.current) {
     audioRef.current = getSharedAudio(PLAYER_AUDIO_KEY);
@@ -399,6 +424,8 @@ export function PlayerProvider({ children }: { children: ReactNode }) {
       const detail = (event as CustomEvent<{
         crossfadeSeconds?: number;
         infinitePlaybackEnabled?: boolean;
+        smartPlaylistSuggestionsEnabled?: boolean;
+        smartPlaylistSuggestionsCadence?: number;
       }>).detail;
       if (typeof detail?.crossfadeSeconds === "number") {
         setCrossfadeSeconds(detail.crossfadeSeconds);
@@ -409,6 +436,16 @@ export function PlayerProvider({ children }: { children: ReactNode }) {
         setInfinitePlaybackEnabled(detail.infinitePlaybackEnabled);
       } else {
         setInfinitePlaybackEnabled(getInfinitePlaybackPreference());
+      }
+      if (typeof detail?.smartPlaylistSuggestionsEnabled === "boolean") {
+        setSmartPlaylistSuggestionsEnabled(detail.smartPlaylistSuggestionsEnabled);
+      } else {
+        setSmartPlaylistSuggestionsEnabled(getSmartPlaylistSuggestionsPreference());
+      }
+      if (typeof detail?.smartPlaylistSuggestionsCadence === "number") {
+        setSmartPlaylistSuggestionsCadence(detail.smartPlaylistSuggestionsCadence);
+      } else {
+        setSmartPlaylistSuggestionsCadence(getSmartPlaylistSuggestionsCadencePreference());
       }
     };
 
@@ -525,6 +562,101 @@ export function PlayerProvider({ children }: { children: ReactNode }) {
         continuationInFlightRef.current = false;
       });
   }, [currentIndex, infinitePlaybackEnabled, playSource, queue, recentlyPlayed, shuffle]);
+
+  useEffect(() => {
+    const currentTrack = queue[currentIndex];
+    const nextTrack = queue[currentIndex + 1];
+    const supportsSmartInclusion =
+      smartPlaylistSuggestionsEnabled &&
+      !shuffle &&
+      !!currentTrack &&
+      playSource?.type === "playlist" &&
+      !!playSource?.radio?.seedId;
+
+    if (!supportsSmartInclusion) {
+      playlistSuggestionSignatureRef.current = null;
+      return;
+    }
+    if (currentTrack?.isSuggested) {
+      playlistSuggestionSignatureRef.current = null;
+      return;
+    }
+    if (isLikelyContinuousAlbumBlock(currentTrack, nextTrack)) {
+      playlistSuggestionSignatureRef.current = null;
+      return;
+    }
+
+    const playedOriginalCount = queue
+      .slice(0, currentIndex + 1)
+      .filter((track) => !track.isSuggested).length;
+
+    if (
+      playedOriginalCount === 0 ||
+      playedOriginalCount % smartPlaylistSuggestionsCadence !== 0
+    ) {
+      playlistSuggestionSignatureRef.current = null;
+      return;
+    }
+
+    if (nextTrack?.isSuggested) {
+      playlistSuggestionSignatureRef.current = [
+        playSource?.radio?.seedId ?? "",
+        playedOriginalCount,
+        currentTrack?.id ?? "",
+      ].join("::");
+      return;
+    }
+
+    if (playlistSuggestionInFlightRef.current) return;
+
+    const signature = [
+      playSource?.radio?.seedId ?? "",
+      playedOriginalCount,
+      currentTrack?.id ?? "",
+      queue.length,
+    ].join("::");
+    if (playlistSuggestionSignatureRef.current === signature) return;
+    playlistSuggestionSignatureRef.current = signature;
+    playlistSuggestionInFlightRef.current = true;
+
+    fetchInfiniteContinuation(playSource!, SMART_PLAYLIST_SUGGESTION_BATCH_SIZE)
+      .then((tracks) => {
+        if (!tracks.length) return;
+        setQueue((prev) => {
+          const existingKeys = new Set(
+            [...prev, ...recentlyPlayed].map((track) => getTrackCacheKey(track)),
+          );
+          const suggestion = tracks.find((track) => {
+            const key = getTrackCacheKey(track);
+            if (!key || existingKeys.has(key)) return false;
+            return true;
+          });
+          if (!suggestion) return prev;
+
+          const nextQueue = [...prev];
+          nextQueue.splice(currentIndex + 1, 0, {
+            ...suggestion,
+            isSuggested: true,
+            suggestionSource: "playlist",
+          });
+          return nextQueue;
+        });
+      })
+      .catch((error) => {
+        console.warn("[player] playlist suggestion failed:", error);
+      })
+      .finally(() => {
+        playlistSuggestionInFlightRef.current = false;
+      });
+  }, [
+    currentIndex,
+    playSource,
+    queue,
+    recentlyPlayed,
+    shuffle,
+    smartPlaylistSuggestionsCadence,
+    smartPlaylistSuggestionsEnabled,
+  ]);
 
   useEffect(() => {
     const onTimeUpdate = () => setCurrentTime(audio.currentTime);
@@ -701,6 +833,7 @@ export function PlayerProvider({ children }: { children: ReactNode }) {
     } catch { /* ok */ }
 
     restoredRef.current = false;
+    playlistSuggestionSignatureRef.current = null;
     clearPreloadedTrack();
     setQueue([track]);
     setCurrentIndex(0);
@@ -721,6 +854,7 @@ export function PlayerProvider({ children }: { children: ReactNode }) {
     if (!track) return;
 
     restoredRef.current = false;
+    playlistSuggestionSignatureRef.current = null;
     clearPreloadedTrack();
     setQueue(tracks);
     setCurrentIndex(startIndex);
@@ -811,6 +945,7 @@ export function PlayerProvider({ children }: { children: ReactNode }) {
   }, [audio]);
 
   const clearQueue = useCallback(() => {
+    playlistSuggestionSignatureRef.current = null;
     clearPreloadedTrack();
     audio.pause();
     audio.removeAttribute("src");

--- a/app/listen/src/contexts/PlayerContext.tsx
+++ b/app/listen/src/contexts/PlayerContext.tsx
@@ -12,6 +12,7 @@ import {
   getCrossfadeDurationPreference,
   PLAYER_PLAYBACK_PREFS_EVENT,
 } from "@/lib/player-playback-prefs";
+import { fetchRadioContinuation } from "@/lib/radio";
 
 export interface Track {
   id: string;
@@ -101,6 +102,8 @@ const STORAGE_KEY = "listen-player-state";
 const RECENTLY_PLAYED_KEY = "listen-recently-played";
 const MAX_RECENT = 10;
 const NEXT_TRACK_PRELOAD_WINDOW_SECONDS = 15;
+const RADIO_REFILL_THRESHOLD = 3;
+const RADIO_REFILL_BATCH_SIZE = 30;
 const PLAYER_AUDIO_KEY = "__listenPlayerAudio";
 const PLAYER_PRELOAD_AUDIO_KEY = "__listenPlayerPreloadAudio";
 
@@ -230,6 +233,8 @@ export function PlayerProvider({ children }: { children: ReactNode }) {
   const restoredRef = useRef(stored.current.queue.length > 0);
   const shouldAutoplayRef = useRef(false);
   const lastNonZeroVolumeRef = useRef(Math.max(getStoredVolume(), 0.5));
+  const radioRefillInFlightRef = useRef(false);
+  const radioRefillSignatureRef = useRef<string | null>(null);
 
   if (!audioRef.current) {
     audioRef.current = getSharedAudio(PLAYER_AUDIO_KEY);
@@ -406,6 +411,54 @@ export function PlayerProvider({ children }: { children: ReactNode }) {
       clearPreloadedTrack();
     };
   }, [audio, clearPreloadedTrack]);
+
+  useEffect(() => {
+    const currentTrack = queue[currentIndex];
+    if (!isPlaying || !currentTrack) return;
+    if (playSource?.type !== "radio" || !playSource.radio) return;
+
+    const remainingUpcoming = queue.length - currentIndex - 1;
+    if (remainingUpcoming > RADIO_REFILL_THRESHOLD) {
+      radioRefillSignatureRef.current = null;
+      return;
+    }
+    if (radioRefillInFlightRef.current) return;
+
+    const signature = [
+      playSource.name,
+      playSource.radio.seedType,
+      playSource.radio.seedId ?? "",
+      playSource.radio.seedPath ?? "",
+      currentTrack.id,
+      queue.length,
+    ].join("::");
+    if (radioRefillSignatureRef.current === signature) return;
+    radioRefillSignatureRef.current = signature;
+    radioRefillInFlightRef.current = true;
+
+    const existingKeys = new Set(
+      [...queue, ...recentlyPlayed].map((track) => getTrackCacheKey(track)),
+    );
+
+    fetchRadioContinuation(playSource, RADIO_REFILL_BATCH_SIZE)
+      .then((tracks) => {
+        const uniqueTracks = tracks.filter((track) => {
+          const key = getTrackCacheKey(track);
+          if (!key || existingKeys.has(key)) return false;
+          existingKeys.add(key);
+          return true;
+        });
+        if (uniqueTracks.length > 0) {
+          setQueue((prev) => [...prev, ...uniqueTracks]);
+        }
+      })
+      .catch((error) => {
+        console.warn("[player] radio refill failed:", error);
+      })
+      .finally(() => {
+        radioRefillInFlightRef.current = false;
+      });
+  }, [currentIndex, isPlaying, playSource, queue, recentlyPlayed]);
 
   useEffect(() => {
     const onTimeUpdate = () => setCurrentTime(audio.currentTime);

--- a/app/listen/src/contexts/PlayerContext.tsx
+++ b/app/listen/src/contexts/PlayerContext.tsx
@@ -179,6 +179,31 @@ function getTrackCacheKey(track: Track): string {
   return [track.libraryTrackId ?? "", track.navidromeId ?? "", track.path ?? "", track.id].join("::");
 }
 
+function getPlaySourceSignature(source: PlaySource | null): string | null {
+  if (!source) return null;
+  return [
+    source.type,
+    source.name,
+    source.radio?.seedType ?? "",
+    source.radio?.seedId ?? "",
+    source.radio?.seedPath ?? "",
+  ].join("::");
+}
+
+function collectUniqueTracks(candidates: Track[], queue: Track[], recent: Track[]): Track[] {
+  const existingKeys = new Set(
+    [...queue, ...recent].map((track) => getTrackCacheKey(track)),
+  );
+  const uniqueTracks: Track[] = [];
+  for (const track of candidates) {
+    const key = getTrackCacheKey(track);
+    if (!key || existingKeys.has(key)) continue;
+    existingKeys.add(key);
+    uniqueTracks.push(track);
+  }
+  return uniqueTracks;
+}
+
 function getPredictableNextTrack(
   queue: Track[],
   currentIndex: number,
@@ -266,6 +291,8 @@ export function PlayerProvider({ children }: { children: ReactNode }) {
   const playlistSuggestionSignatureRef = useRef<string | null>(null);
   const currentIndexRef = useRef(currentIndex);
   const playSourceRef = useRef(playSource);
+  const queueRef = useRef(queue);
+  const recentlyPlayedRef = useRef(recentlyPlayed);
 
   if (!audioRef.current) {
     audioRef.current = getSharedAudio(PLAYER_AUDIO_KEY);
@@ -281,7 +308,9 @@ export function PlayerProvider({ children }: { children: ReactNode }) {
   useEffect(() => {
     currentIndexRef.current = currentIndex;
     playSourceRef.current = playSource;
-  }, [currentIndex, playSource]);
+    queueRef.current = queue;
+    recentlyPlayedRef.current = recentlyPlayed;
+  }, [currentIndex, playSource, queue, recentlyPlayed]);
 
   useEffect(() => {
     saveQueue(queue, currentIndex);
@@ -481,10 +510,7 @@ export function PlayerProvider({ children }: { children: ReactNode }) {
     if (radioRefillInFlightRef.current) return;
 
     const signature = [
-      playSource.name,
-      playSource.radio.seedType,
-      playSource.radio.seedId ?? "",
-      playSource.radio.seedPath ?? "",
+      getPlaySourceSignature(playSource),
       currentTrack.id,
       queue.length,
     ].join("::");
@@ -492,21 +518,16 @@ export function PlayerProvider({ children }: { children: ReactNode }) {
     radioRefillSignatureRef.current = signature;
     radioRefillInFlightRef.current = true;
 
-    const existingKeys = new Set(
-      [...queue, ...recentlyPlayed].map((track) => getTrackCacheKey(track)),
-    );
-
     fetchRadioContinuation(playSource, RADIO_REFILL_BATCH_SIZE)
       .then((tracks) => {
-        const uniqueTracks = tracks.filter((track) => {
-          const key = getTrackCacheKey(track);
-          if (!key || existingKeys.has(key)) return false;
-          existingKeys.add(key);
-          return true;
+        if (radioRefillSignatureRef.current !== signature) return;
+        if (getPlaySourceSignature(playSourceRef.current) !== getPlaySourceSignature(playSource)) return;
+        setQueue((prev) => {
+          if (radioRefillSignatureRef.current !== signature) return prev;
+          if (getPlaySourceSignature(playSourceRef.current) !== getPlaySourceSignature(playSource)) return prev;
+          const uniqueTracks = collectUniqueTracks(tracks, prev, recentlyPlayedRef.current);
+          return uniqueTracks.length > 0 ? [...prev, ...uniqueTracks] : prev;
         });
-        if (uniqueTracks.length > 0) {
-          setQueue((prev) => [...prev, ...uniqueTracks]);
-        }
       })
       .catch((error) => {
         console.warn("[player] radio refill failed:", error);
@@ -514,7 +535,7 @@ export function PlayerProvider({ children }: { children: ReactNode }) {
       .finally(() => {
         radioRefillInFlightRef.current = false;
       });
-  }, [currentIndex, isPlaying, playSource, queue, recentlyPlayed]);
+  }, [currentIndex, isPlaying, playSource, queue.length]);
 
   useEffect(() => {
     const currentTrack = queue[currentIndex];
@@ -534,14 +555,8 @@ export function PlayerProvider({ children }: { children: ReactNode }) {
     }
     if (continuationInFlightRef.current) return;
 
-    const signature = [
-      playSource?.type ?? "",
-      playSource?.name ?? "",
-      playSource?.radio?.seedType ?? "",
-      playSource?.radio?.seedId ?? "",
-      currentTrack?.id ?? "",
-      queue.length,
-    ].join("::");
+    const sessionSignature = getPlaySourceSignature(playSource);
+    const signature = [sessionSignature, currentTrack?.id ?? "", queue.length].join("::");
     if (continuationSignatureRef.current === signature) return;
     continuationSignatureRef.current = signature;
     continuationInFlightRef.current = true;
@@ -549,16 +564,12 @@ export function PlayerProvider({ children }: { children: ReactNode }) {
     fetchInfiniteContinuation(playSource!, RADIO_REFILL_BATCH_SIZE)
       .then((tracks) => {
         if (!tracks.length) return;
+        if (continuationSignatureRef.current !== signature) return;
+        if (getPlaySourceSignature(playSourceRef.current) !== sessionSignature) return;
         setQueue((prev) => {
-          const existingKeys = new Set(
-            [...prev, ...recentlyPlayed].map((track) => getTrackCacheKey(track)),
-          );
-          const uniqueTracks = tracks.filter((track) => {
-            const key = getTrackCacheKey(track);
-            if (!key || existingKeys.has(key)) return false;
-            existingKeys.add(key);
-            return true;
-          });
+          if (continuationSignatureRef.current !== signature) return prev;
+          if (getPlaySourceSignature(playSourceRef.current) !== sessionSignature) return prev;
+          const uniqueTracks = collectUniqueTracks(tracks, prev, recentlyPlayedRef.current);
           return uniqueTracks.length > 0 ? [...prev, ...uniqueTracks] : prev;
         });
       })
@@ -568,7 +579,7 @@ export function PlayerProvider({ children }: { children: ReactNode }) {
       .finally(() => {
         continuationInFlightRef.current = false;
       });
-  }, [currentIndex, infinitePlaybackEnabled, playSource, queue, recentlyPlayed, shuffle]);
+  }, [currentIndex, infinitePlaybackEnabled, playSource, queue.length, shuffle]);
 
   useEffect(() => {
     const currentTrack = queue[currentIndex];
@@ -629,8 +640,10 @@ export function PlayerProvider({ children }: { children: ReactNode }) {
     fetchInfiniteContinuation(playSource!, SMART_PLAYLIST_SUGGESTION_BATCH_SIZE)
       .then((tracks) => {
         if (!tracks.length) return;
+        if (playlistSuggestionSignatureRef.current !== signature) return;
         const expectedSeedId = playSource?.radio?.seedId ?? null;
         setQueue((prev) => {
+          if (playlistSuggestionSignatureRef.current !== signature) return prev;
           const latestSource = playSourceRef.current;
           const insertionIndex = currentIndexRef.current + 1;
           if (
@@ -643,7 +656,7 @@ export function PlayerProvider({ children }: { children: ReactNode }) {
           }
 
           const existingKeys = new Set(
-            [...prev, ...recentlyPlayed].map((track) => getTrackCacheKey(track)),
+            [...prev, ...recentlyPlayedRef.current].map((track) => getTrackCacheKey(track)),
           );
           const suggestion = tracks.find((track) => {
             const key = getTrackCacheKey(track);
@@ -672,7 +685,6 @@ export function PlayerProvider({ children }: { children: ReactNode }) {
     currentIndex,
     playSource,
     queue,
-    recentlyPlayed,
     shuffle,
     smartPlaylistSuggestionsCadence,
     smartPlaylistSuggestionsEnabled,
@@ -687,54 +699,71 @@ export function PlayerProvider({ children }: { children: ReactNode }) {
     ) {
       return false;
     }
+    if (continuationInFlightRef.current) {
+      return false;
+    }
+
+    const sessionSignature = getPlaySourceSignature(playSource);
+    const requestSignature = [sessionSignature, currentIndexRef.current, queueRef.current.length, "manual"].join("::");
 
     shouldAutoplayRef.current = false;
     setIsPlaying(false);
     setIsBuffering(true);
+    continuationSignatureRef.current = requestSignature;
     continuationInFlightRef.current = true;
 
     fetchInfiniteContinuation(playSource, RADIO_REFILL_BATCH_SIZE)
       .then((tracks) => {
+        if (continuationSignatureRef.current !== requestSignature) {
+          setIsBuffering(false);
+          return;
+        }
+        if (getPlaySourceSignature(playSourceRef.current) !== sessionSignature) {
+          setIsBuffering(false);
+          return;
+        }
         if (!tracks.length) {
           setIsBuffering(false);
           return;
         }
 
-        let appended = false;
+        const uniqueTracks = collectUniqueTracks(tracks, queueRef.current, recentlyPlayedRef.current);
+        if (uniqueTracks.length === 0) {
+          setIsBuffering(false);
+          return;
+        }
+
         setQueue((prev) => {
-          const existingKeys = new Set(
-            [...prev, ...recentlyPlayed].map((track) => getTrackCacheKey(track)),
-          );
-          const uniqueTracks = tracks.filter((track) => {
-            const key = getTrackCacheKey(track);
-            if (!key || existingKeys.has(key)) return false;
-            existingKeys.add(key);
-            return true;
-          });
-          if (uniqueTracks.length === 0) return prev;
-          appended = true;
-          return [...prev, ...uniqueTracks];
+          if (continuationSignatureRef.current !== requestSignature) return prev;
+          if (getPlaySourceSignature(playSourceRef.current) !== sessionSignature) return prev;
+          const stillUnique = collectUniqueTracks(uniqueTracks, prev, recentlyPlayedRef.current);
+          return stillUnique.length > 0 ? [...prev, ...stillUnique] : prev;
         });
 
-        if (appended) {
-          shouldAutoplayRef.current = true;
-          setCurrentIndex((i) => i + 1);
-          setCurrentTime(0);
-          setDuration(0);
-        } else {
-          setIsBuffering(false);
-        }
+        shouldAutoplayRef.current = true;
+        setCurrentIndex((index) => {
+          if (continuationSignatureRef.current !== requestSignature) return index;
+          if (getPlaySourceSignature(playSourceRef.current) !== sessionSignature) return index;
+          return index + 1;
+        });
+        setCurrentTime(0);
+        setDuration(0);
       })
       .catch((error) => {
         console.warn("[player] continuation after end failed:", error);
-        setIsBuffering(false);
+        if (continuationSignatureRef.current === requestSignature) {
+          setIsBuffering(false);
+        }
       })
       .finally(() => {
         continuationInFlightRef.current = false;
+        if (continuationSignatureRef.current === requestSignature) {
+          continuationSignatureRef.current = null;
+        }
       });
 
     return true;
-  }, [infinitePlaybackEnabled, playSource, recentlyPlayed, shuffle]);
+  }, [infinitePlaybackEnabled, playSource, shuffle]);
 
   useEffect(() => {
     const onTimeUpdate = () => setCurrentTime(audio.currentTime);

--- a/app/listen/src/contexts/PlayerContext.tsx
+++ b/app/listen/src/contexts/PlayerContext.tsx
@@ -25,10 +25,18 @@ export interface Track {
 }
 
 type RepeatMode = "off" | "one" | "all";
+type RadioSeedType = "track" | "album" | "artist" | "playlist";
+
+interface RadioSession {
+  seedType: RadioSeedType;
+  seedId?: string | number | null;
+  seedPath?: string | null;
+}
 
 export interface PlaySource {
   type: "album" | "playlist" | "radio" | "track" | "queue";
   name: string;
+  radio?: RadioSession;
 }
 
 interface PlayerStateValue {

--- a/app/listen/src/contexts/PlayerContext.tsx
+++ b/app/listen/src/contexts/PlayerContext.tsx
@@ -517,9 +517,11 @@ export function PlayerProvider({ children }: { children: ReactNode }) {
     if (radioRefillSignatureRef.current === signature) return;
     radioRefillSignatureRef.current = signature;
     radioRefillInFlightRef.current = true;
+    const controller = new AbortController();
 
-    fetchRadioContinuation(playSource, RADIO_REFILL_BATCH_SIZE)
+    fetchRadioContinuation(playSource, RADIO_REFILL_BATCH_SIZE, { signal: controller.signal })
       .then((tracks) => {
+        if (controller.signal.aborted) return;
         if (radioRefillSignatureRef.current !== signature) return;
         if (getPlaySourceSignature(playSourceRef.current) !== getPlaySourceSignature(playSource)) return;
         setQueue((prev) => {
@@ -530,11 +532,18 @@ export function PlayerProvider({ children }: { children: ReactNode }) {
         });
       })
       .catch((error) => {
+        if (controller.signal.aborted) return;
         console.warn("[player] radio refill failed:", error);
       })
       .finally(() => {
-        radioRefillInFlightRef.current = false;
+        if (!controller.signal.aborted) {
+          radioRefillInFlightRef.current = false;
+        }
       });
+    return () => {
+      controller.abort();
+      radioRefillInFlightRef.current = false;
+    };
   }, [currentIndex, isPlaying, playSource, queue.length]);
 
   useEffect(() => {
@@ -560,9 +569,11 @@ export function PlayerProvider({ children }: { children: ReactNode }) {
     if (continuationSignatureRef.current === signature) return;
     continuationSignatureRef.current = signature;
     continuationInFlightRef.current = true;
+    const controller = new AbortController();
 
-    fetchInfiniteContinuation(playSource!, RADIO_REFILL_BATCH_SIZE)
+    fetchInfiniteContinuation(playSource!, RADIO_REFILL_BATCH_SIZE, { signal: controller.signal })
       .then((tracks) => {
+        if (controller.signal.aborted) return;
         if (!tracks.length) return;
         if (continuationSignatureRef.current !== signature) return;
         if (getPlaySourceSignature(playSourceRef.current) !== sessionSignature) return;
@@ -574,11 +585,18 @@ export function PlayerProvider({ children }: { children: ReactNode }) {
         });
       })
       .catch((error) => {
+        if (controller.signal.aborted) return;
         console.warn("[player] continuation refill failed:", error);
       })
       .finally(() => {
-        continuationInFlightRef.current = false;
+        if (!controller.signal.aborted) {
+          continuationInFlightRef.current = false;
+        }
       });
+    return () => {
+      controller.abort();
+      continuationInFlightRef.current = false;
+    };
   }, [currentIndex, infinitePlaybackEnabled, playSource, queue.length, shuffle]);
 
   useEffect(() => {
@@ -636,9 +654,11 @@ export function PlayerProvider({ children }: { children: ReactNode }) {
     if (playlistSuggestionSignatureRef.current === signature) return;
     playlistSuggestionSignatureRef.current = signature;
     playlistSuggestionInFlightRef.current = true;
+    const controller = new AbortController();
 
-    fetchInfiniteContinuation(playSource!, SMART_PLAYLIST_SUGGESTION_BATCH_SIZE)
+    fetchInfiniteContinuation(playSource!, SMART_PLAYLIST_SUGGESTION_BATCH_SIZE, { signal: controller.signal })
       .then((tracks) => {
+        if (controller.signal.aborted) return;
         if (!tracks.length) return;
         if (playlistSuggestionSignatureRef.current !== signature) return;
         const expectedSeedId = playSource?.radio?.seedId ?? null;
@@ -676,11 +696,18 @@ export function PlayerProvider({ children }: { children: ReactNode }) {
         });
       })
       .catch((error) => {
+        if (controller.signal.aborted) return;
         console.warn("[player] playlist suggestion failed:", error);
       })
       .finally(() => {
-        playlistSuggestionInFlightRef.current = false;
+        if (!controller.signal.aborted) {
+          playlistSuggestionInFlightRef.current = false;
+        }
       });
+    return () => {
+      controller.abort();
+      playlistSuggestionInFlightRef.current = false;
+    };
   }, [
     currentIndex,
     playSource,

--- a/app/listen/src/contexts/PlayerContext.tsx
+++ b/app/listen/src/contexts/PlayerContext.tsx
@@ -10,9 +10,10 @@ import {
 } from "react";
 import {
   getCrossfadeDurationPreference,
+  getInfinitePlaybackPreference,
   PLAYER_PLAYBACK_PREFS_EVENT,
 } from "@/lib/player-playback-prefs";
-import { fetchRadioContinuation } from "@/lib/radio";
+import { fetchInfiniteContinuation, fetchRadioContinuation } from "@/lib/radio";
 
 export interface Track {
   id: string;
@@ -230,11 +231,14 @@ export function PlayerProvider({ children }: { children: ReactNode }) {
   const [repeat, setRepeat] = useState<RepeatMode>("off");
   const [recentlyPlayed, setRecentlyPlayed] = useState<Track[]>(getStoredRecentlyPlayed);
   const [crossfadeSeconds, setCrossfadeSeconds] = useState(getCrossfadeDurationPreference);
+  const [infinitePlaybackEnabled, setInfinitePlaybackEnabled] = useState(getInfinitePlaybackPreference);
   const restoredRef = useRef(stored.current.queue.length > 0);
   const shouldAutoplayRef = useRef(false);
   const lastNonZeroVolumeRef = useRef(Math.max(getStoredVolume(), 0.5));
   const radioRefillInFlightRef = useRef(false);
   const radioRefillSignatureRef = useRef<string | null>(null);
+  const continuationInFlightRef = useRef(false);
+  const continuationSignatureRef = useRef<string | null>(null);
 
   if (!audioRef.current) {
     audioRef.current = getSharedAudio(PLAYER_AUDIO_KEY);
@@ -392,11 +396,19 @@ export function PlayerProvider({ children }: { children: ReactNode }) {
 
   useEffect(() => {
     const onPrefsChanged = (event: Event) => {
-      const detail = (event as CustomEvent<{ crossfadeSeconds?: number }>).detail;
+      const detail = (event as CustomEvent<{
+        crossfadeSeconds?: number;
+        infinitePlaybackEnabled?: boolean;
+      }>).detail;
       if (typeof detail?.crossfadeSeconds === "number") {
         setCrossfadeSeconds(detail.crossfadeSeconds);
       } else {
         setCrossfadeSeconds(getCrossfadeDurationPreference());
+      }
+      if (typeof detail?.infinitePlaybackEnabled === "boolean") {
+        setInfinitePlaybackEnabled(detail.infinitePlaybackEnabled);
+      } else {
+        setInfinitePlaybackEnabled(getInfinitePlaybackPreference());
       }
     };
 
@@ -461,6 +473,60 @@ export function PlayerProvider({ children }: { children: ReactNode }) {
   }, [currentIndex, isPlaying, playSource, queue, recentlyPlayed]);
 
   useEffect(() => {
+    const currentTrack = queue[currentIndex];
+    const supportsContinuation =
+      infinitePlaybackEnabled &&
+      !shuffle &&
+      !!currentTrack &&
+      (playSource?.type === "album" || playSource?.type === "playlist") &&
+      !!playSource?.radio?.seedId;
+
+    if (!supportsContinuation) return;
+
+    const remainingUpcoming = queue.length - currentIndex - 1;
+    if (remainingUpcoming > RADIO_REFILL_THRESHOLD) {
+      continuationSignatureRef.current = null;
+      return;
+    }
+    if (continuationInFlightRef.current) return;
+
+    const signature = [
+      playSource?.type ?? "",
+      playSource?.name ?? "",
+      playSource?.radio?.seedType ?? "",
+      playSource?.radio?.seedId ?? "",
+      currentTrack?.id ?? "",
+      queue.length,
+    ].join("::");
+    if (continuationSignatureRef.current === signature) return;
+    continuationSignatureRef.current = signature;
+    continuationInFlightRef.current = true;
+
+    fetchInfiniteContinuation(playSource!, RADIO_REFILL_BATCH_SIZE)
+      .then((tracks) => {
+        if (!tracks.length) return;
+        setQueue((prev) => {
+          const existingKeys = new Set(
+            [...prev, ...recentlyPlayed].map((track) => getTrackCacheKey(track)),
+          );
+          const uniqueTracks = tracks.filter((track) => {
+            const key = getTrackCacheKey(track);
+            if (!key || existingKeys.has(key)) return false;
+            existingKeys.add(key);
+            return true;
+          });
+          return uniqueTracks.length > 0 ? [...prev, ...uniqueTracks] : prev;
+        });
+      })
+      .catch((error) => {
+        console.warn("[player] continuation refill failed:", error);
+      })
+      .finally(() => {
+        continuationInFlightRef.current = false;
+      });
+  }, [currentIndex, infinitePlaybackEnabled, playSource, queue, recentlyPlayed, shuffle]);
+
+  useEffect(() => {
     const onTimeUpdate = () => setCurrentTime(audio.currentTime);
     const onDurationChange = () => setDuration(audio.duration || 0);
     const onEnded = () => {
@@ -522,6 +588,56 @@ export function PlayerProvider({ children }: { children: ReactNode }) {
         setCurrentIndex((i) => i + 1);
       } else if (repeat === "all") {
         setCurrentIndex(0);
+      } else if (
+        infinitePlaybackEnabled &&
+        !shuffle &&
+        (playSource?.type === "album" || playSource?.type === "playlist") &&
+        playSource?.radio?.seedId
+      ) {
+        shouldAutoplayRef.current = false;
+        setIsPlaying(false);
+        setIsBuffering(true);
+        continuationInFlightRef.current = true;
+
+        fetchInfiniteContinuation(playSource, RADIO_REFILL_BATCH_SIZE)
+          .then((tracks) => {
+            if (!tracks.length) {
+              setIsBuffering(false);
+              return;
+            }
+
+            let appended = false;
+            setQueue((prev) => {
+              const existingKeys = new Set(
+                [...prev, ...recentlyPlayed].map((track) => getTrackCacheKey(track)),
+              );
+              const uniqueTracks = tracks.filter((track) => {
+                const key = getTrackCacheKey(track);
+                if (!key || existingKeys.has(key)) return false;
+                existingKeys.add(key);
+                return true;
+              });
+              if (uniqueTracks.length === 0) return prev;
+              appended = true;
+              return [...prev, ...uniqueTracks];
+            });
+
+            if (appended) {
+              shouldAutoplayRef.current = true;
+              setCurrentIndex((i) => i + 1);
+              setCurrentTime(0);
+              setDuration(0);
+            } else {
+              setIsBuffering(false);
+            }
+          })
+          .catch((error) => {
+            console.warn("[player] continuation after end failed:", error);
+            setIsBuffering(false);
+          })
+          .finally(() => {
+            continuationInFlightRef.current = false;
+          });
       } else {
         shouldAutoplayRef.current = false;
         setIsPlaying(false);
@@ -575,7 +691,7 @@ export function PlayerProvider({ children }: { children: ReactNode }) {
       audio.removeEventListener("seeked", onSeeked);
       audio.removeEventListener("error", onError);
     };
-  }, [audio, crossfadeSeconds, currentIndex, playSource, queue, repeat, shuffle]);
+  }, [audio, crossfadeSeconds, currentIndex, infinitePlaybackEnabled, playSource, queue, recentlyPlayed, repeat, shuffle]);
 
   const play = useCallback((track: Track, source?: PlaySource) => {
     try {

--- a/app/listen/src/lib/player-playback-prefs.ts
+++ b/app/listen/src/lib/player-playback-prefs.ts
@@ -2,6 +2,8 @@ export const PLAYER_PLAYBACK_PREFS_EVENT = "listen-player-playback-prefs";
 
 const CROSSFADE_DURATION_KEY = "listen-player-crossfade-seconds";
 const INFINITE_PLAYBACK_KEY = "listen-player-infinite-playback";
+const SMART_PLAYLIST_SUGGESTIONS_KEY = "listen-player-smart-playlist-suggestions";
+const SMART_PLAYLIST_SUGGESTIONS_CADENCE_KEY = "listen-player-smart-playlist-suggestions-cadence";
 
 export function getCrossfadeDurationPreference(): number {
   try {
@@ -41,6 +43,55 @@ export function setInfinitePlaybackPreference(enabled: boolean) {
     window.dispatchEvent(
       new CustomEvent(PLAYER_PLAYBACK_PREFS_EVENT, {
         detail: { infinitePlaybackEnabled: enabled },
+      }),
+    );
+  } catch {
+    // ignore localStorage failures in private mode or restricted environments
+  }
+}
+
+export function getSmartPlaylistSuggestionsPreference(): boolean {
+  try {
+    const raw = localStorage.getItem(SMART_PLAYLIST_SUGGESTIONS_KEY);
+    if (raw == null) return false;
+    return raw === "true";
+  } catch {
+    return false;
+  }
+}
+
+export function setSmartPlaylistSuggestionsPreference(enabled: boolean) {
+  try {
+    localStorage.setItem(SMART_PLAYLIST_SUGGESTIONS_KEY, enabled ? "true" : "false");
+    window.dispatchEvent(
+      new CustomEvent(PLAYER_PLAYBACK_PREFS_EVENT, {
+        detail: { smartPlaylistSuggestionsEnabled: enabled },
+      }),
+    );
+  } catch {
+    // ignore localStorage failures in private mode or restricted environments
+  }
+}
+
+export function getSmartPlaylistSuggestionsCadencePreference(): number {
+  try {
+    const raw = localStorage.getItem(SMART_PLAYLIST_SUGGESTIONS_CADENCE_KEY);
+    if (!raw) return 5;
+    const parsed = Number.parseInt(raw, 10);
+    if (!Number.isFinite(parsed) || parsed < 2) return 5;
+    return Math.min(parsed, 10);
+  } catch {
+    return 5;
+  }
+}
+
+export function setSmartPlaylistSuggestionsCadencePreference(count: number) {
+  const value = Math.max(2, Math.min(count, 10));
+  try {
+    localStorage.setItem(SMART_PLAYLIST_SUGGESTIONS_CADENCE_KEY, String(value));
+    window.dispatchEvent(
+      new CustomEvent(PLAYER_PLAYBACK_PREFS_EVENT, {
+        detail: { smartPlaylistSuggestionsCadence: value },
       }),
     );
   } catch {

--- a/app/listen/src/lib/player-playback-prefs.ts
+++ b/app/listen/src/lib/player-playback-prefs.ts
@@ -1,6 +1,7 @@
 export const PLAYER_PLAYBACK_PREFS_EVENT = "listen-player-playback-prefs";
 
 const CROSSFADE_DURATION_KEY = "listen-player-crossfade-seconds";
+const INFINITE_PLAYBACK_KEY = "listen-player-infinite-playback";
 
 export function getCrossfadeDurationPreference(): number {
   try {
@@ -19,6 +20,29 @@ export function setCrossfadeDurationPreference(seconds: number) {
   try {
     localStorage.setItem(CROSSFADE_DURATION_KEY, String(value));
     window.dispatchEvent(new CustomEvent(PLAYER_PLAYBACK_PREFS_EVENT, { detail: { crossfadeSeconds: value } }));
+  } catch {
+    // ignore localStorage failures in private mode or restricted environments
+  }
+}
+
+export function getInfinitePlaybackPreference(): boolean {
+  try {
+    const raw = localStorage.getItem(INFINITE_PLAYBACK_KEY);
+    if (raw == null) return true;
+    return raw !== "false";
+  } catch {
+    return true;
+  }
+}
+
+export function setInfinitePlaybackPreference(enabled: boolean) {
+  try {
+    localStorage.setItem(INFINITE_PLAYBACK_KEY, enabled ? "true" : "false");
+    window.dispatchEvent(
+      new CustomEvent(PLAYER_PLAYBACK_PREFS_EVENT, {
+        detail: { infinitePlaybackEnabled: enabled },
+      }),
+    );
   } catch {
     // ignore localStorage failures in private mode or restricted environments
   }

--- a/app/listen/src/lib/radio.ts
+++ b/app/listen/src/lib/radio.ts
@@ -31,7 +31,12 @@ interface RadioResponse {
 function toTrack(payload: RadioTrackPayload): Track {
   const trackPath = payload.track_path || "";
   const navidromeId = payload.navidrome_id || undefined;
-  const playbackId = trackPath || navidromeId || String(payload.track_id || "");
+  const playbackId =
+    trackPath ||
+    navidromeId ||
+    (payload.track_id != null
+      ? String(payload.track_id)
+      : `radio:${payload.artist || "unknown"}:${payload.album || "unknown"}:${payload.title || "unknown"}`);
 
   return {
     id: playbackId,

--- a/app/listen/src/lib/radio.ts
+++ b/app/listen/src/lib/radio.ts
@@ -21,6 +21,8 @@ interface RadioResponse {
       track_id?: number | null;
       track_path?: string | null;
       artist_name?: string | null;
+      album_id?: number | null;
+      playlist_id?: number | null;
     };
   };
   tracks: RadioTrackPayload[];
@@ -91,6 +93,49 @@ export async function fetchTrackRadio(seed: {
         seedType: "track",
         seedId: data.session?.seed?.track_id ?? seed.libraryTrackId ?? null,
         seedPath: data.session?.seed?.track_path ?? seed.path ?? null,
+      },
+    },
+  };
+}
+
+export async function fetchAlbumRadio(seed: {
+  albumId: number;
+  artistName: string;
+  albumName: string;
+}): Promise<{
+  tracks: Track[];
+  source: PlaySource;
+}> {
+  const data = await api<RadioResponse>(`/api/radio/album/${seed.albumId}?limit=50`);
+  return {
+    tracks: (data.tracks || []).map(toTrack),
+    source: {
+      type: "radio",
+      name: data.session?.name || `${seed.albumName} Radio`,
+      radio: {
+        seedType: "album",
+        seedId: data.session?.seed?.album_id ?? seed.albumId,
+      },
+    },
+  };
+}
+
+export async function fetchPlaylistRadio(seed: {
+  playlistId: number;
+  playlistName: string;
+}): Promise<{
+  tracks: Track[];
+  source: PlaySource;
+}> {
+  const data = await api<RadioResponse>(`/api/radio/playlist/${seed.playlistId}?limit=50`);
+  return {
+    tracks: (data.tracks || []).map(toTrack),
+    source: {
+      type: "radio",
+      name: data.session?.name || `${seed.playlistName} Radio`,
+      radio: {
+        seedType: "playlist",
+        seedId: data.session?.seed?.playlist_id ?? seed.playlistId,
       },
     },
   };

--- a/app/listen/src/lib/radio.ts
+++ b/app/listen/src/lib/radio.ts
@@ -1,5 +1,5 @@
 import type { PlaySource, Track } from "@/contexts/PlayerContext";
-import { api } from "@/lib/api";
+import { ApiError, api } from "@/lib/api";
 import { encPath } from "@/lib/utils";
 
 export interface RadioTrackPayload {
@@ -28,6 +28,10 @@ interface RadioResponse {
   tracks: RadioTrackPayload[];
 }
 
+interface RadioRequestOptions {
+  signal?: AbortSignal;
+}
+
 function toTrack(payload: RadioTrackPayload): Track {
   const trackPath = payload.track_path || "";
   const navidromeId = payload.navidrome_id || undefined;
@@ -52,11 +56,22 @@ function toTrack(payload: RadioTrackPayload): Track {
   };
 }
 
-export async function fetchArtistRadio(artistName: string, limit = 50): Promise<{
+async function requestRadio(url: string, options: RadioRequestOptions = {}): Promise<RadioResponse> {
+  try {
+    return await api<RadioResponse>(url, "GET", undefined, { signal: options.signal });
+  } catch (error) {
+    if (error instanceof ApiError && error.status === 404) {
+      return { tracks: [] };
+    }
+    throw error;
+  }
+}
+
+export async function fetchArtistRadio(artistName: string, limit = 50, options: RadioRequestOptions = {}): Promise<{
   tracks: Track[];
   source: PlaySource;
 }> {
-  const data = await api<RadioResponse>(`/api/radio/artist/${encPath(artistName)}?limit=${limit}`);
+  const data = await requestRadio(`/api/radio/artist/${encPath(artistName)}?limit=${limit}`, options);
   return {
     tracks: (data.tracks || []).map(toTrack),
     source: {
@@ -74,7 +89,7 @@ export async function fetchTrackRadio(seed: {
   libraryTrackId?: number | null;
   path?: string | null;
   title: string;
-}): Promise<{
+}, options: RadioRequestOptions = {}): Promise<{
   tracks: Track[];
   source: PlaySource;
 }> {
@@ -88,7 +103,7 @@ export async function fetchTrackRadio(seed: {
   }
   params.set("limit", "50");
 
-  const data = await api<RadioResponse>(`/api/radio/track?${params.toString()}`);
+  const data = await requestRadio(`/api/radio/track?${params.toString()}`, options);
   return {
     tracks: (data.tracks || []).map(toTrack),
     source: {
@@ -107,11 +122,11 @@ export async function fetchAlbumRadio(seed: {
   albumId: number;
   artistName: string;
   albumName: string;
-}): Promise<{
+}, options: RadioRequestOptions = {}): Promise<{
   tracks: Track[];
   source: PlaySource;
 }> {
-  const data = await api<RadioResponse>(`/api/radio/album/${seed.albumId}?limit=50`);
+  const data = await requestRadio(`/api/radio/album/${seed.albumId}?limit=50`, options);
   return {
     tracks: (data.tracks || []).map(toTrack),
     source: {
@@ -128,11 +143,11 @@ export async function fetchAlbumRadio(seed: {
 export async function fetchPlaylistRadio(seed: {
   playlistId: number;
   playlistName: string;
-}): Promise<{
+}, options: RadioRequestOptions = {}): Promise<{
   tracks: Track[];
   source: PlaySource;
 }> {
-  const data = await api<RadioResponse>(`/api/radio/playlist/${seed.playlistId}?limit=50`);
+  const data = await requestRadio(`/api/radio/playlist/${seed.playlistId}?limit=50`, options);
   return {
     tracks: (data.tracks || []).map(toTrack),
     source: {
@@ -146,12 +161,16 @@ export async function fetchPlaylistRadio(seed: {
   };
 }
 
-export async function fetchRadioContinuation(source: PlaySource, limit = 30): Promise<Track[]> {
+export async function fetchRadioContinuation(
+  source: PlaySource,
+  limit = 30,
+  options: RadioRequestOptions = {},
+): Promise<Track[]> {
   const radio = source.radio;
   if (!radio) return [];
 
   if (radio.seedType === "artist" && radio.seedId) {
-    const data = await api<RadioResponse>(`/api/radio/artist/${encPath(String(radio.seedId))}?limit=${limit}`);
+    const data = await requestRadio(`/api/radio/artist/${encPath(String(radio.seedId))}?limit=${limit}`, options);
     return (data.tracks || []).map(toTrack);
   }
 
@@ -164,34 +183,38 @@ export async function fetchRadioContinuation(source: PlaySource, limit = 30): Pr
     } else {
       return [];
     }
-    const data = await api<RadioResponse>(`/api/radio/track?${params.toString()}`);
+    const data = await requestRadio(`/api/radio/track?${params.toString()}`, options);
     return (data.tracks || []).map(toTrack);
   }
 
   if (radio.seedType === "album" && radio.seedId != null) {
-    const data = await api<RadioResponse>(`/api/radio/album/${radio.seedId}?limit=${limit}`);
+    const data = await requestRadio(`/api/radio/album/${radio.seedId}?limit=${limit}`, options);
     return (data.tracks || []).map(toTrack);
   }
 
   if (radio.seedType === "playlist" && radio.seedId != null) {
-    const data = await api<RadioResponse>(`/api/radio/playlist/${radio.seedId}?limit=${limit}`);
+    const data = await requestRadio(`/api/radio/playlist/${radio.seedId}?limit=${limit}`, options);
     return (data.tracks || []).map(toTrack);
   }
 
   return [];
 }
 
-export async function fetchInfiniteContinuation(source: PlaySource, limit = 30): Promise<Track[]> {
+export async function fetchInfiniteContinuation(
+  source: PlaySource,
+  limit = 30,
+  options: RadioRequestOptions = {},
+): Promise<Track[]> {
   const seed = source.radio;
   if (!seed) return [];
 
   if (source.type === "album" && seed.seedType === "album" && seed.seedId != null) {
-    const data = await api<RadioResponse>(`/api/radio/album/${seed.seedId}?limit=${limit}`);
+    const data = await requestRadio(`/api/radio/album/${seed.seedId}?limit=${limit}`, options);
     return (data.tracks || []).map(toTrack);
   }
 
   if (source.type === "playlist" && seed.seedType === "playlist" && seed.seedId != null) {
-    const data = await api<RadioResponse>(`/api/radio/playlist/${seed.seedId}?limit=${limit}`);
+    const data = await requestRadio(`/api/radio/playlist/${seed.seedId}?limit=${limit}`, options);
     return (data.tracks || []).map(toTrack);
   }
 

--- a/app/listen/src/lib/radio.ts
+++ b/app/listen/src/lib/radio.ts
@@ -175,3 +175,20 @@ export async function fetchRadioContinuation(source: PlaySource, limit = 30): Pr
 
   return [];
 }
+
+export async function fetchInfiniteContinuation(source: PlaySource, limit = 30): Promise<Track[]> {
+  const seed = source.radio;
+  if (!seed) return [];
+
+  if (source.type === "album" && seed.seedType === "album" && seed.seedId != null) {
+    const data = await api<RadioResponse>(`/api/radio/album/${seed.seedId}?limit=${limit}`);
+    return (data.tracks || []).map(toTrack);
+  }
+
+  if (source.type === "playlist" && seed.seedType === "playlist" && seed.seedId != null) {
+    const data = await api<RadioResponse>(`/api/radio/playlist/${seed.seedId}?limit=${limit}`);
+    return (data.tracks || []).map(toTrack);
+  }
+
+  return [];
+}

--- a/app/listen/src/lib/radio.ts
+++ b/app/listen/src/lib/radio.ts
@@ -140,3 +140,38 @@ export async function fetchPlaylistRadio(seed: {
     },
   };
 }
+
+export async function fetchRadioContinuation(source: PlaySource, limit = 30): Promise<Track[]> {
+  const radio = source.radio;
+  if (!radio) return [];
+
+  if (radio.seedType === "artist" && radio.seedId) {
+    const data = await api<RadioResponse>(`/api/radio/artist/${encPath(String(radio.seedId))}?limit=${limit}`);
+    return (data.tracks || []).map(toTrack);
+  }
+
+  if (radio.seedType === "track") {
+    const params = new URLSearchParams({ limit: String(limit) });
+    if (radio.seedId != null) {
+      params.set("track_id", String(radio.seedId));
+    } else if (radio.seedPath) {
+      params.set("path", radio.seedPath);
+    } else {
+      return [];
+    }
+    const data = await api<RadioResponse>(`/api/radio/track?${params.toString()}`);
+    return (data.tracks || []).map(toTrack);
+  }
+
+  if (radio.seedType === "album" && radio.seedId != null) {
+    const data = await api<RadioResponse>(`/api/radio/album/${radio.seedId}?limit=${limit}`);
+    return (data.tracks || []).map(toTrack);
+  }
+
+  if (radio.seedType === "playlist" && radio.seedId != null) {
+    const data = await api<RadioResponse>(`/api/radio/playlist/${radio.seedId}?limit=${limit}`);
+    return (data.tracks || []).map(toTrack);
+  }
+
+  return [];
+}

--- a/app/listen/src/lib/radio.ts
+++ b/app/listen/src/lib/radio.ts
@@ -1,0 +1,97 @@
+import type { PlaySource, Track } from "@/contexts/PlayerContext";
+import { api } from "@/lib/api";
+import { encPath } from "@/lib/utils";
+
+export interface RadioTrackPayload {
+  track_id?: number | null;
+  navidrome_id?: string | null;
+  track_path?: string | null;
+  title: string;
+  artist: string;
+  album?: string | null;
+  duration?: number | null;
+  score?: number | null;
+}
+
+interface RadioResponse {
+  session?: {
+    type?: "track" | "album" | "artist" | "playlist";
+    name?: string;
+    seed?: {
+      track_id?: number | null;
+      track_path?: string | null;
+      artist_name?: string | null;
+    };
+  };
+  tracks: RadioTrackPayload[];
+}
+
+function toTrack(payload: RadioTrackPayload): Track {
+  const trackPath = payload.track_path || "";
+  const navidromeId = payload.navidrome_id || undefined;
+  const playbackId = trackPath || navidromeId || String(payload.track_id || "");
+
+  return {
+    id: playbackId,
+    title: payload.title || "Unknown",
+    artist: payload.artist || "Unknown",
+    album: payload.album || undefined,
+    albumCover: payload.artist && payload.album
+      ? `/api/cover/${encPath(payload.artist)}/${encPath(payload.album)}`
+      : undefined,
+    path: trackPath || undefined,
+    navidromeId,
+    libraryTrackId: payload.track_id || undefined,
+  };
+}
+
+export async function fetchArtistRadio(artistName: string, limit = 50): Promise<{
+  tracks: Track[];
+  source: PlaySource;
+}> {
+  const data = await api<RadioResponse>(`/api/radio/artist/${encPath(artistName)}?limit=${limit}`);
+  return {
+    tracks: (data.tracks || []).map(toTrack),
+    source: {
+      type: "radio",
+      name: data.session?.name || `${artistName} Radio`,
+      radio: {
+        seedType: "artist",
+        seedId: data.session?.seed?.artist_name || artistName,
+      },
+    },
+  };
+}
+
+export async function fetchTrackRadio(seed: {
+  libraryTrackId?: number | null;
+  path?: string | null;
+  title: string;
+}): Promise<{
+  tracks: Track[];
+  source: PlaySource;
+}> {
+  const params = new URLSearchParams();
+  if (seed.libraryTrackId != null) {
+    params.set("track_id", String(seed.libraryTrackId));
+  } else if (seed.path) {
+    params.set("path", seed.path);
+  } else {
+    throw new Error("track radio requires libraryTrackId or path");
+  }
+  params.set("limit", "50");
+
+  const data = await api<RadioResponse>(`/api/radio/track?${params.toString()}`);
+  return {
+    tracks: (data.tracks || []).map(toTrack),
+    source: {
+      type: "radio",
+      name: data.session?.name || `${seed.title} Radio`,
+      radio: {
+        seedType: "track",
+        seedId: data.session?.seed?.track_id ?? seed.libraryTrackId ?? null,
+        seedPath: data.session?.seed?.track_path ?? seed.path ?? null,
+      },
+    },
+  };
+}

--- a/app/listen/src/pages/Album.tsx
+++ b/app/listen/src/pages/Album.tsx
@@ -1,6 +1,6 @@
 import { useRef, useState } from "react";
 import { useParams, useNavigate } from "react-router";
-import { Clock, Disc, Heart, ListPlus, MoreHorizontal, Play, Share2, Shuffle, User } from "lucide-react";
+import { Clock, Disc, Heart, ListPlus, MoreHorizontal, Play, Radio, Share2, Shuffle, User } from "lucide-react";
 import { toast } from "sonner";
 
 import { AppMenuButton, AppPopover, AppPopoverDivider } from "@/components/ui/AppPopover";
@@ -11,6 +11,7 @@ import { usePlaylistComposer } from "@/contexts/PlaylistComposerContext";
 import { usePlayerActions, type Track } from "@/contexts/PlayerContext";
 import { useSavedAlbums } from "@/contexts/SavedAlbumsContext";
 import { TrackRow, type TrackRowData } from "@/components/cards/TrackRow";
+import { fetchAlbumRadio } from "@/lib/radio";
 import { encPath, formatBadgeClass } from "@/lib/utils";
 
 interface AlbumTrack {
@@ -154,6 +155,23 @@ export function Album() {
     const shuffled = [...playerTracks].sort(() => Math.random() - 0.5);
     playAll(shuffled);
   };
+
+  async function handleAlbumRadio() {
+    try {
+      const radio = await fetchAlbumRadio({
+        albumId,
+        artistName,
+        albumName: displayName,
+      });
+      if (!radio.tracks.length) {
+        toast.info("Album radio is not available yet");
+        return;
+      }
+      playAll(radio.tracks, 0, radio.source);
+    } catch {
+      toast.error("Failed to start album radio");
+    }
+  }
 
   const handleAddToQueue = () => {
     playerTracks.forEach((t) => addToQueue(t));
@@ -344,6 +362,13 @@ export function Album() {
         >
           <Shuffle size={15} />
           Shuffle
+        </button>
+        <button
+          className="flex items-center gap-2 px-4 py-2.5 rounded-full border border-white/15 text-sm text-foreground hover:bg-white/5 transition-colors"
+          onClick={handleAlbumRadio}
+        >
+          <Radio size={15} />
+          Album Radio
         </button>
         <button
           className="flex items-center gap-2 px-4 py-2.5 rounded-full border border-white/15 text-sm text-foreground hover:bg-white/5 transition-colors"

--- a/app/listen/src/pages/Album.tsx
+++ b/app/listen/src/pages/Album.tsx
@@ -147,13 +147,29 @@ export function Album() {
   );
 
   const handlePlay = (startIndex = 0) => {
-    if (playerTracks.length > 0) playAll(playerTracks, startIndex);
+    if (playerTracks.length > 0) {
+      playAll(playerTracks, startIndex, {
+        type: "album",
+        name: `${artistName} — ${displayName}`,
+        radio: {
+          seedType: "album",
+          seedId: albumId,
+        },
+      });
+    }
   };
 
   const handleShuffle = () => {
     if (playerTracks.length === 0) return;
     const shuffled = [...playerTracks].sort(() => Math.random() - 0.5);
-    playAll(shuffled);
+    playAll(shuffled, 0, {
+      type: "album",
+      name: `${artistName} — ${displayName}`,
+      radio: {
+        seedType: "album",
+        seedId: albumId,
+      },
+    });
   };
 
   async function handleAlbumRadio() {

--- a/app/listen/src/pages/Album.tsx
+++ b/app/listen/src/pages/Album.tsx
@@ -64,6 +64,17 @@ interface Playlist {
   name: string;
 }
 
+function shuffleArray<T>(arr: T[]): T[] {
+  const copy = [...arr];
+  for (let i = copy.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    const tmp = copy[i]!;
+    copy[i] = copy[j]!;
+    copy[j] = tmp;
+  }
+  return copy;
+}
+
 function buildPlayerTracks(data: AlbumData): Track[] {
   const cover = `/api/cover/${encPath(data.artist)}/${encPath(data.name)}`;
   return data.tracks.map((t) => ({
@@ -161,7 +172,7 @@ export function Album() {
 
   const handleShuffle = () => {
     if (playerTracks.length === 0) return;
-    const shuffled = [...playerTracks].sort(() => Math.random() - 0.5);
+    const shuffled = shuffleArray(playerTracks);
     playAll(shuffled, 0, {
       type: "album",
       name: `${artistName} — ${displayName}`,

--- a/app/listen/src/pages/Artist.tsx
+++ b/app/listen/src/pages/Artist.tsx
@@ -191,7 +191,7 @@ export function Artist() {
     }
 
     const queue = shuffle ? shuffleArray(playerTracks) : playerTracks;
-    playAll(queue, shuffle ? 0 : startIndex, { type: "album", name: `${decodedName} Top Tracks` });
+    playAll(queue, shuffle ? 0 : startIndex, { type: "queue", name: `${decodedName} Top Tracks` });
   }
 
   function genreSlug(name: string) {

--- a/app/listen/src/pages/Artist.tsx
+++ b/app/listen/src/pages/Artist.tsx
@@ -25,6 +25,7 @@ import { AppModal, ModalBody, ModalCloseButton, ModalHeader } from "@/components
 import { usePlayerActions, type Track } from "@/contexts/PlayerContext";
 import { useApi } from "@/hooks/use-api";
 import { api } from "@/lib/api";
+import { fetchArtistRadio } from "@/lib/radio";
 import { encPath, formatCompact } from "@/lib/utils";
 
 interface ArtistAlbum {
@@ -166,25 +167,18 @@ export function Artist() {
   async function handleArtistRadio() {
     if (!decodedName) return;
     try {
-      const radioTracks = await api<ArtistTopTrack[]>(`/api/artist-radio/${encPath(decodedName)}?limit=50`);
-      if (!radioTracks?.length) {
+      const radio = await fetchArtistRadio(decodedName);
+      if (!radio.tracks.length) {
         toast.info("Artist radio is not available yet");
         return;
       }
 
-      const queue: Track[] = radioTracks.map((track) => ({
-        id: track.id,
-        title: track.title || "Unknown",
-        artist: track.artist || decodedName,
-        album: track.album,
-        albumCover: track.artist && track.album
-          ? `/api/cover/${encPath(track.artist)}/${encPath(track.album)}`
-          : coverFallback,
-        path: track.id.includes("/") ? track.id : undefined,
-        navidromeId: track.id.includes("/") ? undefined : track.id,
+      const queue: Track[] = radio.tracks.map((track) => ({
+        ...track,
+        albumCover: track.albumCover || coverFallback,
       }));
 
-      playAll(queue, 0, { type: "radio", name: `${decodedName} Radio` });
+      playAll(queue, 0, radio.source);
     } catch {
       toast.error("Failed to start artist radio");
     }

--- a/app/listen/src/pages/ArtistTopTracks.tsx
+++ b/app/listen/src/pages/ArtistTopTracks.tsx
@@ -45,7 +45,7 @@ export function ArtistTopTracks() {
       toast.info("No top tracks available for this artist yet");
       return;
     }
-    playAll(queue, 0, { type: "album", name: `${decodedName} Top Tracks` });
+    playAll(queue, 0, { type: "queue", name: `${decodedName} Top Tracks` });
   }
 
   if (loading) {

--- a/app/listen/src/pages/CuratedPlaylist.tsx
+++ b/app/listen/src/pages/CuratedPlaylist.tsx
@@ -92,12 +92,20 @@ export function CuratedPlaylist() {
 
   function handlePlay() {
     if (playerTracks.length === 0) return;
-    playAll(playerTracks, 0, { type: "playlist", name: data?.name || "Playlist" });
+    playAll(playerTracks, 0, {
+      type: "playlist",
+      name: data?.name || "Playlist",
+      radio: data ? { seedType: "playlist", seedId: data.id } : undefined,
+    });
   }
 
   function handleShuffle() {
     if (playerTracks.length === 0) return;
-    playAll(shuffleArray(playerTracks), 0, { type: "playlist", name: data?.name || "Playlist" });
+    playAll(shuffleArray(playerTracks), 0, {
+      type: "playlist",
+      name: data?.name || "Playlist",
+      radio: data ? { seedType: "playlist", seedId: data.id } : undefined,
+    });
   }
 
   async function handlePlaylistRadio() {

--- a/app/listen/src/pages/CuratedPlaylist.tsx
+++ b/app/listen/src/pages/CuratedPlaylist.tsx
@@ -281,7 +281,7 @@ export function CuratedPlaylist() {
         <button
           onClick={handlePlaylistRadio}
           disabled={playerTracks.length === 0}
-          className="inline-flex items-center gap-2 rounded-full border border-white/15 px-4 py-2.5 text-sm text-foreground hover:bg-white/5 transition-colors"
+          className="inline-flex items-center gap-2 rounded-full border border-white/15 px-4 py-2.5 text-sm text-foreground hover:bg-white/5 transition-colors disabled:opacity-50"
         >
           <Radio size={15} />
           Playlist Radio

--- a/app/listen/src/pages/CuratedPlaylist.tsx
+++ b/app/listen/src/pages/CuratedPlaylist.tsx
@@ -1,6 +1,6 @@
 import { useMemo, useState } from "react";
 import { useNavigate, useParams } from "react-router";
-import { ArrowLeft, Heart, Loader2, Play, Shuffle, Share2, Sparkles, Users } from "lucide-react";
+import { ArrowLeft, Heart, Loader2, Play, Radio, Shuffle, Share2, Sparkles, Users } from "lucide-react";
 import { toast } from "sonner";
 
 import { useApi } from "@/hooks/use-api";
@@ -9,6 +9,7 @@ import { TrackRow } from "@/components/cards/TrackRow";
 import { PlaylistArtwork, type PlaylistArtworkTrack } from "@/components/playlists/PlaylistArtwork";
 import { usePlayerActions, type Track } from "@/contexts/PlayerContext";
 import { usePlaylistComposer } from "@/contexts/PlaylistComposerContext";
+import { fetchPlaylistRadio } from "@/lib/radio";
 import { encPath } from "@/lib/utils";
 
 interface CuratedPlaylistTrack {
@@ -97,6 +98,23 @@ export function CuratedPlaylist() {
   function handleShuffle() {
     if (playerTracks.length === 0) return;
     playAll(shuffleArray(playerTracks), 0, { type: "playlist", name: data?.name || "Playlist" });
+  }
+
+  async function handlePlaylistRadio() {
+    if (!data) return;
+    try {
+      const radio = await fetchPlaylistRadio({
+        playlistId: data.id,
+        playlistName: data.name,
+      });
+      if (!radio.tracks.length) {
+        toast.info("Playlist radio is not available yet");
+        return;
+      }
+      playAll(radio.tracks, 0, radio.source);
+    } catch {
+      toast.error("Failed to start playlist radio");
+    }
   }
 
   async function handleShare() {
@@ -251,6 +269,14 @@ export function CuratedPlaylist() {
         >
           <Shuffle size={15} />
           Shuffle
+        </button>
+        <button
+          onClick={handlePlaylistRadio}
+          disabled={playerTracks.length === 0}
+          className="inline-flex items-center gap-2 rounded-full border border-white/15 px-4 py-2.5 text-sm text-foreground hover:bg-white/5 transition-colors"
+        >
+          <Radio size={15} />
+          Playlist Radio
         </button>
         <button
           onClick={handleToggleFollow}

--- a/app/listen/src/pages/CuratedPlaylist.tsx
+++ b/app/listen/src/pages/CuratedPlaylist.tsx
@@ -266,14 +266,16 @@ export function CuratedPlaylist() {
       <div className="flex flex-wrap items-center gap-3">
         <button
           onClick={handlePlay}
-          className="inline-flex items-center gap-2 rounded-full bg-primary px-5 py-2.5 text-sm font-medium text-primary-foreground hover:bg-primary/90 transition-colors"
+          disabled={playerTracks.length === 0}
+          className="inline-flex items-center gap-2 rounded-full bg-primary px-5 py-2.5 text-sm font-medium text-primary-foreground hover:bg-primary/90 transition-colors disabled:opacity-50"
         >
           <Play size={16} fill="currentColor" />
           Play
         </button>
         <button
           onClick={handleShuffle}
-          className="inline-flex items-center gap-2 rounded-full border border-white/15 px-4 py-2.5 text-sm text-foreground hover:bg-white/5 transition-colors"
+          disabled={playerTracks.length === 0}
+          className="inline-flex items-center gap-2 rounded-full border border-white/15 px-4 py-2.5 text-sm text-foreground hover:bg-white/5 transition-colors disabled:opacity-50"
         >
           <Shuffle size={15} />
           Shuffle

--- a/app/listen/src/pages/Explore.tsx
+++ b/app/listen/src/pages/Explore.tsx
@@ -78,6 +78,37 @@ interface PlaylistDetailData {
   tracks: PlaylistDetailTrack[];
 }
 
+async function loadSystemPlaylistTracks(playlistId: number): Promise<{
+  tracks: Track[];
+  source: {
+    type: "playlist";
+    name: string;
+    radio: { seedType: "playlist"; seedId: number };
+  };
+}> {
+  const data = await api<PlaylistDetailData>(`/api/curation/playlists/${playlistId}`);
+  return {
+    tracks: (data.tracks || []).map((track) => ({
+      id: track.track_path || String(track.id || track.track_id || Math.random()),
+      title: track.title || "Unknown",
+      artist: track.artist || "",
+      album: track.album || "",
+      albumCover:
+        track.artist && track.album
+          ? `/api/cover/${encPath(track.artist)}/${encPath(track.album)}`
+          : data.cover_data_url || undefined,
+      path: track.track_path,
+      libraryTrackId: track.track_id,
+      navidromeId: track.navidrome_id,
+    })),
+    source: {
+      type: "playlist",
+      name: data.name,
+      radio: { seedType: "playlist", seedId: playlistId },
+    },
+  };
+}
+
 function Pill({ label, count, onClick }: { label: string; count?: number; onClick: () => void }) {
   return (
     <button
@@ -308,26 +339,9 @@ function PlaylistCategoryView({ category, onBack }: { category: string; onBack: 
 
   async function handlePlayPlaylist(playlistId: number, playlistName: string) {
     try {
-      const data = await api<PlaylistDetailData>(`/api/curation/playlists/${playlistId}`);
-      const playerTracks: Track[] = (data.tracks || []).map((track) => ({
-        id: track.track_path || String(track.id || track.track_id || Math.random()),
-        title: track.title || "Unknown",
-        artist: track.artist || "",
-        album: track.album || "",
-        albumCover:
-          track.artist && track.album
-            ? `/api/cover/${encPath(track.artist)}/${encPath(track.album)}`
-            : data.cover_data_url || undefined,
-        path: track.track_path,
-        libraryTrackId: track.track_id,
-        navidromeId: track.navidrome_id,
-      }));
-      if (playerTracks.length > 0) {
-        playAll(playerTracks, 0, {
-          type: "playlist",
-          name: playlistName,
-          radio: { seedType: "playlist", seedId: playlistId },
-        });
+      const playlist = await loadSystemPlaylistTracks(playlistId);
+      if (playlist.tracks.length > 0) {
+        playAll(playlist.tracks, 0, { ...playlist.source, name: playlistName });
       }
     } catch {
       toast.error("Failed to play playlist");
@@ -413,26 +427,9 @@ export function Explore() {
 
   async function handlePlayPlaylist(playlistId: number, playlistName: string) {
     try {
-      const data = await api<PlaylistDetailData>(`/api/curation/playlists/${playlistId}`);
-      const playerTracks: Track[] = (data.tracks || []).map((track) => ({
-        id: track.track_path || String(track.id || track.track_id || Math.random()),
-        title: track.title || "Unknown",
-        artist: track.artist || "",
-        album: track.album || "",
-        albumCover:
-          track.artist && track.album
-            ? `/api/cover/${encPath(track.artist)}/${encPath(track.album)}`
-            : data.cover_data_url || undefined,
-        path: track.track_path,
-        libraryTrackId: track.track_id,
-        navidromeId: track.navidrome_id,
-      }));
-      if (playerTracks.length > 0) {
-        playAll(playerTracks, 0, {
-          type: "playlist",
-          name: playlistName,
-          radio: { seedType: "playlist", seedId: playlistId },
-        });
+      const playlist = await loadSystemPlaylistTracks(playlistId);
+      if (playlist.tracks.length > 0) {
+        playAll(playlist.tracks, 0, { ...playlist.source, name: playlistName });
       }
     } catch {
       toast.error("Failed to play playlist");

--- a/app/listen/src/pages/Explore.tsx
+++ b/app/listen/src/pages/Explore.tsx
@@ -323,7 +323,11 @@ function PlaylistCategoryView({ category, onBack }: { category: string; onBack: 
         navidromeId: track.navidrome_id,
       }));
       if (playerTracks.length > 0) {
-        playAll(playerTracks, 0, { type: "playlist", name: playlistName });
+        playAll(playerTracks, 0, {
+          type: "playlist",
+          name: playlistName,
+          radio: { seedType: "playlist", seedId: playlistId },
+        });
       }
     } catch {
       toast.error("Failed to play playlist");
@@ -424,7 +428,11 @@ export function Explore() {
         navidromeId: track.navidrome_id,
       }));
       if (playerTracks.length > 0) {
-        playAll(playerTracks, 0, { type: "playlist", name: playlistName });
+        playAll(playerTracks, 0, {
+          type: "playlist",
+          name: playlistName,
+          radio: { seedType: "playlist", seedId: playlistId },
+        });
       }
     } catch {
       toast.error("Failed to play playlist");

--- a/app/listen/src/pages/Explore.tsx
+++ b/app/listen/src/pages/Explore.tsx
@@ -3,7 +3,7 @@ import { useNavigate, useSearchParams } from "react-router";
 import { Search, Loader2, ArrowLeft, ArrowRight } from "lucide-react";
 import { toast } from "sonner";
 import { useApi } from "@/hooks/use-api";
-import { api } from "@/lib/api";
+import { ApiError, api } from "@/lib/api";
 import { AlbumCard } from "@/components/cards/AlbumCard";
 import { ArtistCard } from "@/components/cards/ArtistCard";
 import { TrackRow } from "@/components/cards/TrackRow";
@@ -458,21 +458,30 @@ export function Explore() {
       return;
     }
 
-    let cancelled = false;
+    const controller = new AbortController();
     setSearching(true);
 
-    api<SearchResults>(`/api/search?q=${encodeURIComponent(debouncedQuery)}&limit=20`)
+    api<SearchResults>(`/api/search?q=${encodeURIComponent(debouncedQuery)}&limit=20`, "GET", undefined, {
+      signal: controller.signal,
+    })
       .then((data) => {
-        if (!cancelled) setSearchResults(data);
+        if (!controller.signal.aborted) setSearchResults(data);
       })
-      .catch(() => {
-        if (!cancelled) setSearchResults({ artists: [], albums: [], tracks: [] });
+      .catch((error) => {
+        if (controller.signal.aborted) return;
+        if (error instanceof ApiError && error.status === 404) {
+          setSearchResults({ artists: [], albums: [], tracks: [] });
+          return;
+        }
+        setSearchResults({ artists: [], albums: [], tracks: [] });
       })
       .finally(() => {
-        if (!cancelled) setSearching(false);
+        if (!controller.signal.aborted) setSearching(false);
       });
 
-    return () => { cancelled = true; };
+    return () => {
+      controller.abort();
+    };
   }, [debouncedQuery]);
 
   const isSearching = debouncedQuery.trim().length > 0;

--- a/app/listen/src/pages/Home.tsx
+++ b/app/listen/src/pages/Home.tsx
@@ -409,7 +409,11 @@ export function Home() {
         navidromeId: track.navidrome_id,
       }));
       if (playerTracks.length > 0) {
-        playAll(playerTracks, 0, { type: "playlist", name: playlistName });
+        playAll(playerTracks, 0, {
+          type: "playlist",
+          name: playlistName,
+          radio: { seedType: "playlist", seedId: playlistId },
+        });
       }
     } catch {
       toast.error("Failed to play playlist");

--- a/app/listen/src/pages/Library.tsx
+++ b/app/listen/src/pages/Library.tsx
@@ -257,6 +257,7 @@ function PlaylistsTab() {
           {followedCurated.map((playlist) => (
             <PlaylistListRow
               key={`curated-${playlist.id}`}
+              playlistId={playlist.id}
               name={playlist.name}
               description={playlist.description}
               coverDataUrl={playlist.cover_data_url}
@@ -287,6 +288,7 @@ function PlaylistsTab() {
           {playlists.map((pl) => (
             <PlaylistListRow
               key={pl.id}
+              playlistId={pl.id}
               name={pl.name}
               description={pl.description}
               coverDataUrl={pl.cover_data_url}

--- a/app/listen/src/pages/Playlist.tsx
+++ b/app/listen/src/pages/Playlist.tsx
@@ -1,6 +1,6 @@
 import { useMemo, useState } from "react";
 import { useNavigate, useParams } from "react-router";
-import { Play, Shuffle, Loader2, Sparkles, RefreshCw, Pencil, Trash2, Share2 } from "lucide-react";
+import { Play, Shuffle, Loader2, Sparkles, RefreshCw, Pencil, Trash2, Share2, Radio } from "lucide-react";
 import { toast } from "sonner";
 import { useApi } from "@/hooks/use-api";
 import { api } from "@/lib/api";
@@ -13,6 +13,7 @@ import {
 import { AppModal, ModalBody, ModalFooter, ModalHeader, ModalCloseButton } from "@/components/ui/AppModal";
 import { usePlayerActions, type Track } from "@/contexts/PlayerContext";
 import { usePlaylistComposer } from "@/contexts/PlaylistComposerContext";
+import { fetchPlaylistRadio } from "@/lib/radio";
 import { encPath } from "@/lib/utils";
 
 interface PlaylistTrack {
@@ -119,6 +120,23 @@ export function Playlist() {
   function handleShuffle() {
     if (playerTracks.length === 0) return;
     playAll(shuffleArray(playerTracks), 0);
+  }
+
+  async function handlePlaylistRadio() {
+    if (!data) return;
+    try {
+      const radio = await fetchPlaylistRadio({
+        playlistId: data.id,
+        playlistName: data.name,
+      });
+      if (!radio.tracks.length) {
+        toast.info("Playlist radio is not available yet");
+        return;
+      }
+      playAll(radio.tracks, 0, radio.source);
+    } catch {
+      toast.error("Failed to start playlist radio");
+    }
   }
 
   async function handleShare() {
@@ -321,18 +339,26 @@ export function Playlist() {
             <Play size={16} fill="currentColor" />
             Play
           </button>
-          <button
-            onClick={handleShuffle}
-            disabled={playerTracks.length === 0}
-            className="flex items-center gap-2 rounded-lg border border-white/20 px-5 py-2.5 text-sm font-medium text-foreground hover:bg-white/10 transition-colors disabled:opacity-50"
-          >
-            <Shuffle size={16} />
-            Shuffle
-          </button>
-          <button
-            onClick={() => setEditorOpen(true)}
-            className="flex items-center gap-2 rounded-lg border border-white/20 px-4 py-2.5 text-sm font-medium text-foreground hover:bg-white/10 transition-colors"
-          >
+        <button
+          onClick={handleShuffle}
+          disabled={playerTracks.length === 0}
+          className="flex items-center gap-2 rounded-lg border border-white/20 px-5 py-2.5 text-sm font-medium text-foreground hover:bg-white/10 transition-colors disabled:opacity-50"
+        >
+          <Shuffle size={16} />
+          Shuffle
+        </button>
+        <button
+          onClick={handlePlaylistRadio}
+          disabled={playerTracks.length === 0}
+          className="flex items-center gap-2 rounded-lg border border-white/20 px-5 py-2.5 text-sm font-medium text-foreground hover:bg-white/10 transition-colors disabled:opacity-50"
+        >
+          <Radio size={16} />
+          Playlist Radio
+        </button>
+        <button
+          onClick={() => setEditorOpen(true)}
+          className="flex items-center gap-2 rounded-lg border border-white/20 px-4 py-2.5 text-sm font-medium text-foreground hover:bg-white/10 transition-colors"
+        >
             <Pencil size={16} />
             Edit
           </button>

--- a/app/listen/src/pages/Playlist.tsx
+++ b/app/listen/src/pages/Playlist.tsx
@@ -114,12 +114,20 @@ export function Playlist() {
 
   function handlePlay() {
     if (playerTracks.length === 0) return;
-    playAll(playerTracks, 0);
+    playAll(playerTracks, 0, {
+      type: "playlist",
+      name: data?.name || "Playlist",
+      radio: data ? { seedType: "playlist", seedId: data.id } : undefined,
+    });
   }
 
   function handleShuffle() {
     if (playerTracks.length === 0) return;
-    playAll(shuffleArray(playerTracks), 0);
+    playAll(shuffleArray(playerTracks), 0, {
+      type: "playlist",
+      name: data?.name || "Playlist",
+      radio: data ? { seedType: "playlist", seedId: data.id } : undefined,
+    });
   }
 
   async function handlePlaylistRadio() {

--- a/app/listen/src/pages/Settings.tsx
+++ b/app/listen/src/pages/Settings.tsx
@@ -38,6 +38,7 @@ function RangeRow({
   max,
   step,
   displayValue,
+  disabled = false,
   onChange,
 }: {
   label: string;
@@ -47,10 +48,11 @@ function RangeRow({
   max: number;
   step: number;
   displayValue?: string;
+  disabled?: boolean;
   onChange: (value: number) => void;
 }) {
   return (
-    <div className="space-y-2">
+    <div className={`space-y-2 ${disabled ? "opacity-50" : ""}`}>
       <div className="flex items-center justify-between gap-4">
         <div>
           <div className="text-sm font-medium text-foreground">{label}</div>
@@ -66,8 +68,9 @@ function RangeRow({
         max={max}
         step={step}
         value={value}
+        disabled={disabled}
         onChange={(event) => onChange(Number(event.target.value))}
-        className="w-full accent-cyan-400"
+        className="w-full accent-cyan-400 disabled:cursor-not-allowed"
       />
     </div>
   );
@@ -172,6 +175,7 @@ export function Settings() {
           max={10}
           step={1}
           displayValue={`Every ${smartPlaylistSuggestionsCadence} tracks`}
+          disabled={!smartPlaylistSuggestionsEnabled}
           onChange={(value) => {
             setSmartPlaylistSuggestionsCadence(value);
             setSmartPlaylistSuggestionsCadencePreference(value);

--- a/app/listen/src/pages/Settings.tsx
+++ b/app/listen/src/pages/Settings.tsx
@@ -1,8 +1,12 @@
 import {
   getCrossfadeDurationPreference,
   getInfinitePlaybackPreference,
+  getSmartPlaylistSuggestionsCadencePreference,
+  getSmartPlaylistSuggestionsPreference,
   setInfinitePlaybackPreference,
   setCrossfadeDurationPreference,
+  setSmartPlaylistSuggestionsCadencePreference,
+  setSmartPlaylistSuggestionsPreference,
 } from "@/lib/player-playback-prefs";
 import { useState } from "react";
 
@@ -109,6 +113,12 @@ function ToggleRow({
 export function Settings() {
   const [crossfadeSeconds, setCrossfadeSeconds] = useState(getCrossfadeDurationPreference);
   const [infinitePlaybackEnabled, setInfinitePlaybackEnabled] = useState(getInfinitePlaybackPreference);
+  const [smartPlaylistSuggestionsEnabled, setSmartPlaylistSuggestionsEnabled] = useState(
+    getSmartPlaylistSuggestionsPreference,
+  );
+  const [smartPlaylistSuggestionsCadence, setSmartPlaylistSuggestionsCadence] = useState(
+    getSmartPlaylistSuggestionsCadencePreference,
+  );
 
   return (
     <div className="space-y-8">
@@ -143,6 +153,28 @@ export function Settings() {
           onChange={(value) => {
             setCrossfadeSeconds(value);
             setCrossfadeDurationPreference(value);
+          }}
+        />
+        <ToggleRow
+          label="Smart playlist suggestions"
+          description="While listening to a playlist, occasionally slip in one contextual recommendation without changing the playlist itself."
+          checked={smartPlaylistSuggestionsEnabled}
+          onChange={(value) => {
+            setSmartPlaylistSuggestionsEnabled(value);
+            setSmartPlaylistSuggestionsPreference(value);
+          }}
+        />
+        <RangeRow
+          label="Suggestion cadence"
+          description="How many original playlist tracks should play before a suggested track can be inserted."
+          value={smartPlaylistSuggestionsCadence}
+          min={2}
+          max={10}
+          step={1}
+          displayValue={`Every ${smartPlaylistSuggestionsCadence} tracks`}
+          onChange={(value) => {
+            setSmartPlaylistSuggestionsCadence(value);
+            setSmartPlaylistSuggestionsCadencePreference(value);
           }}
         />
       </Section>

--- a/app/listen/src/pages/Settings.tsx
+++ b/app/listen/src/pages/Settings.tsx
@@ -1,5 +1,7 @@
 import {
   getCrossfadeDurationPreference,
+  getInfinitePlaybackPreference,
+  setInfinitePlaybackPreference,
   setCrossfadeDurationPreference,
 } from "@/lib/player-playback-prefs";
 import { useState } from "react";
@@ -67,8 +69,46 @@ function RangeRow({
   );
 }
 
+function ToggleRow({
+  label,
+  description,
+  checked,
+  onChange,
+}: {
+  label: string;
+  description?: string;
+  checked: boolean;
+  onChange: (checked: boolean) => void;
+}) {
+  return (
+    <div className="flex items-start justify-between gap-4">
+      <div>
+        <div className="text-sm font-medium text-foreground">{label}</div>
+        {description ? <p className="mt-1 text-xs leading-5 text-muted-foreground">{description}</p> : null}
+      </div>
+      <button
+        type="button"
+        aria-pressed={checked}
+        onClick={() => onChange(!checked)}
+        className={`relative inline-flex h-7 w-12 flex-shrink-0 items-center rounded-full border transition-colors ${
+          checked
+            ? "border-cyan-400/50 bg-cyan-400/25"
+            : "border-white/10 bg-white/[0.03]"
+        }`}
+      >
+        <span
+          className={`inline-block h-5 w-5 rounded-full bg-white shadow-sm transition-transform ${
+            checked ? "translate-x-6" : "translate-x-1"
+          }`}
+        />
+      </button>
+    </div>
+  );
+}
+
 export function Settings() {
   const [crossfadeSeconds, setCrossfadeSeconds] = useState(getCrossfadeDurationPreference);
+  const [infinitePlaybackEnabled, setInfinitePlaybackEnabled] = useState(getInfinitePlaybackPreference);
 
   return (
     <div className="space-y-8">
@@ -83,6 +123,15 @@ export function Settings() {
         title="Playback"
         description="These preferences shape how the player behaves between tracks."
       >
+        <ToggleRow
+          label="Infinite playback"
+          description="When an album or playlist ends, keep the session going with context-aware continuation."
+          checked={infinitePlaybackEnabled}
+          onChange={(value) => {
+            setInfinitePlaybackEnabled(value);
+            setInfinitePlaybackPreference(value);
+          }}
+        />
         <RangeRow
           label="Crossfade"
           description="Set a preferred crossfade length for compatible transitions. Continuous album playback should still favor the most seamless handoff available."

--- a/app/shared/web/api.ts
+++ b/app/shared/web/api.ts
@@ -6,6 +6,10 @@ export interface ApiClientOptions {
   defaultHeaders?: Record<string, string>;
 }
 
+export interface ApiRequestOptions {
+  signal?: AbortSignal;
+}
+
 export class ApiError extends Error {
   constructor(
     public status: number,
@@ -26,11 +30,13 @@ export function createApiClient(options: ApiClientOptions = {}) {
     url: string,
     method: ApiMethod = "GET",
     body?: unknown,
+    options: ApiRequestOptions = {},
   ): Promise<T> {
     const headers: Record<string, string> = { ...defaultHeaders };
     const requestOptions: RequestInit = {
       method,
       headers,
+      signal: options.signal,
     };
 
     if (credentials) {

--- a/app/tests/test_radio_contracts.py
+++ b/app/tests/test_radio_contracts.py
@@ -64,3 +64,65 @@ class TestRadioApiContracts:
         assert data["session"]["seed"]["track_id"] == 99
         assert data["session"]["seed"]["track_path"] == "Converge/Jane Doe/01 - Concubine.flac"
         assert data["tracks"][1]["artist"] == "Botch"
+
+    def test_album_radio_returns_session_and_tracks(self, test_app):
+        tracks = [
+            {
+                "track_id": 10,
+                "navidrome_id": "nd-10",
+                "track_path": "Converge/Jane Doe/01 - Concubine.flac",
+                "title": "Concubine",
+                "artist": "Converge",
+                "album": "Jane Doe",
+                "duration": 94.0,
+                "score": None,
+            }
+        ]
+
+        with patch("crate.api.radio.get_db_ctx") as mock_ctx, \
+             patch("crate.api.radio.generate_album_radio", return_value=tracks):
+            mock_ctx.return_value.__enter__.return_value.fetchone.return_value = {
+                "artist": "Converge",
+                "name": "Jane Doe",
+            }
+            mock_ctx.return_value.__exit__.return_value = False
+
+            resp = test_app.get("/api/radio/album/5?limit=50")
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["session"]["type"] == "album"
+        assert data["session"]["seed"]["album_id"] == 5
+        assert data["tracks"][0]["album"] == "Jane Doe"
+
+    def test_playlist_radio_returns_session_and_tracks(self, test_app):
+        tracks = [
+            {
+                "track_id": 77,
+                "navidrome_id": "nd-77",
+                "track_path": "Converge/Jane Doe/11 - Jane Doe.flac",
+                "title": "Jane Doe",
+                "artist": "Converge",
+                "album": "Jane Doe",
+                "duration": 690.0,
+                "score": 0.84,
+            }
+        ]
+
+        with patch("crate.api.radio.get_db_ctx") as mock_ctx, \
+             patch("crate.api.radio.generate_playlist_radio", return_value=tracks):
+            mock_ctx.return_value.__enter__.return_value.fetchone.return_value = {
+                "id": 7,
+                "name": "Hardcore",
+                "scope": "system",
+                "user_id": None,
+            }
+            mock_ctx.return_value.__exit__.return_value = False
+
+            resp = test_app.get("/api/radio/playlist/7?limit=50")
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["session"]["type"] == "playlist"
+        assert data["session"]["seed"]["playlist_id"] == 7
+        assert data["tracks"][0]["title"] == "Jane Doe"

--- a/app/tests/test_radio_contracts.py
+++ b/app/tests/test_radio_contracts.py
@@ -116,6 +116,7 @@ class TestRadioApiContracts:
                 "name": "Hardcore",
                 "scope": "system",
                 "user_id": None,
+                "is_active": True,
             }
             mock_ctx.return_value.__exit__.return_value = False
 
@@ -141,3 +142,7 @@ class TestRadioApiContracts:
             resp = test_app.get("/api/radio/playlist/12?limit=50")
 
         assert resp.status_code == 404
+
+    def test_radio_endpoints_clamp_limit(self, test_app):
+        resp = test_app.get("/api/radio/artist/Converge?limit=101")
+        assert resp.status_code == 422

--- a/app/tests/test_radio_contracts.py
+++ b/app/tests/test_radio_contracts.py
@@ -1,0 +1,66 @@
+"""Regression contracts for unified radio endpoints."""
+
+from unittest.mock import patch
+
+
+class TestRadioApiContracts:
+    def test_artist_radio_returns_session_and_tracks(self, test_app):
+        tracks = [
+            {
+                "track_id": 42,
+                "navidrome_id": "nd-42",
+                "track_path": "Converge/Jane Doe/01 - Concubine.flac",
+                "title": "Concubine",
+                "artist": "Converge",
+                "album": "Jane Doe",
+                "duration": 94.0,
+                "score": 0.92,
+            }
+        ]
+
+        with patch("crate.api.radio.generate_artist_radio", return_value=tracks):
+            resp = test_app.get("/api/radio/artist/Converge?limit=25")
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["session"] == {
+            "type": "artist",
+            "name": "Converge Radio",
+            "seed": {"artist_name": "Converge"},
+        }
+        assert data["tracks"] == tracks
+
+    def test_track_radio_accepts_track_id_and_returns_tracks(self, test_app):
+        tracks = [
+            {
+                "track_id": 99,
+                "navidrome_id": "nd-99",
+                "track_path": "Converge/Jane Doe/01 - Concubine.flac",
+                "title": "Concubine",
+                "artist": "Converge",
+                "album": "Jane Doe",
+                "duration": 94.0,
+                "score": None,
+            },
+            {
+                "track_id": 123,
+                "navidrome_id": "nd-123",
+                "track_path": "Botch/We Are the Romans/02 - To Our Friends in the Great White North.flac",
+                "title": "To Our Friends in the Great White North",
+                "artist": "Botch",
+                "album": "We Are the Romans",
+                "duration": 181.0,
+                "score": 0.88,
+            },
+        ]
+
+        with patch("crate.api.radio._resolve_track_path", return_value="/music/Converge/Jane Doe/01 - Concubine.flac"), \
+             patch("crate.api.radio.generate_track_radio", return_value=tracks):
+            resp = test_app.get("/api/radio/track?track_id=99&limit=50")
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["session"]["type"] == "track"
+        assert data["session"]["seed"]["track_id"] == 99
+        assert data["session"]["seed"]["track_path"] == "Converge/Jane Doe/01 - Concubine.flac"
+        assert data["tracks"][1]["artist"] == "Botch"

--- a/app/tests/test_radio_contracts.py
+++ b/app/tests/test_radio_contracts.py
@@ -126,3 +126,18 @@ class TestRadioApiContracts:
         assert data["session"]["type"] == "playlist"
         assert data["session"]["seed"]["playlist_id"] == 7
         assert data["tracks"][0]["title"] == "Jane Doe"
+
+    def test_playlist_radio_hides_inactive_system_playlists(self, test_app):
+        with patch("crate.api.radio.get_db_ctx") as mock_ctx:
+            mock_ctx.return_value.__enter__.return_value.fetchone.return_value = {
+                "id": 12,
+                "name": "Hidden Editorial",
+                "scope": "system",
+                "user_id": None,
+                "is_active": False,
+            }
+            mock_ctx.return_value.__exit__.return_value = False
+
+            resp = test_app.get("/api/radio/playlist/12?limit=50")
+
+        assert resp.status_code == 404

--- a/docs/plans/2026-03-31-radio-and-playlist-intelligence-design.md
+++ b/docs/plans/2026-03-31-radio-and-playlist-intelligence-design.md
@@ -6,7 +6,7 @@
 
 ## Estado actual
 
-### Batch 1 en curso
+### Batch 1-5 completados
 
 Ya está arrancada una primera base técnica segura para esta iteración:
 
@@ -20,12 +20,11 @@ Ya está arrancada una primera base técnica segura para esta iteración:
 - `Album`, `Playlist` y `CuratedPlaylist` ya exponen acciones directas de radio
 - las sesiones de radio ya pueden hacer `queue refill` automático al acercarse al final de la cola
 - `album` y `playlist` ya soportan `infinite continuation` cuando la preferencia del player está activa
-
-### Aún no implementado
-
-Sigue pendiente para batches posteriores:
-
 - `smart track inclusion`
+  - solo durante reproducción de playlists
+  - configurable desde `Settings`
+  - efímera en cola, sin mutar la playlist guardada
+  - marcada visualmente como `Suggested` en las superficies de cola
 
 ## Resumen
 
@@ -491,6 +490,7 @@ Mi recomendación:
 ## Fase 4
 
 - `smart track inclusion`
+- estado: implementado como inserción de 1 sugerencia cada N temas originales de playlist
 
 ## Por Qué Este Orden
 

--- a/docs/plans/2026-03-31-radio-and-playlist-intelligence-design.md
+++ b/docs/plans/2026-03-31-radio-and-playlist-intelligence-design.md
@@ -19,12 +19,12 @@ Ya está arrancada una primera base técnica segura para esta iteración:
 - el `Suggested` del player ya puede arrancar `track radio`
 - `Album`, `Playlist` y `CuratedPlaylist` ya exponen acciones directas de radio
 - las sesiones de radio ya pueden hacer `queue refill` automático al acercarse al final de la cola
+- `album` y `playlist` ya soportan `infinite continuation` cuando la preferencia del player está activa
 
 ### Aún no implementado
 
 Sigue pendiente para batches posteriores:
 
-- `infinite continuation` al final de álbum/playlist
 - `smart track inclusion`
 
 ## Resumen

--- a/docs/plans/2026-03-31-radio-and-playlist-intelligence-design.md
+++ b/docs/plans/2026-03-31-radio-and-playlist-intelligence-design.md
@@ -18,12 +18,12 @@ Ya está arrancada una primera base técnica segura para esta iteración:
 - `listen` ya modela una sesión mínima de radio en `playSource.radio`
 - el `Suggested` del player ya puede arrancar `track radio`
 - `Album`, `Playlist` y `CuratedPlaylist` ya exponen acciones directas de radio
+- las sesiones de radio ya pueden hacer `queue refill` automático al acercarse al final de la cola
 
 ### Aún no implementado
 
 Sigue pendiente para batches posteriores:
 
-- auto-refill de cola para sesiones de radio
 - `infinite continuation` al final de álbum/playlist
 - `smart track inclusion`
 

--- a/docs/plans/2026-03-31-radio-and-playlist-intelligence-design.md
+++ b/docs/plans/2026-03-31-radio-and-playlist-intelligence-design.md
@@ -4,6 +4,28 @@
 **Estado**: Activo
 **Scope**: radio por `track` / `album` / `artist` / `playlist`, reproducción infinita con suggested tracks, e inclusión inteligente de pistas en playlists
 
+## Estado actual
+
+### Batch 1 en curso
+
+Ya está arrancada una primera base técnica segura para esta iteración:
+
+- API unificada de radio en `/api/radio/*`
+- `artist radio` migrada desde el endpoint legacy a contrato nuevo
+- `track radio` disponible como primera semilla adicional
+- `listen` ya modela una sesión mínima de radio en `playSource.radio`
+- el `Suggested` del player ya puede arrancar `track radio`
+
+### Aún no implementado
+
+Sigue pendiente para batches posteriores:
+
+- `album radio`
+- `playlist radio`
+- auto-refill de cola para sesiones de radio
+- `infinite continuation` al final de álbum/playlist
+- `smart track inclusion`
+
 ## Resumen
 
 Este documento consolida la estrategia de Crate para toda la reproducción “inteligente” en `listen`.

--- a/docs/plans/2026-03-31-radio-and-playlist-intelligence-design.md
+++ b/docs/plans/2026-03-31-radio-and-playlist-intelligence-design.md
@@ -13,15 +13,16 @@ Ya está arrancada una primera base técnica segura para esta iteración:
 - API unificada de radio en `/api/radio/*`
 - `artist radio` migrada desde el endpoint legacy a contrato nuevo
 - `track radio` disponible como primera semilla adicional
+- `album radio` disponible como primera semilla multi-track
+- `playlist radio` disponible para playlists personales y del sistema
 - `listen` ya modela una sesión mínima de radio en `playSource.radio`
 - el `Suggested` del player ya puede arrancar `track radio`
+- `Album`, `Playlist` y `CuratedPlaylist` ya exponen acciones directas de radio
 
 ### Aún no implementado
 
 Sigue pendiente para batches posteriores:
 
-- `album radio`
-- `playlist radio`
 - auto-refill de cola para sesiones de radio
 - `infinite continuation` al final de álbum/playlist
 - `smart track inclusion`


### PR DESCRIPTION
## Summary

This PR implements the first complete `radio + playlist intelligence` iteration for `listen`.

It adds:
- unified radio endpoints for `track`, `album`, `artist`, and `playlist`
- direct radio entry points in Listen surfaces
- radio queue auto-refill
- infinite continuation for album and playlist playback
- smart playlist suggestions inserted ephemerally into the playback queue
- playback settings for infinite mode and smart suggestion cadence
- review-driven fixes around queue insertion and playlist visibility

## What changed

### Backend
- Added a unified radio API in `app/crate/api/radio.py`
  - `GET /api/radio/artist/{name}`
  - `GET /api/radio/track`
  - `GET /api/radio/album/{album_id}`
  - `GET /api/radio/playlist/{playlist_id}`
- Extended `app/crate/bliss.py` with:
  - normalized radio payloads
  - `generate_track_radio`
  - `generate_album_radio`
  - `generate_playlist_radio`
  - multi-seed aggregation and queue interleaving helpers
- Restricted playlist radio so inactive system playlists are not exposed

### Listen player
- Extended `PlayerContext` to model radio seeds in `playSource.radio`
- Added radio queue refill when the queue gets close to the end
- Added infinite continuation for `album` and `playlist` playback
- Added smart playlist suggestions:
  - only for playlist playback
  - configurable from Settings
  - inserted only into the in-memory queue
  - visually marked as `Suggested`
  - avoids inserting into likely continuous album blocks
- Fixed a race where suggestions could be inserted at the wrong place if the user skipped while the recommendation request was in flight
- Made manual `Next` on the last track respect infinite continuation

### Listen UI
- Artist, Album, Playlist, and Curated Playlist now expose radio actions
- Suggested tab in the extended player can start track radio
- Queue surfaces show `Suggested` badges:
  - `QueuePanel`
  - `ExtendedPlayer`
  - `FullscreenPlayer`
- Added playback settings for:
  - infinite playback
  - smart playlist suggestions
  - suggestion cadence

### Docs
- Updated `docs/plans/2026-03-31-radio-and-playlist-intelligence-design.md` with the implemented state of the iteration

## Validation

- `npm run build` in `app/listen` ✅
- Python syntax checks for the touched backend modules ✅
- `app/tests/test_radio_contracts.py` still resolves as `skipped` under the current fixture environment in this workspace, so contract coverage exists but is not yet executing effectively here

## Follow-ups

Potential follow-ups after this PR:
- make the radio contract tests run effectively in the local fixture setup
- add a small QA pass for long-running radio / continuation sessions
- decide whether suggested tracks should be explicitly dismissible from queue UI


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Unified radio endpoints for artist/track/album/playlist and client radio fetchers; UI buttons to start radios and seed play actions
* **UX**
  * “Suggested” badge, improved title truncation, and radio-aware play behavior across player and queues
* **Settings**
  * Infinite playback, smart playlist suggestions, and suggestion cadence controls with persisted preferences
* **Tests**
  * Added radio API contract tests
* **Documentation**
  * Design doc updated with rollout checklist and smart-suggestion details
* **Chores**
  * New test runner target and abort-capable API request option
<!-- end of auto-generated comment: release notes by coderabbit.ai -->