### PR TITLE
Stats and Upcoming intelligence foundations for Listen

### DIFF
--- a/app/crate/actors.py
+++ b/app/crate/actors.py
@@ -53,6 +53,7 @@ TASK_POOL_CONFIG: dict[str, tuple[str, int, int, int]] = {
     "sync_playlist_navidrome": ("fast", 1, 120, 0),
     "sync_user_navidrome":  ("fast",    1, 120, 5),
     "sync_system_playlist_navidrome": ("fast", 1, 300, 2),
+    "refresh_user_listening_stats": ("fast", 1, 300, 0),
 
     # New content processing (priority 1)
     "process_new_content":  ("default", 1, 14400, 0),

--- a/app/crate/api/me.py
+++ b/app/crate/api/me.py
@@ -2,7 +2,7 @@
 
 from datetime import datetime, timedelta, timezone
 
-from fastapi import APIRouter, Request, HTTPException
+from fastapi import APIRouter, Request, HTTPException, Query
 from pydantic import BaseModel
 
 from crate.api.auth import _require_auth
@@ -220,6 +220,72 @@ def stats(request: Request):
     user = _require_auth(request)
     from crate.db.user_library import get_play_stats
     return get_play_stats(user["id"])
+
+
+@router.get("/stats/overview")
+def stats_overview(request: Request, window: str = Query("30d")):
+    user = _require_auth(request)
+    from crate.db.user_library import get_stats_overview
+
+    try:
+        return get_stats_overview(user["id"], window=window)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+
+@router.get("/stats/trends")
+def stats_trends(request: Request, window: str = Query("30d")):
+    user = _require_auth(request)
+    from crate.db.user_library import get_stats_trends
+
+    try:
+        return get_stats_trends(user["id"], window=window)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+
+@router.get("/stats/top-tracks")
+def stats_top_tracks(request: Request, window: str = Query("30d"), limit: int = Query(20, ge=1, le=100)):
+    user = _require_auth(request)
+    from crate.db.user_library import get_top_tracks
+
+    try:
+        return {"window": window, "items": get_top_tracks(user["id"], window=window, limit=limit)}
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+
+@router.get("/stats/top-artists")
+def stats_top_artists(request: Request, window: str = Query("30d"), limit: int = Query(20, ge=1, le=100)):
+    user = _require_auth(request)
+    from crate.db.user_library import get_top_artists
+
+    try:
+        return {"window": window, "items": get_top_artists(user["id"], window=window, limit=limit)}
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+
+@router.get("/stats/top-albums")
+def stats_top_albums(request: Request, window: str = Query("30d"), limit: int = Query(20, ge=1, le=100)):
+    user = _require_auth(request)
+    from crate.db.user_library import get_top_albums
+
+    try:
+        return {"window": window, "items": get_top_albums(user["id"], window=window, limit=limit)}
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+
+@router.get("/stats/top-genres")
+def stats_top_genres(request: Request, window: str = Query("30d"), limit: int = Query(20, ge=1, le=100)):
+    user = _require_auth(request)
+    from crate.db.user_library import get_top_genres
+
+    try:
+        return {"window": window, "items": get_top_genres(user["id"], window=window, limit=limit)}
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
 
 
 @router.post("/play-events")

--- a/app/crate/api/me.py
+++ b/app/crate/api/me.py
@@ -30,6 +30,29 @@ class RecordPlayRequest(BaseModel):
     album: str = ""
 
 
+class RecordPlayEventRequest(BaseModel):
+    track_id: int | None = None
+    track_path: str | None = None
+    title: str = ""
+    artist: str = ""
+    album: str = ""
+    started_at: str
+    ended_at: str
+    played_seconds: float = 0
+    track_duration_seconds: float | None = None
+    completion_ratio: float | None = None
+    was_skipped: bool = False
+    was_completed: bool = False
+    play_source_type: str | None = None
+    play_source_id: str | None = None
+    play_source_name: str | None = None
+    context_artist: str | None = None
+    context_album: str | None = None
+    context_playlist_id: int | None = None
+    device_type: str | None = None
+    app_platform: str | None = None
+
+
 def _probable_setlists_for_artists(artist_names: list[str]) -> dict[str, list[dict]]:
     from crate import setlistfm
 
@@ -197,6 +220,37 @@ def stats(request: Request):
     user = _require_auth(request)
     from crate.db.user_library import get_play_stats
     return get_play_stats(user["id"])
+
+
+@router.post("/play-events")
+def record_play_event_endpoint(request: Request, body: RecordPlayEventRequest):
+    user = _require_auth(request)
+    from crate.db.user_library import record_play_event
+
+    event_id = record_play_event(
+        user["id"],
+        track_id=body.track_id,
+        track_path=body.track_path,
+        title=body.title,
+        artist=body.artist,
+        album=body.album,
+        started_at=body.started_at,
+        ended_at=body.ended_at,
+        played_seconds=body.played_seconds,
+        track_duration_seconds=body.track_duration_seconds,
+        completion_ratio=body.completion_ratio,
+        was_skipped=body.was_skipped,
+        was_completed=body.was_completed,
+        play_source_type=body.play_source_type,
+        play_source_id=body.play_source_id,
+        play_source_name=body.play_source_name,
+        context_artist=body.context_artist,
+        context_album=body.context_album,
+        context_playlist_id=body.context_playlist_id,
+        device_type=body.device_type,
+        app_platform=body.app_platform,
+    )
+    return {"ok": True, "id": event_id}
 
 
 # ── Feed ─────────────────────────────────────────────────────

--- a/app/crate/api/me.py
+++ b/app/crate/api/me.py
@@ -53,6 +53,10 @@ class RecordPlayEventRequest(BaseModel):
     app_platform: str | None = None
 
 
+class ShowReminderRequest(BaseModel):
+    reminder_type: str
+
+
 def _probable_setlists_for_artists(artist_names: list[str]) -> dict[str, list[dict]]:
     from crate import setlistfm
 
@@ -65,6 +69,86 @@ def _probable_setlists_for_artists(artist_names: list[str]) -> dict[str, list[di
         except Exception:
             continue
     return result
+
+
+def _build_upcoming_insights(
+    user_id: int,
+    shows: list[dict],
+    attending_show_ids: set[int],
+) -> list[dict]:
+    from crate.db import get_show_reminders
+    from crate.db.user_library import get_top_artists
+
+    if not shows:
+        return []
+
+    reminders = get_show_reminders(user_id, [show["id"] for show in shows if show.get("id") is not None])
+    reminder_keys = {(row["show_id"], row["reminder_type"]) for row in reminders}
+    hot_artists = {
+        row["artist_name"]
+        for row in get_top_artists(user_id, window="30d", limit=12)
+        if row.get("artist_name")
+    }
+
+    today = datetime.now(timezone.utc).date()
+    insights: list[dict] = []
+    for show in sorted(shows, key=lambda item: item.get("date", "")):
+        show_id = show.get("id")
+        if not show_id or show_id not in attending_show_ids:
+            continue
+
+        date_str = show.get("date")
+        if not date_str:
+            continue
+        try:
+            show_date = datetime.strptime(date_str, "%Y-%m-%d").date()
+        except ValueError:
+            continue
+
+        days_until = (show_date - today).days
+        artist_name = show.get("artist_name") or ""
+        has_setlist = bool(show.get("probable_setlist"))
+
+        if 7 < days_until <= 30 and (show_id, "one_month") not in reminder_keys:
+            insights.append({
+                "type": "one_month",
+                "show_id": show_id,
+                "artist": artist_name,
+                "date": date_str,
+                "title": show.get("venue") or artist_name,
+                "subtitle": f"{days_until} days to go",
+                "message": f"{artist_name} is coming up in about a month.",
+                "has_setlist": has_setlist,
+            })
+
+        if 1 < days_until <= 7 and (show_id, "one_week") not in reminder_keys:
+            insights.append({
+                "type": "one_week",
+                "show_id": show_id,
+                "artist": artist_name,
+                "date": date_str,
+                "title": show.get("venue") or artist_name,
+                "subtitle": f"{days_until} days to go",
+                "message": f"{artist_name} is coming up this week.",
+                "has_setlist": has_setlist,
+            })
+
+        if has_setlist and days_until <= 30 and (show_id, "show_prep") not in reminder_keys:
+            weight = "high" if artist_name in hot_artists else "normal"
+            insights.append({
+                "type": "show_prep",
+                "show_id": show_id,
+                "artist": artist_name,
+                "date": date_str,
+                "title": f"{artist_name} probable setlist",
+                "subtitle": "Show prep",
+                "message": "Warm up with the likely setlist before the show.",
+                "has_setlist": True,
+                "weight": weight,
+            })
+
+    insights.sort(key=lambda item: (item.get("date", ""), item.get("type", "")))
+    return insights[:8]
 
 
 # ── Library Summary ──────────────────────────────────────────
@@ -387,10 +471,13 @@ def upcoming(request: Request, limit: int = 120):
     if not followed_names:
         return {
             "items": [],
+            "insights": [],
             "summary": {
                 "followed_artists": 0,
                 "show_count": 0,
                 "release_count": 0,
+                "attending_count": 0,
+                "insight_count": 0,
             },
         }
 
@@ -507,12 +594,24 @@ def upcoming(request: Request, limit: int = 120):
             }
         )
 
+    enriched_shows = [
+        {
+            **dict(show),
+            "probable_setlist": (setlist_map.get(show.get("artist_name", "")) or [])[:8],
+        }
+        for show in shows
+    ]
+    insights = _build_upcoming_insights(user["id"], enriched_shows, attending_show_ids)
+
     return {
         "items": items,
+        "insights": insights,
         "summary": {
             "followed_artists": len(followed_names),
             "show_count": len([item for item in items if item["type"] == "show"]),
             "release_count": len([item for item in items if item["type"] == "release"]),
+            "attending_count": len(attending_show_ids),
+            "insight_count": len(insights),
         },
     }
 
@@ -531,3 +630,14 @@ def unattend_show_endpoint(request: Request, show_id: int):
     from crate.db import unattend_show
 
     return {"ok": True, "removed": unattend_show(user["id"], show_id)}
+
+
+@router.post("/shows/{show_id}/reminders")
+def create_show_reminder_endpoint(request: Request, show_id: int, body: ShowReminderRequest):
+    user = _require_auth(request)
+    from crate.db import create_show_reminder
+
+    if body.reminder_type not in {"one_month", "one_week", "show_prep"}:
+        raise HTTPException(status_code=400, detail="Unsupported reminder type")
+
+    return {"ok": True, "added": create_show_reminder(user["id"], show_id, body.reminder_type)}

--- a/app/crate/api/me.py
+++ b/app/crate/api/me.py
@@ -372,6 +372,17 @@ def stats_top_genres(request: Request, window: str = Query("30d"), limit: int = 
         raise HTTPException(status_code=400, detail=str(exc)) from exc
 
 
+@router.get("/stats/replay")
+def stats_replay(request: Request, window: str = Query("30d"), limit: int = Query(30, ge=1, le=100)):
+    user = _require_auth(request)
+    from crate.db.user_library import get_replay_mix
+
+    try:
+        return get_replay_mix(user["id"], window=window, limit=limit)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+
 @router.post("/play-events")
 def record_play_event_endpoint(request: Request, body: RecordPlayEventRequest):
     user = _require_auth(request)

--- a/app/crate/api/me.py
+++ b/app/crate/api/me.py
@@ -3,7 +3,7 @@
 from datetime import datetime, timedelta, timezone
 
 from fastapi import APIRouter, Request, HTTPException, Query
-from pydantic import BaseModel
+from pydantic import BaseModel, field_validator, model_validator
 
 from crate.api.auth import _require_auth
 
@@ -36,8 +36,8 @@ class RecordPlayEventRequest(BaseModel):
     title: str = ""
     artist: str = ""
     album: str = ""
-    started_at: str
-    ended_at: str
+    started_at: datetime
+    ended_at: datetime
     played_seconds: float = 0
     track_duration_seconds: float | None = None
     completion_ratio: float | None = None
@@ -52,22 +52,53 @@ class RecordPlayEventRequest(BaseModel):
     device_type: str | None = None
     app_platform: str | None = None
 
+    @field_validator("played_seconds")
+    @classmethod
+    def _validate_played_seconds(cls, value: float) -> float:
+        if value < 0:
+            raise ValueError("played_seconds must be >= 0")
+        return value
+
+    @field_validator("track_duration_seconds")
+    @classmethod
+    def _validate_track_duration(cls, value: float | None) -> float | None:
+        if value is not None and value <= 0:
+            raise ValueError("track_duration_seconds must be > 0")
+        return value
+
+    @field_validator("completion_ratio")
+    @classmethod
+    def _validate_completion_ratio(cls, value: float | None) -> float | None:
+        if value is not None and not 0 <= value <= 1:
+            raise ValueError("completion_ratio must be between 0 and 1")
+        return value
+
+    @model_validator(mode="after")
+    def _validate_consistency(self):
+        if self.started_at > self.ended_at:
+            raise ValueError("started_at must be <= ended_at")
+        if self.was_skipped and self.was_completed:
+            raise ValueError("was_skipped and was_completed cannot both be true")
+        if self.track_duration_seconds and self.completion_ratio is not None:
+            derived = min(1.0, max(0.0, self.played_seconds / self.track_duration_seconds))
+            if abs(derived - self.completion_ratio) > 0.15:
+                raise ValueError("completion_ratio does not match played_seconds and track_duration_seconds")
+        return self
+
 
 class ShowReminderRequest(BaseModel):
     reminder_type: str
 
 
 def _probable_setlists_for_artists(artist_names: list[str]) -> dict[str, list[dict]]:
-    from crate import setlistfm
+    from crate.db import get_cache
 
     result: dict[str, list[dict]] = {}
     for artist_name in artist_names:
-        try:
-            probable = setlistfm.get_probable_setlist(artist_name)
-            if probable:
-                result[artist_name] = probable
-        except Exception:
-            continue
+        cached = get_cache(f"setlistfm:probable:{artist_name.lower()}", max_age_seconds=86400 * 7)
+        songs = cached.get("songs") if isinstance(cached, dict) else None
+        if songs:
+            result[artist_name] = songs
     return result
 
 
@@ -289,6 +320,8 @@ def history(request: Request, limit: int = 50):
 def record(request: Request, body: RecordPlayRequest):
     user = _require_auth(request)
     from crate.db.user_library import record_play
+    # Legacy endpoint kept for recently-played surfaces while /play-events becomes the
+    # canonical telemetry path. Remove once remaining callers are migrated.
     record_play(
         user["id"],
         track_path=body.track_path,
@@ -386,6 +419,7 @@ def stats_replay(request: Request, window: str = Query("30d"), limit: int = Quer
 @router.post("/play-events")
 def record_play_event_endpoint(request: Request, body: RecordPlayEventRequest):
     user = _require_auth(request)
+    from crate.db import create_task_dedup
     from crate.db.user_library import record_play_event
 
     event_id = record_play_event(
@@ -395,8 +429,8 @@ def record_play_event_endpoint(request: Request, body: RecordPlayEventRequest):
         title=body.title,
         artist=body.artist,
         album=body.album,
-        started_at=body.started_at,
-        ended_at=body.ended_at,
+        started_at=body.started_at.isoformat(),
+        ended_at=body.ended_at.isoformat(),
         played_seconds=body.played_seconds,
         track_duration_seconds=body.track_duration_seconds,
         completion_ratio=body.completion_ratio,
@@ -411,6 +445,7 @@ def record_play_event_endpoint(request: Request, body: RecordPlayEventRequest):
         device_type=body.device_type,
         app_platform=body.app_platform,
     )
+    create_task_dedup("refresh_user_listening_stats", {"user_id": user["id"]})
     return {"ok": True, "id": event_id}
 
 
@@ -424,9 +459,11 @@ def feed(request: Request, limit: int = 30):
     from crate.db.core import get_db_ctx
 
     followed = get_followed_artists(user["id"])
-    followed_names = {f["artist_name"] for f in followed}
+    followed_names = [f["artist_name"] for f in followed if f.get("artist_name")]
 
     items = []
+    recent_day_cutoff = (datetime.now(timezone.utc) - timedelta(days=30)).strftime("%Y-%m-%d")
+    today = datetime.now(timezone.utc).strftime("%Y-%m-%d")
     with get_db_ctx() as cur:
         if followed_names:
             placeholders = ",".join(["%s"] * len(followed_names))
@@ -435,10 +472,10 @@ def feed(request: Request, limit: int = 30):
                        la.updated_at AS date
                 FROM library_albums la
                 WHERE la.artist IN ({placeholders})
-                AND la.updated_at > (NOW() AT TIME ZONE 'UTC' - INTERVAL '30 days')::text
+                AND substring(COALESCE(la.updated_at, ''), 1, 10) >= %s
                 ORDER BY la.updated_at DESC
                 LIMIT %s
-            """, list(followed_names) + [limit])
+            """, list(followed_names) + [recent_day_cutoff, limit])
             for r in cur.fetchall():
                 items.append(dict(r))
 
@@ -447,10 +484,10 @@ def feed(request: Request, limit: int = 30):
                        s.city, s.country, s.date, s.url, s.image_url
                 FROM shows s
                 WHERE s.artist_name IN ({placeholders})
-                AND s.date >= CURRENT_DATE::text
+                AND s.date >= %s
                 ORDER BY s.date
                 LIMIT %s
-            """, list(followed_names) + [limit])
+            """, list(followed_names) + [today, limit])
             for r in cur.fetchall():
                 items.append(dict(r))
 

--- a/app/crate/db/__init__.py
+++ b/app/crate/db/__init__.py
@@ -121,6 +121,6 @@ from crate.db.user_library import (
     follow_artist, unfollow_artist, get_followed_artists, is_following,
     save_album, unsave_album, get_saved_albums, is_album_saved,
     like_track, unlike_track, get_liked_tracks, is_track_liked,
-    record_play, record_play_event, get_play_history, get_play_stats,
+    record_play, record_play_event, recompute_user_listening_aggregates, get_play_history, get_play_stats,
     get_user_library_counts,
 )

--- a/app/crate/db/__init__.py
+++ b/app/crate/db/__init__.py
@@ -120,6 +120,6 @@ from crate.db.user_library import (
     follow_artist, unfollow_artist, get_followed_artists, is_following,
     save_album, unsave_album, get_saved_albums, is_album_saved,
     like_track, unlike_track, get_liked_tracks, is_track_liked,
-    record_play, get_play_history, get_play_stats,
+    record_play, record_play_event, get_play_history, get_play_stats,
     get_user_library_counts,
 )

--- a/app/crate/db/__init__.py
+++ b/app/crate/db/__init__.py
@@ -102,6 +102,7 @@ from crate.db.shows import (
     upsert_show, get_upcoming_shows, get_all_shows,
     get_show_cities, get_show_countries, delete_past_shows,
     attend_show, unattend_show, get_attending_show_ids,
+    get_show_reminders, create_show_reminder,
 )
 
 # Task Events (SSE)

--- a/app/crate/db/core.py
+++ b/app/crate/db/core.py
@@ -770,6 +770,19 @@ def init_db():
         """)
         cur.execute("CREATE INDEX IF NOT EXISTS idx_user_show_attendance_user ON user_show_attendance(user_id)")
         cur.execute("CREATE INDEX IF NOT EXISTS idx_user_show_attendance_show ON user_show_attendance(show_id)")
+        cur.execute("""
+            CREATE TABLE IF NOT EXISTS user_show_reminders (
+                id SERIAL PRIMARY KEY,
+                user_id INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+                show_id INTEGER NOT NULL REFERENCES shows(id) ON DELETE CASCADE,
+                reminder_type TEXT NOT NULL,
+                created_at TEXT NOT NULL,
+                triggered_at TEXT,
+                UNIQUE(user_id, show_id, reminder_type)
+            )
+        """)
+        cur.execute("CREATE INDEX IF NOT EXISTS idx_user_show_reminders_user ON user_show_reminders(user_id, show_id)")
+        cur.execute("CREATE INDEX IF NOT EXISTS idx_user_show_reminders_type ON user_show_reminders(user_id, reminder_type)")
 
         # Migration: track rating (0-5 stars)
         cur.execute("""

--- a/app/crate/db/core.py
+++ b/app/crate/db/core.py
@@ -914,6 +914,37 @@ def init_db():
         cur.execute("CREATE INDEX IF NOT EXISTS idx_play_history_user ON play_history(user_id, played_at DESC)")
         cur.execute("CREATE INDEX IF NOT EXISTS idx_play_history_track ON play_history(track_id)")
 
+        cur.execute("""
+            CREATE TABLE IF NOT EXISTS user_play_events (
+                id SERIAL PRIMARY KEY,
+                user_id INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+                track_id INTEGER REFERENCES library_tracks(id) ON DELETE SET NULL,
+                track_path TEXT,
+                title TEXT,
+                artist TEXT,
+                album TEXT,
+                started_at TEXT NOT NULL,
+                ended_at TEXT NOT NULL,
+                played_seconds DOUBLE PRECISION NOT NULL DEFAULT 0,
+                track_duration_seconds DOUBLE PRECISION,
+                completion_ratio DOUBLE PRECISION,
+                was_skipped BOOLEAN NOT NULL DEFAULT FALSE,
+                was_completed BOOLEAN NOT NULL DEFAULT FALSE,
+                play_source_type TEXT,
+                play_source_id TEXT,
+                play_source_name TEXT,
+                context_artist TEXT,
+                context_album TEXT,
+                context_playlist_id INTEGER,
+                device_type TEXT,
+                app_platform TEXT,
+                created_at TEXT NOT NULL
+            )
+        """)
+        cur.execute("CREATE INDEX IF NOT EXISTS idx_user_play_events_user ON user_play_events(user_id, ended_at DESC)")
+        cur.execute("CREATE INDEX IF NOT EXISTS idx_user_play_events_track ON user_play_events(track_id)")
+        cur.execute("CREATE INDEX IF NOT EXISTS idx_user_play_events_source ON user_play_events(user_id, play_source_type, ended_at DESC)")
+
         # Migration: add user_id to favorites table if missing
         cur.execute("""
             DO $$ BEGIN

--- a/app/crate/db/core.py
+++ b/app/crate/db/core.py
@@ -9,6 +9,7 @@ from datetime import datetime, timezone
 import psycopg2
 import psycopg2.extras
 import psycopg2.pool
+from psycopg2 import sql
 
 log = logging.getLogger(__name__)
 
@@ -67,17 +68,30 @@ def _ensure_database():
         # Create app role if missing
         cur.execute("SELECT 1 FROM pg_roles WHERE rolname = %s", (app_user,))
         if not cur.fetchone():
-            cur.execute(f"CREATE ROLE {app_user} WITH LOGIN PASSWORD %s", (app_pass,))
+            cur.execute(
+                sql.SQL("CREATE ROLE {} WITH LOGIN PASSWORD %s").format(sql.Identifier(app_user)),
+                (app_pass,),
+            )
             log.info("Created database role: %s", app_user)
 
         # Create app database if missing
         cur.execute("SELECT 1 FROM pg_database WHERE datname = %s", (app_db,))
         if not cur.fetchone():
-            cur.execute(f"CREATE DATABASE {app_db} OWNER {app_user}")
+            cur.execute(
+                sql.SQL("CREATE DATABASE {} OWNER {}").format(
+                    sql.Identifier(app_db),
+                    sql.Identifier(app_user),
+                )
+            )
             log.info("Created database: %s", app_db)
 
         # Ensure ownership
-        cur.execute(f"ALTER DATABASE {app_db} OWNER TO {app_user}")
+        cur.execute(
+            sql.SQL("ALTER DATABASE {} OWNER TO {}").format(
+                sql.Identifier(app_db),
+                sql.Identifier(app_user),
+            )
+        )
 
         cur.close()
         conn.close()
@@ -886,15 +900,27 @@ def init_db():
         cur.execute("CREATE INDEX IF NOT EXISTS idx_user_saved_albums_user ON user_saved_albums(user_id)")
 
         cur.execute("""
-            DO $$ BEGIN
-                IF EXISTS (
-                    SELECT 1
-                    FROM information_schema.columns
-                    WHERE table_name = 'user_liked_tracks' AND column_name = 'track_path'
+            DO $$
+            BEGIN
+                -- One-shot migration: the old user_liked_tracks shape used track_path and is incompatible
+                -- with the current track_id PK. Guard with a settings flag so we never re-run a destructive
+                -- check silently on every startup.
+                IF NOT EXISTS (
+                    SELECT 1 FROM settings WHERE key = 'migration:user_liked_tracks_v2_applied'
                 ) THEN
-                    DROP TABLE user_liked_tracks;
+                    IF EXISTS (
+                        SELECT 1
+                        FROM information_schema.columns
+                        WHERE table_name = 'user_liked_tracks' AND column_name = 'track_path'
+                    ) THEN
+                        DROP TABLE user_liked_tracks;
+                    END IF;
+                    INSERT INTO settings (key, value)
+                    VALUES ('migration:user_liked_tracks_v2_applied', 'true')
+                    ON CONFLICT (key) DO NOTHING;
                 END IF;
-            END $$
+            END
+            $$
         """)
         cur.execute("""
             CREATE TABLE IF NOT EXISTS user_liked_tracks (
@@ -957,6 +983,9 @@ def init_db():
         cur.execute("CREATE INDEX IF NOT EXISTS idx_user_play_events_user ON user_play_events(user_id, ended_at DESC)")
         cur.execute("CREATE INDEX IF NOT EXISTS idx_user_play_events_track ON user_play_events(track_id)")
         cur.execute("CREATE INDEX IF NOT EXISTS idx_user_play_events_source ON user_play_events(user_id, play_source_type, ended_at DESC)")
+        cur.execute("CREATE INDEX IF NOT EXISTS idx_user_play_events_user_artist ON user_play_events(user_id, artist, ended_at DESC)")
+        cur.execute("CREATE INDEX IF NOT EXISTS idx_user_play_events_user_album ON user_play_events(user_id, album, ended_at DESC)")
+        cur.execute("CREATE INDEX IF NOT EXISTS idx_user_play_events_user_day ON user_play_events(user_id, (substring(ended_at, 1, 10)))")
 
         cur.execute("""
             CREATE TABLE IF NOT EXISTS user_daily_listening (

--- a/app/crate/db/core.py
+++ b/app/crate/db/core.py
@@ -945,6 +945,89 @@ def init_db():
         cur.execute("CREATE INDEX IF NOT EXISTS idx_user_play_events_track ON user_play_events(track_id)")
         cur.execute("CREATE INDEX IF NOT EXISTS idx_user_play_events_source ON user_play_events(user_id, play_source_type, ended_at DESC)")
 
+        cur.execute("""
+            CREATE TABLE IF NOT EXISTS user_daily_listening (
+                user_id INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+                day TEXT NOT NULL,
+                play_count INTEGER NOT NULL DEFAULT 0,
+                complete_play_count INTEGER NOT NULL DEFAULT 0,
+                skip_count INTEGER NOT NULL DEFAULT 0,
+                minutes_listened DOUBLE PRECISION NOT NULL DEFAULT 0,
+                unique_tracks INTEGER NOT NULL DEFAULT 0,
+                unique_artists INTEGER NOT NULL DEFAULT 0,
+                unique_albums INTEGER NOT NULL DEFAULT 0,
+                PRIMARY KEY (user_id, day)
+            )
+        """)
+        cur.execute("CREATE INDEX IF NOT EXISTS idx_user_daily_listening_user ON user_daily_listening(user_id, day DESC)")
+
+        cur.execute("""
+            CREATE TABLE IF NOT EXISTS user_track_stats (
+                user_id INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+                window TEXT NOT NULL,
+                entity_key TEXT NOT NULL,
+                track_id INTEGER REFERENCES library_tracks(id) ON DELETE SET NULL,
+                track_path TEXT,
+                title TEXT,
+                artist TEXT,
+                album TEXT,
+                play_count INTEGER NOT NULL DEFAULT 0,
+                complete_play_count INTEGER NOT NULL DEFAULT 0,
+                minutes_listened DOUBLE PRECISION NOT NULL DEFAULT 0,
+                first_played_at TEXT,
+                last_played_at TEXT,
+                PRIMARY KEY (user_id, window, entity_key)
+            )
+        """)
+        cur.execute("CREATE INDEX IF NOT EXISTS idx_user_track_stats_lookup ON user_track_stats(user_id, window, play_count DESC)")
+
+        cur.execute("""
+            CREATE TABLE IF NOT EXISTS user_artist_stats (
+                user_id INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+                window TEXT NOT NULL,
+                artist_name TEXT NOT NULL,
+                play_count INTEGER NOT NULL DEFAULT 0,
+                complete_play_count INTEGER NOT NULL DEFAULT 0,
+                minutes_listened DOUBLE PRECISION NOT NULL DEFAULT 0,
+                first_played_at TEXT,
+                last_played_at TEXT,
+                PRIMARY KEY (user_id, window, artist_name)
+            )
+        """)
+        cur.execute("CREATE INDEX IF NOT EXISTS idx_user_artist_stats_lookup ON user_artist_stats(user_id, window, play_count DESC)")
+
+        cur.execute("""
+            CREATE TABLE IF NOT EXISTS user_album_stats (
+                user_id INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+                window TEXT NOT NULL,
+                entity_key TEXT NOT NULL,
+                artist TEXT,
+                album TEXT,
+                play_count INTEGER NOT NULL DEFAULT 0,
+                complete_play_count INTEGER NOT NULL DEFAULT 0,
+                minutes_listened DOUBLE PRECISION NOT NULL DEFAULT 0,
+                first_played_at TEXT,
+                last_played_at TEXT,
+                PRIMARY KEY (user_id, window, entity_key)
+            )
+        """)
+        cur.execute("CREATE INDEX IF NOT EXISTS idx_user_album_stats_lookup ON user_album_stats(user_id, window, play_count DESC)")
+
+        cur.execute("""
+            CREATE TABLE IF NOT EXISTS user_genre_stats (
+                user_id INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+                window TEXT NOT NULL,
+                genre_name TEXT NOT NULL,
+                play_count INTEGER NOT NULL DEFAULT 0,
+                complete_play_count INTEGER NOT NULL DEFAULT 0,
+                minutes_listened DOUBLE PRECISION NOT NULL DEFAULT 0,
+                first_played_at TEXT,
+                last_played_at TEXT,
+                PRIMARY KEY (user_id, window, genre_name)
+            )
+        """)
+        cur.execute("CREATE INDEX IF NOT EXISTS idx_user_genre_stats_lookup ON user_genre_stats(user_id, window, play_count DESC)")
+
         # Migration: add user_id to favorites table if missing
         cur.execute("""
             DO $$ BEGIN

--- a/app/crate/db/shows.py
+++ b/app/crate/db/shows.py
@@ -1,36 +1,115 @@
 """Shows — persistent storage for upcoming concerts/events."""
 
 from datetime import datetime, timezone
+
 from crate.db.core import get_db_ctx
 
 
 def upsert_show(external_id: str, artist_name: str, date: str, **kwargs) -> int | None:
     """Insert or update a show. Deduplicates by (artist, date, venue)."""
     now = datetime.now(timezone.utc).isoformat()
-    venue = kwargs.get("venue") or ""
+    normalized_external_id = (external_id or "").strip() or None
+    venue = (kwargs.get("venue") or "").strip() or None
     with get_db_ctx() as cur:
-        # Skip if same artist+date+venue already exists (Ticketmaster returns dupes)
+        if normalized_external_id:
+            cur.execute("""
+                INSERT INTO shows (external_id, artist_name, date, local_time, venue, city, region,
+                    country, country_code, latitude, longitude, url, image_url, lineup,
+                    price_range, status, source, created_at, updated_at)
+                VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+                ON CONFLICT (external_id) DO UPDATE SET
+                    artist_name = EXCLUDED.artist_name,
+                    date = EXCLUDED.date,
+                    local_time = EXCLUDED.local_time,
+                    venue = EXCLUDED.venue,
+                    city = EXCLUDED.city,
+                    region = EXCLUDED.region,
+                    country = EXCLUDED.country,
+                    country_code = EXCLUDED.country_code,
+                    latitude = EXCLUDED.latitude,
+                    longitude = EXCLUDED.longitude,
+                    url = EXCLUDED.url,
+                    image_url = EXCLUDED.image_url,
+                    lineup = EXCLUDED.lineup,
+                    price_range = EXCLUDED.price_range,
+                    status = EXCLUDED.status,
+                    source = EXCLUDED.source,
+                    updated_at = EXCLUDED.updated_at
+                RETURNING id
+            """, (
+                normalized_external_id, artist_name, date,
+                kwargs.get("local_time"), venue, kwargs.get("city"),
+                kwargs.get("region"), kwargs.get("country"), kwargs.get("country_code"),
+                kwargs.get("latitude"), kwargs.get("longitude"),
+                kwargs.get("url"), kwargs.get("image_url"),
+                kwargs.get("lineup"), kwargs.get("price_range"),
+                kwargs.get("status", "onsale"), kwargs.get("source", "ticketmaster"),
+                now, now,
+            ))
+            return cur.fetchone()["id"]
+
         cur.execute(
-            "SELECT id FROM shows WHERE artist_name = %s AND date = %s AND venue = %s LIMIT 1",
+            """
+            SELECT id
+            FROM shows
+            WHERE external_id IS NULL
+              AND artist_name = %s
+              AND date = %s
+              AND COALESCE(venue, '') = COALESCE(%s, '')
+            LIMIT 1
+            """,
             (artist_name, date, venue),
         )
         existing = cur.fetchone()
         if existing:
+            cur.execute(
+                """
+                UPDATE shows
+                SET local_time = %s,
+                    city = %s,
+                    region = %s,
+                    country = %s,
+                    country_code = %s,
+                    latitude = %s,
+                    longitude = %s,
+                    url = %s,
+                    image_url = %s,
+                    lineup = %s,
+                    price_range = %s,
+                    status = %s,
+                    source = %s,
+                    updated_at = %s
+                WHERE id = %s
+                """,
+                (
+                    kwargs.get("local_time"),
+                    kwargs.get("city"),
+                    kwargs.get("region"),
+                    kwargs.get("country"),
+                    kwargs.get("country_code"),
+                    kwargs.get("latitude"),
+                    kwargs.get("longitude"),
+                    kwargs.get("url"),
+                    kwargs.get("image_url"),
+                    kwargs.get("lineup"),
+                    kwargs.get("price_range"),
+                    kwargs.get("status", "onsale"),
+                    kwargs.get("source", "ticketmaster"),
+                    now,
+                    existing["id"],
+                ),
+            )
             return existing["id"]
+
         cur.execute("""
             INSERT INTO shows (external_id, artist_name, date, local_time, venue, city, region,
                 country, country_code, latitude, longitude, url, image_url, lineup,
                 price_range, status, source, created_at, updated_at)
             VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
-            ON CONFLICT (external_id) DO UPDATE SET
-                date = EXCLUDED.date, local_time = EXCLUDED.local_time,
-                venue = EXCLUDED.venue, city = EXCLUDED.city,
-                status = EXCLUDED.status, price_range = EXCLUDED.price_range,
-                updated_at = EXCLUDED.updated_at
             RETURNING id
         """, (
-            external_id, artist_name, date,
-            kwargs.get("local_time"), kwargs.get("venue"), kwargs.get("city"),
+            None, artist_name, date,
+            kwargs.get("local_time"), venue, kwargs.get("city"),
             kwargs.get("region"), kwargs.get("country"), kwargs.get("country_code"),
             kwargs.get("latitude"), kwargs.get("longitude"),
             kwargs.get("url"), kwargs.get("image_url"),
@@ -175,6 +254,6 @@ def create_show_reminder(user_id: int, show_id: int, reminder_type: str) -> bool
             VALUES (%s, %s, %s, %s, %s)
             ON CONFLICT (user_id, show_id, reminder_type) DO NOTHING
             """,
-            (user_id, show_id, reminder_type, now, now),
+            (user_id, show_id, reminder_type, now, None),
         )
         return cur.rowcount > 0

--- a/app/crate/db/shows.py
+++ b/app/crate/db/shows.py
@@ -140,3 +140,41 @@ def get_attending_show_ids(user_id: int, show_ids: list[int]) -> set[int]:
             [user_id, *show_ids],
         )
         return {row["show_id"] for row in cur.fetchall()}
+
+
+def get_show_reminders(user_id: int, show_ids: list[int] | None = None) -> list[dict]:
+    with get_db_ctx() as cur:
+        if show_ids:
+            placeholders = ",".join(["%s"] * len(show_ids))
+            cur.execute(
+                f"""
+                SELECT id, user_id, show_id, reminder_type, created_at, triggered_at
+                FROM user_show_reminders
+                WHERE user_id = %s AND show_id IN ({placeholders})
+                """,
+                [user_id, *show_ids],
+            )
+        else:
+            cur.execute(
+                """
+                SELECT id, user_id, show_id, reminder_type, created_at, triggered_at
+                FROM user_show_reminders
+                WHERE user_id = %s
+                """,
+                (user_id,),
+            )
+        return [dict(row) for row in cur.fetchall()]
+
+
+def create_show_reminder(user_id: int, show_id: int, reminder_type: str) -> bool:
+    now = datetime.now(timezone.utc).isoformat()
+    with get_db_ctx() as cur:
+        cur.execute(
+            """
+            INSERT INTO user_show_reminders (user_id, show_id, reminder_type, created_at, triggered_at)
+            VALUES (%s, %s, %s, %s, %s)
+            ON CONFLICT (user_id, show_id, reminder_type) DO NOTHING
+            """,
+            (user_id, show_id, reminder_type, now, now),
+        )
+        return cur.rowcount > 0

--- a/app/crate/db/user_library.py
+++ b/app/crate/db/user_library.py
@@ -780,6 +780,51 @@ def get_top_genres(user_id: int, window: str = "30d", limit: int = 20) -> list[d
         return [dict(row) for row in cur.fetchall()]
 
 
+def get_replay_mix(user_id: int, window: str = "30d", limit: int = 30) -> dict:
+    normalized = _normalize_stats_window(window)
+    candidate_limit = max(limit * 4, 60)
+    candidates = get_top_tracks(user_id, window=normalized, limit=candidate_limit)
+
+    items: list[dict] = []
+    artist_counts: dict[str, int] = {}
+    for row in candidates:
+        artist_name = row.get("artist") or ""
+        if artist_name and artist_counts.get(artist_name, 0) >= 4:
+            continue
+        items.append(row)
+        if artist_name:
+            artist_counts[artist_name] = artist_counts.get(artist_name, 0) + 1
+        if len(items) >= limit:
+            break
+
+    if normalized == "7d":
+        title = "Your last 7 days"
+        subtitle = "A quick replay of the week so far."
+    elif normalized == "30d":
+        title = "Replay this month"
+        subtitle = "The tracks that defined your last 30 days."
+    elif normalized == "90d":
+        title = "Replay this season"
+        subtitle = "The songs you've kept coming back to lately."
+    elif normalized == "365d":
+        title = "Replay this year"
+        subtitle = "A long-view mix from your past year."
+    else:
+        title = "All-time replay"
+        subtitle = "Your enduring favorites across the whole library."
+
+    total_minutes = round(sum(float(item.get("minutes_listened") or 0) for item in items), 1)
+
+    return {
+        "window": normalized,
+        "title": title,
+        "subtitle": subtitle,
+        "track_count": len(items),
+        "minutes_listened": total_minutes,
+        "items": items,
+    }
+
+
 # ── User Library Summary ─────────────────────────────────────
 
 def get_user_library_counts(user_id: int) -> dict:

--- a/app/crate/db/user_library.py
+++ b/app/crate/db/user_library.py
@@ -1,8 +1,11 @@
+import logging
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
 from crate.config import load_config
 from crate.db.core import get_db_ctx
+
+log = logging.getLogger(__name__)
 
 _STATS_WINDOWS: dict[str, int | None] = {
     "7d": 7,
@@ -56,8 +59,6 @@ def _resolve_track_id(cur, track_id: int | None = None, track_path: str | None =
     library_root = str(_library_root()).rstrip("/")
     absolute_candidate = f"{library_root}/{relative_path}" if library_root and relative_path else track_path
     music_candidate = f"/music/{relative_path}" if relative_path else track_path
-    suffix_candidate = f"%/{relative_path}" if relative_path else ""
-
     cur.execute(
         """
         SELECT id
@@ -66,7 +67,6 @@ def _resolve_track_id(cur, track_id: int | None = None, track_path: str | None =
            OR path = %s
            OR path = %s
            OR navidrome_id = %s
-           OR (%s != '' AND path LIKE %s)
         ORDER BY CASE
             WHEN path = %s THEN 0
             WHEN path = %s THEN 1
@@ -80,8 +80,6 @@ def _resolve_track_id(cur, track_id: int | None = None, track_path: str | None =
             absolute_candidate,
             music_candidate,
             track_path,
-            suffix_candidate,
-            suffix_candidate,
             track_path,
             absolute_candidate,
             music_candidate,
@@ -329,7 +327,6 @@ def record_play_event(
             ),
         )
         event_id = cur.fetchone()["id"]
-        _recompute_user_listening_aggregates(cur, user_id)
         return event_id
 
 
@@ -348,6 +345,8 @@ def _window_day_cutoff(window: str) -> str | None:
 
 
 def _recompute_user_listening_aggregates(cur, user_id: int):
+    # Full-window recompute is intentionally centralized here so the worker can own the
+    # expensive path. The API request only writes the raw play event and enqueues this work.
     _recompute_user_daily_listening(cur, user_id)
     for window, days in _STATS_WINDOWS.items():
         cutoff = _window_cutoff(days)
@@ -355,6 +354,11 @@ def _recompute_user_listening_aggregates(cur, user_id: int):
         _recompute_user_artist_stats(cur, user_id, window, cutoff)
         _recompute_user_album_stats(cur, user_id, window, cutoff)
         _recompute_user_genre_stats(cur, user_id, window, cutoff)
+
+
+def recompute_user_listening_aggregates(user_id: int) -> None:
+    with get_db_ctx() as cur:
+        _recompute_user_listening_aggregates(cur, user_id)
 
 
 def _recompute_user_daily_listening(cur, user_id: int):
@@ -534,7 +538,9 @@ def _recompute_user_genre_stats(cur, user_id: int, window: str, cutoff: str | No
             MIN(upe.started_at) AS first_played_at,
             MAX(upe.ended_at) AS last_played_at
         FROM user_play_events upe
-        JOIN library_tracks lt ON lt.id = upe.track_id
+        LEFT JOIN library_tracks lt
+          ON lt.id = upe.track_id
+          OR (upe.track_id IS NULL AND COALESCE(upe.track_path, '') != '' AND lt.path = upe.track_path)
         WHERE {where_sql}
           AND COALESCE(lt.genre, '') != ''
         GROUP BY lt.genre
@@ -588,6 +594,7 @@ def get_play_stats(user_id: int) -> dict:
         top_artists = [dict(r) for r in cur.fetchall()]
 
         if not total and not top_artists:
+            log.info("Falling back to legacy play_history for user %s stats", user_id)
             cur.execute("SELECT COUNT(*) AS total_plays FROM play_history WHERE user_id = %s", (user_id,))
             total = cur.fetchone()["total_plays"]
             cur.execute("""
@@ -693,19 +700,21 @@ def get_top_tracks(user_id: int, window: str = "30d", limit: int = 20) -> list[d
         cur.execute(
             """
             SELECT
-                track_id,
-                track_path,
-                title,
-                artist,
-                album,
-                play_count,
-                complete_play_count,
-                minutes_listened,
-                first_played_at,
-                last_played_at
-            FROM user_track_stats
-            WHERE user_id = %s AND window = %s
-            ORDER BY play_count DESC, minutes_listened DESC, last_played_at DESC
+                uts.track_id,
+                COALESCE(lt.path, uts.track_path) AS track_path,
+                COALESCE(lt.title, uts.title) AS title,
+                COALESCE(lt.artist, uts.artist) AS artist,
+                COALESCE(lt.album, uts.album) AS album,
+                lt.navidrome_id,
+                uts.play_count,
+                uts.complete_play_count,
+                uts.minutes_listened,
+                uts.first_played_at,
+                uts.last_played_at
+            FROM user_track_stats uts
+            LEFT JOIN library_tracks lt ON lt.id = uts.track_id
+            WHERE uts.user_id = %s AND uts.window = %s
+            ORDER BY uts.play_count DESC, uts.minutes_listened DESC, uts.last_played_at DESC
             LIMIT %s
             """,
             (user_id, normalized, limit),

--- a/app/crate/db/user_library.py
+++ b/app/crate/db/user_library.py
@@ -1,8 +1,16 @@
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
 from crate.config import load_config
 from crate.db.core import get_db_ctx
+
+_STATS_WINDOWS: dict[str, int | None] = {
+    "7d": 7,
+    "30d": 30,
+    "90d": 90,
+    "365d": 365,
+    "all_time": None,
+}
 
 
 def _library_root() -> Path:
@@ -313,7 +321,211 @@ def record_play_event(
                 created_at,
             ),
         )
-        return cur.fetchone()["id"]
+        event_id = cur.fetchone()["id"]
+        _recompute_user_listening_aggregates(cur, user_id)
+        return event_id
+
+
+def _window_cutoff(days: int | None) -> str | None:
+    if days is None:
+        return None
+    return (datetime.now(timezone.utc) - timedelta(days=days)).isoformat()
+
+
+def _recompute_user_listening_aggregates(cur, user_id: int):
+    _recompute_user_daily_listening(cur, user_id)
+    for window, days in _STATS_WINDOWS.items():
+        cutoff = _window_cutoff(days)
+        _recompute_user_track_stats(cur, user_id, window, cutoff)
+        _recompute_user_artist_stats(cur, user_id, window, cutoff)
+        _recompute_user_album_stats(cur, user_id, window, cutoff)
+        _recompute_user_genre_stats(cur, user_id, window, cutoff)
+
+
+def _recompute_user_daily_listening(cur, user_id: int):
+    cur.execute("DELETE FROM user_daily_listening WHERE user_id = %s", (user_id,))
+    cur.execute(
+        """
+        INSERT INTO user_daily_listening (
+            user_id,
+            day,
+            play_count,
+            complete_play_count,
+            skip_count,
+            minutes_listened,
+            unique_tracks,
+            unique_artists,
+            unique_albums
+        )
+        SELECT
+            user_id,
+            substring(ended_at, 1, 10) AS day,
+            COUNT(*)::INTEGER AS play_count,
+            SUM(CASE WHEN was_completed THEN 1 ELSE 0 END)::INTEGER AS complete_play_count,
+            SUM(CASE WHEN was_skipped THEN 1 ELSE 0 END)::INTEGER AS skip_count,
+            COALESCE(SUM(played_seconds), 0) / 60.0 AS minutes_listened,
+            COUNT(DISTINCT COALESCE(track_id::text, NULLIF(track_path, ''), 'unknown-track'))::INTEGER AS unique_tracks,
+            COUNT(DISTINCT NULLIF(artist, ''))::INTEGER AS unique_artists,
+            COUNT(DISTINCT NULLIF(CONCAT(COALESCE(artist, ''), '||', COALESCE(album, '')), '||'))::INTEGER AS unique_albums
+        FROM user_play_events
+        WHERE user_id = %s
+        GROUP BY user_id, substring(ended_at, 1, 10)
+        """,
+        (user_id,),
+    )
+
+
+def _window_filter_sql(cutoff: str | None) -> tuple[str, tuple]:
+    if cutoff is None:
+        return "upe.user_id = %s", ()
+    return "upe.user_id = %s AND upe.ended_at >= %s", (cutoff,)
+
+
+def _recompute_user_track_stats(cur, user_id: int, window: str, cutoff: str | None):
+    cur.execute("DELETE FROM user_track_stats WHERE user_id = %s AND window = %s", (user_id, window))
+    where_sql, extra_params = _window_filter_sql(cutoff)
+    cur.execute(
+        f"""
+        INSERT INTO user_track_stats (
+            user_id,
+            window,
+            entity_key,
+            track_id,
+            track_path,
+            title,
+            artist,
+            album,
+            play_count,
+            complete_play_count,
+            minutes_listened,
+            first_played_at,
+            last_played_at
+        )
+        SELECT
+            %s,
+            %s,
+            COALESCE(upe.track_id::text, NULLIF(upe.track_path, ''), 'unknown-track') AS entity_key,
+            MAX(upe.track_id) AS track_id,
+            MAX(upe.track_path) AS track_path,
+            MAX(upe.title) AS title,
+            MAX(upe.artist) AS artist,
+            MAX(upe.album) AS album,
+            COUNT(*)::INTEGER AS play_count,
+            SUM(CASE WHEN upe.was_completed THEN 1 ELSE 0 END)::INTEGER AS complete_play_count,
+            COALESCE(SUM(upe.played_seconds), 0) / 60.0 AS minutes_listened,
+            MIN(upe.started_at) AS first_played_at,
+            MAX(upe.ended_at) AS last_played_at
+        FROM user_play_events upe
+        WHERE {where_sql}
+          AND (upe.track_id IS NOT NULL OR COALESCE(upe.track_path, '') != '')
+        GROUP BY COALESCE(upe.track_id::text, NULLIF(upe.track_path, ''), 'unknown-track')
+        """,
+        (user_id, window, user_id, *extra_params),
+    )
+
+
+def _recompute_user_artist_stats(cur, user_id: int, window: str, cutoff: str | None):
+    cur.execute("DELETE FROM user_artist_stats WHERE user_id = %s AND window = %s", (user_id, window))
+    where_sql, extra_params = _window_filter_sql(cutoff)
+    cur.execute(
+        f"""
+        INSERT INTO user_artist_stats (
+            user_id,
+            window,
+            artist_name,
+            play_count,
+            complete_play_count,
+            minutes_listened,
+            first_played_at,
+            last_played_at
+        )
+        SELECT
+            %s,
+            %s,
+            upe.artist AS artist_name,
+            COUNT(*)::INTEGER AS play_count,
+            SUM(CASE WHEN upe.was_completed THEN 1 ELSE 0 END)::INTEGER AS complete_play_count,
+            COALESCE(SUM(upe.played_seconds), 0) / 60.0 AS minutes_listened,
+            MIN(upe.started_at) AS first_played_at,
+            MAX(upe.ended_at) AS last_played_at
+        FROM user_play_events upe
+        WHERE {where_sql}
+          AND COALESCE(upe.artist, '') != ''
+        GROUP BY upe.artist
+        """,
+        (user_id, window, user_id, *extra_params),
+    )
+
+
+def _recompute_user_album_stats(cur, user_id: int, window: str, cutoff: str | None):
+    cur.execute("DELETE FROM user_album_stats WHERE user_id = %s AND window = %s", (user_id, window))
+    where_sql, extra_params = _window_filter_sql(cutoff)
+    cur.execute(
+        f"""
+        INSERT INTO user_album_stats (
+            user_id,
+            window,
+            entity_key,
+            artist,
+            album,
+            play_count,
+            complete_play_count,
+            minutes_listened,
+            first_played_at,
+            last_played_at
+        )
+        SELECT
+            %s,
+            %s,
+            CONCAT(COALESCE(upe.artist, ''), '||', COALESCE(upe.album, '')) AS entity_key,
+            MAX(upe.artist) AS artist,
+            MAX(upe.album) AS album,
+            COUNT(*)::INTEGER AS play_count,
+            SUM(CASE WHEN upe.was_completed THEN 1 ELSE 0 END)::INTEGER AS complete_play_count,
+            COALESCE(SUM(upe.played_seconds), 0) / 60.0 AS minutes_listened,
+            MIN(upe.started_at) AS first_played_at,
+            MAX(upe.ended_at) AS last_played_at
+        FROM user_play_events upe
+        WHERE {where_sql}
+          AND COALESCE(upe.album, '') != ''
+        GROUP BY CONCAT(COALESCE(upe.artist, ''), '||', COALESCE(upe.album, ''))
+        """,
+        (user_id, window, user_id, *extra_params),
+    )
+
+
+def _recompute_user_genre_stats(cur, user_id: int, window: str, cutoff: str | None):
+    cur.execute("DELETE FROM user_genre_stats WHERE user_id = %s AND window = %s", (user_id, window))
+    where_sql, extra_params = _window_filter_sql(cutoff)
+    cur.execute(
+        f"""
+        INSERT INTO user_genre_stats (
+            user_id,
+            window,
+            genre_name,
+            play_count,
+            complete_play_count,
+            minutes_listened,
+            first_played_at,
+            last_played_at
+        )
+        SELECT
+            %s,
+            %s,
+            lt.genre AS genre_name,
+            COUNT(*)::INTEGER AS play_count,
+            SUM(CASE WHEN upe.was_completed THEN 1 ELSE 0 END)::INTEGER AS complete_play_count,
+            COALESCE(SUM(upe.played_seconds), 0) / 60.0 AS minutes_listened,
+            MIN(upe.started_at) AS first_played_at,
+            MAX(upe.ended_at) AS last_played_at
+        FROM user_play_events upe
+        JOIN library_tracks lt ON lt.id = upe.track_id
+        WHERE {where_sql}
+          AND COALESCE(lt.genre, '') != ''
+        GROUP BY lt.genre
+        """,
+        (user_id, window, user_id, *extra_params),
+    )
 
 
 def get_play_history(user_id: int, limit: int = 50) -> list[dict]:
@@ -343,13 +555,32 @@ def get_play_history(user_id: int, limit: int = 50) -> list[dict]:
 def get_play_stats(user_id: int) -> dict:
     """Get listening stats for a user."""
     with get_db_ctx() as cur:
-        cur.execute("SELECT COUNT(*) AS total_plays FROM play_history WHERE user_id = %s", (user_id,))
+        cur.execute(
+            "SELECT COALESCE(SUM(play_count), 0) AS total_plays FROM user_daily_listening WHERE user_id = %s",
+            (user_id,),
+        )
         total = cur.fetchone()["total_plays"]
-        cur.execute("""
-            SELECT artist, COUNT(*) AS plays FROM play_history
-            WHERE user_id = %s GROUP BY artist ORDER BY plays DESC LIMIT 10
-        """, (user_id,))
+        cur.execute(
+            """
+            SELECT artist_name AS artist, play_count AS plays
+            FROM user_artist_stats
+            WHERE user_id = %s AND window = 'all_time'
+            ORDER BY play_count DESC, minutes_listened DESC, artist_name ASC
+            LIMIT 10
+            """,
+            (user_id,),
+        )
         top_artists = [dict(r) for r in cur.fetchall()]
+
+        if not total and not top_artists:
+            cur.execute("SELECT COUNT(*) AS total_plays FROM play_history WHERE user_id = %s", (user_id,))
+            total = cur.fetchone()["total_plays"]
+            cur.execute("""
+                SELECT artist, COUNT(*) AS plays FROM play_history
+                WHERE user_id = %s GROUP BY artist ORDER BY plays DESC LIMIT 10
+            """, (user_id,))
+            top_artists = [dict(r) for r in cur.fetchall()]
+
     return {"total_plays": total, "top_artists": top_artists}
 
 

--- a/app/crate/db/user_library.py
+++ b/app/crate/db/user_library.py
@@ -13,6 +13,13 @@ _STATS_WINDOWS: dict[str, int | None] = {
 }
 
 
+def _normalize_stats_window(window: str) -> str:
+    candidate = (window or "30d").strip().lower()
+    if candidate not in _STATS_WINDOWS:
+        raise ValueError(f"Unsupported stats window: {window}")
+    return candidate
+
+
 def _library_root() -> Path:
     try:
         return Path(load_config()["library_path"])
@@ -332,6 +339,14 @@ def _window_cutoff(days: int | None) -> str | None:
     return (datetime.now(timezone.utc) - timedelta(days=days)).isoformat()
 
 
+def _window_day_cutoff(window: str) -> str | None:
+    normalized = _normalize_stats_window(window)
+    days = _STATS_WINDOWS[normalized]
+    if days is None:
+        return None
+    return (datetime.now(timezone.utc) - timedelta(days=days)).strftime("%Y-%m-%d")
+
+
 def _recompute_user_listening_aggregates(cur, user_id: int):
     _recompute_user_daily_listening(cur, user_id)
     for window, days in _STATS_WINDOWS.items():
@@ -582,6 +597,187 @@ def get_play_stats(user_id: int) -> dict:
             top_artists = [dict(r) for r in cur.fetchall()]
 
     return {"total_plays": total, "top_artists": top_artists}
+
+
+def get_stats_overview(user_id: int, window: str = "30d") -> dict:
+    normalized = _normalize_stats_window(window)
+    day_cutoff = _window_day_cutoff(normalized)
+    with get_db_ctx() as cur:
+        if day_cutoff is None:
+            cur.execute(
+                """
+                SELECT
+                    COALESCE(SUM(play_count), 0) AS play_count,
+                    COALESCE(SUM(complete_play_count), 0) AS complete_play_count,
+                    COALESCE(SUM(skip_count), 0) AS skip_count,
+                    COALESCE(SUM(minutes_listened), 0) AS minutes_listened,
+                    COUNT(*)::INTEGER AS active_days
+                FROM user_daily_listening
+                WHERE user_id = %s
+                """,
+                (user_id,),
+            )
+        else:
+            cur.execute(
+                """
+                SELECT
+                    COALESCE(SUM(play_count), 0) AS play_count,
+                    COALESCE(SUM(complete_play_count), 0) AS complete_play_count,
+                    COALESCE(SUM(skip_count), 0) AS skip_count,
+                    COALESCE(SUM(minutes_listened), 0) AS minutes_listened,
+                    COUNT(*)::INTEGER AS active_days
+                FROM user_daily_listening
+                WHERE user_id = %s AND day >= %s
+                """,
+                (user_id, day_cutoff),
+            )
+        overview = dict(cur.fetchone() or {})
+
+        cur.execute(
+            """
+            SELECT artist_name, play_count, minutes_listened
+            FROM user_artist_stats
+            WHERE user_id = %s AND window = %s
+            ORDER BY play_count DESC, minutes_listened DESC, artist_name ASC
+            LIMIT 1
+            """,
+            (user_id, normalized),
+        )
+        top_artist = cur.fetchone()
+
+    play_count = overview.get("play_count", 0) or 0
+    skip_count = overview.get("skip_count", 0) or 0
+    return {
+        "window": normalized,
+        "play_count": play_count,
+        "complete_play_count": overview.get("complete_play_count", 0) or 0,
+        "skip_count": skip_count,
+        "minutes_listened": overview.get("minutes_listened", 0) or 0,
+        "active_days": overview.get("active_days", 0) or 0,
+        "skip_rate": (skip_count / play_count) if play_count else 0,
+        "top_artist": dict(top_artist) if top_artist else None,
+    }
+
+
+def get_stats_trends(user_id: int, window: str = "30d") -> dict:
+    normalized = _normalize_stats_window(window)
+    day_cutoff = _window_day_cutoff(normalized)
+    with get_db_ctx() as cur:
+        if day_cutoff is None:
+            cur.execute(
+                """
+                SELECT day, play_count, complete_play_count, skip_count, minutes_listened
+                FROM user_daily_listening
+                WHERE user_id = %s
+                ORDER BY day ASC
+                """,
+                (user_id,),
+            )
+        else:
+            cur.execute(
+                """
+                SELECT day, play_count, complete_play_count, skip_count, minutes_listened
+                FROM user_daily_listening
+                WHERE user_id = %s AND day >= %s
+                ORDER BY day ASC
+                """,
+                (user_id, day_cutoff),
+            )
+        rows = [dict(row) for row in cur.fetchall()]
+    return {"window": normalized, "points": rows}
+
+
+def get_top_tracks(user_id: int, window: str = "30d", limit: int = 20) -> list[dict]:
+    normalized = _normalize_stats_window(window)
+    with get_db_ctx() as cur:
+        cur.execute(
+            """
+            SELECT
+                track_id,
+                track_path,
+                title,
+                artist,
+                album,
+                play_count,
+                complete_play_count,
+                minutes_listened,
+                first_played_at,
+                last_played_at
+            FROM user_track_stats
+            WHERE user_id = %s AND window = %s
+            ORDER BY play_count DESC, minutes_listened DESC, last_played_at DESC
+            LIMIT %s
+            """,
+            (user_id, normalized, limit),
+        )
+        return [dict(row) for row in cur.fetchall()]
+
+
+def get_top_artists(user_id: int, window: str = "30d", limit: int = 20) -> list[dict]:
+    normalized = _normalize_stats_window(window)
+    with get_db_ctx() as cur:
+        cur.execute(
+            """
+            SELECT
+                artist_name,
+                play_count,
+                complete_play_count,
+                minutes_listened,
+                first_played_at,
+                last_played_at
+            FROM user_artist_stats
+            WHERE user_id = %s AND window = %s
+            ORDER BY play_count DESC, minutes_listened DESC, last_played_at DESC
+            LIMIT %s
+            """,
+            (user_id, normalized, limit),
+        )
+        return [dict(row) for row in cur.fetchall()]
+
+
+def get_top_albums(user_id: int, window: str = "30d", limit: int = 20) -> list[dict]:
+    normalized = _normalize_stats_window(window)
+    with get_db_ctx() as cur:
+        cur.execute(
+            """
+            SELECT
+                artist,
+                album,
+                play_count,
+                complete_play_count,
+                minutes_listened,
+                first_played_at,
+                last_played_at
+            FROM user_album_stats
+            WHERE user_id = %s AND window = %s
+            ORDER BY play_count DESC, minutes_listened DESC, last_played_at DESC
+            LIMIT %s
+            """,
+            (user_id, normalized, limit),
+        )
+        return [dict(row) for row in cur.fetchall()]
+
+
+def get_top_genres(user_id: int, window: str = "30d", limit: int = 20) -> list[dict]:
+    normalized = _normalize_stats_window(window)
+    with get_db_ctx() as cur:
+        cur.execute(
+            """
+            SELECT
+                genre_name,
+                play_count,
+                complete_play_count,
+                minutes_listened,
+                first_played_at,
+                last_played_at
+            FROM user_genre_stats
+            WHERE user_id = %s AND window = %s
+            ORDER BY play_count DESC, minutes_listened DESC, last_played_at DESC
+            LIMIT %s
+            """,
+            (user_id, normalized, limit),
+        )
+        return [dict(row) for row in cur.fetchall()]
 
 
 # ── User Library Summary ─────────────────────────────────────

--- a/app/crate/db/user_library.py
+++ b/app/crate/db/user_library.py
@@ -230,6 +230,92 @@ def record_play(
         )
 
 
+def record_play_event(
+    user_id: int,
+    *,
+    track_id: int | None = None,
+    track_path: str | None = None,
+    title: str = "",
+    artist: str = "",
+    album: str = "",
+    started_at: str,
+    ended_at: str,
+    played_seconds: float,
+    track_duration_seconds: float | None = None,
+    completion_ratio: float | None = None,
+    was_skipped: bool = False,
+    was_completed: bool = False,
+    play_source_type: str | None = None,
+    play_source_id: str | None = None,
+    play_source_name: str | None = None,
+    context_artist: str | None = None,
+    context_album: str | None = None,
+    context_playlist_id: int | None = None,
+    device_type: str | None = None,
+    app_platform: str | None = None,
+) -> int:
+    created_at = datetime.now(timezone.utc).isoformat()
+    with get_db_ctx() as cur:
+        resolved_track_id = _resolve_track_id(cur, track_id=track_id, track_path=track_path)
+        cur.execute(
+            """
+            INSERT INTO user_play_events (
+                user_id,
+                track_id,
+                track_path,
+                title,
+                artist,
+                album,
+                started_at,
+                ended_at,
+                played_seconds,
+                track_duration_seconds,
+                completion_ratio,
+                was_skipped,
+                was_completed,
+                play_source_type,
+                play_source_id,
+                play_source_name,
+                context_artist,
+                context_album,
+                context_playlist_id,
+                device_type,
+                app_platform,
+                created_at
+            )
+            VALUES (
+                %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s
+            )
+            RETURNING id
+            """,
+            (
+                user_id,
+                resolved_track_id,
+                track_path,
+                title,
+                artist,
+                album,
+                started_at,
+                ended_at,
+                played_seconds,
+                track_duration_seconds,
+                completion_ratio,
+                was_skipped,
+                was_completed,
+                play_source_type,
+                play_source_id,
+                play_source_name,
+                context_artist,
+                context_album,
+                context_playlist_id,
+                device_type,
+                app_platform,
+                created_at,
+            ),
+        )
+        return cur.fetchone()["id"]
+
+
 def get_play_history(user_id: int, limit: int = 50) -> list[dict]:
     with get_db_ctx() as cur:
         cur.execute("""

--- a/app/crate/worker_handlers/analysis.py
+++ b/app/crate/worker_handlers/analysis.py
@@ -81,6 +81,18 @@ def _handle_compute_analytics(task_id: str, params: dict, config: dict) -> dict:
     return {"artists": artists, "albums": albums, "tracks": tracks}
 
 
+def _handle_refresh_user_listening_stats(task_id: str, params: dict, config: dict) -> dict:
+    from crate.db.user_library import recompute_user_listening_aggregates
+
+    user_id = int(params.get("user_id") or 0)
+    if user_id <= 0:
+        return {"ok": False, "error": "Missing user_id"}
+
+    update_task(task_id, progress=json.dumps({"phase": "stats", "user_id": user_id}))
+    recompute_user_listening_aggregates(user_id)
+    return {"ok": True, "user_id": user_id}
+
+
 def _handle_analyze_album_full(task_id: str, params: dict, config: dict) -> dict:
     """Analyze audio + compute bliss vectors for a single album."""
     from crate.db import get_library_album
@@ -542,6 +554,7 @@ def _handle_requeue_analysis(task_id: str, params: dict, config: dict) -> dict:
 
 ANALYSIS_TASK_HANDLERS: dict[str, TaskHandler] = {
     "compute_analytics": _handle_compute_analytics,
+    "refresh_user_listening_stats": _handle_refresh_user_listening_stats,
     "index_genres": _handle_index_genres,
     "compute_popularity": _handle_compute_popularity,
     # Re-analysis: just resets state, background daemons pick up the work

--- a/app/listen/package-lock.json
+++ b/app/listen/package-lock.json
@@ -8,6 +8,7 @@
       "name": "crate-listen",
       "version": "0.1.0",
       "dependencies": {
+        "@nivo/line": "^0.99.0",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "gl-matrix": "^3.4.4",
@@ -171,6 +172,212 @@
       "peerDependencies": {
         "@emnapi/core": "^1.7.1",
         "@emnapi/runtime": "^1.7.1"
+      }
+    },
+    "node_modules/@nivo/annotations": {
+      "version": "0.99.0",
+      "resolved": "https://registry.npmjs.org/@nivo/annotations/-/annotations-0.99.0.tgz",
+      "integrity": "sha512-jCuuXPbvpaqaz4xF7k5dv0OT2ubn5Nt0gWryuTe/8oVsC/9bzSuK8bM9vBty60m9tfO+X8vUYliuaCDwGksC2g==",
+      "license": "MIT",
+      "dependencies": {
+        "@nivo/colors": "0.99.0",
+        "@nivo/core": "0.99.0",
+        "@nivo/theming": "0.99.0",
+        "@react-spring/web": "9.4.5 || ^9.7.2 || ^10.0",
+        "lodash": "^4.17.21"
+      },
+      "peerDependencies": {
+        "react": "^16.14 || ^17.0 || ^18.0 || ^19.0"
+      }
+    },
+    "node_modules/@nivo/axes": {
+      "version": "0.99.0",
+      "resolved": "https://registry.npmjs.org/@nivo/axes/-/axes-0.99.0.tgz",
+      "integrity": "sha512-3KschnmEL0acRoa7INSSOSEFwJLm54aZwSev7/r8XxXlkgRBriu6ReZy/FG0wfN+ljZ4GMvx+XyIIf6kxzvrZg==",
+      "license": "MIT",
+      "dependencies": {
+        "@nivo/core": "0.99.0",
+        "@nivo/scales": "0.99.0",
+        "@nivo/text": "0.99.0",
+        "@nivo/theming": "0.99.0",
+        "@react-spring/web": "9.4.5 || ^9.7.2 || ^10.0",
+        "@types/d3-format": "^1.4.1",
+        "@types/d3-time-format": "^2.3.1",
+        "d3-format": "^1.4.4",
+        "d3-time-format": "^3.0.0"
+      },
+      "peerDependencies": {
+        "react": "^16.14 || ^17.0 || ^18.0 || ^19.0"
+      }
+    },
+    "node_modules/@nivo/colors": {
+      "version": "0.99.0",
+      "resolved": "https://registry.npmjs.org/@nivo/colors/-/colors-0.99.0.tgz",
+      "integrity": "sha512-hyYt4lEFIfXOUmQ6k3HXm3KwhcgoJpocmoGzLUqzk7DzuhQYJo+4d5jIGGU0N/a70+9XbHIdpKNSblHAIASD3w==",
+      "license": "MIT",
+      "dependencies": {
+        "@nivo/core": "0.99.0",
+        "@nivo/theming": "0.99.0",
+        "@types/d3-color": "^3.0.0",
+        "@types/d3-scale": "^4.0.8",
+        "@types/d3-scale-chromatic": "^3.0.0",
+        "d3-color": "^3.1.0",
+        "d3-scale": "^4.0.2",
+        "d3-scale-chromatic": "^3.0.0",
+        "lodash": "^4.17.21"
+      },
+      "peerDependencies": {
+        "react": "^16.14 || ^17.0 || ^18.0 || ^19.0"
+      }
+    },
+    "node_modules/@nivo/core": {
+      "version": "0.99.0",
+      "resolved": "https://registry.npmjs.org/@nivo/core/-/core-0.99.0.tgz",
+      "integrity": "sha512-olCItqhPG3xHL5ei+vg52aB6o+6S+xR2idpkd9RormTTUniZb8U2rOdcQojOojPY5i9kVeQyLFBpV4YfM7OZ9g==",
+      "license": "MIT",
+      "dependencies": {
+        "@nivo/theming": "0.99.0",
+        "@nivo/tooltip": "0.99.0",
+        "@react-spring/web": "9.4.5 || ^9.7.2 || ^10.0",
+        "@types/d3-shape": "^3.1.6",
+        "d3-color": "^3.1.0",
+        "d3-format": "^1.4.4",
+        "d3-interpolate": "^3.0.1",
+        "d3-scale": "^4.0.2",
+        "d3-scale-chromatic": "^3.0.0",
+        "d3-shape": "^3.2.0",
+        "d3-time-format": "^3.0.0",
+        "lodash": "^4.17.21",
+        "react-virtualized-auto-sizer": "^1.0.26",
+        "use-debounce": "^10.0.4"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/nivo/donate"
+      },
+      "peerDependencies": {
+        "react": "^16.14 || ^17.0 || ^18.0 || ^19.0"
+      }
+    },
+    "node_modules/@nivo/legends": {
+      "version": "0.99.0",
+      "resolved": "https://registry.npmjs.org/@nivo/legends/-/legends-0.99.0.tgz",
+      "integrity": "sha512-P16FjFqNceuTTZphINAh5p0RF0opu3cCKoWppe2aRD9IuVkvRm/wS5K1YwMCxDzKyKh5v0AuTlu9K6o3/hk8hA==",
+      "license": "MIT",
+      "dependencies": {
+        "@nivo/colors": "0.99.0",
+        "@nivo/core": "0.99.0",
+        "@nivo/text": "0.99.0",
+        "@nivo/theming": "0.99.0",
+        "@types/d3-scale": "^4.0.8",
+        "d3-scale": "^4.0.2"
+      },
+      "peerDependencies": {
+        "react": "^16.14 || ^17.0 || ^18.0 || ^19.0"
+      }
+    },
+    "node_modules/@nivo/line": {
+      "version": "0.99.0",
+      "resolved": "https://registry.npmjs.org/@nivo/line/-/line-0.99.0.tgz",
+      "integrity": "sha512-bAqTXSjpnpcGMs341qWFUi7hJTqQiNoSeJHsYPuPS3icuXPcp3WETQH+zRZACeEF79ZigeOWCW+dzODgne1y9w==",
+      "license": "MIT",
+      "dependencies": {
+        "@nivo/annotations": "0.99.0",
+        "@nivo/axes": "0.99.0",
+        "@nivo/colors": "0.99.0",
+        "@nivo/core": "0.99.0",
+        "@nivo/legends": "0.99.0",
+        "@nivo/scales": "0.99.0",
+        "@nivo/theming": "0.99.0",
+        "@nivo/tooltip": "0.99.0",
+        "@nivo/voronoi": "0.99.0",
+        "@react-spring/web": "9.4.5 || ^9.7.2 || ^10.0",
+        "@types/d3-shape": "^3.1.6",
+        "d3-shape": "^3.2.0"
+      },
+      "peerDependencies": {
+        "react": "^16.14 || ^17.0 || ^18.0 || ^19.0"
+      }
+    },
+    "node_modules/@nivo/scales": {
+      "version": "0.99.0",
+      "resolved": "https://registry.npmjs.org/@nivo/scales/-/scales-0.99.0.tgz",
+      "integrity": "sha512-g/2K4L6L8si6E2BWAHtFVGahtDKbUcO6xHJtlIZMwdzaJc7yB16EpWLK8AfI/A42KadLhJSJqBK3mty+c7YZ+w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-interpolate": "^3.0.4",
+        "@types/d3-scale": "^4.0.8",
+        "@types/d3-time": "^1.1.1",
+        "@types/d3-time-format": "^3.0.0",
+        "d3-interpolate": "^3.0.1",
+        "d3-scale": "^4.0.2",
+        "d3-time": "^1.0.11",
+        "d3-time-format": "^3.0.0",
+        "lodash": "^4.17.21"
+      }
+    },
+    "node_modules/@nivo/scales/node_modules/@types/d3-time-format": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-time-format/-/d3-time-format-3.0.4.tgz",
+      "integrity": "sha512-or9DiDnYI1h38J9hxKEsw513+KVuFbEVhl7qdxcaudoiqWWepapUen+2vAriFGexr6W5+P4l9+HJrB39GG+oRg==",
+      "license": "MIT"
+    },
+    "node_modules/@nivo/text": {
+      "version": "0.99.0",
+      "resolved": "https://registry.npmjs.org/@nivo/text/-/text-0.99.0.tgz",
+      "integrity": "sha512-ho3oZpAZApsJNjsIL5WJSAdg/wjzTBcwo1KiHBlRGUmD+yUWO8qp7V+mnYRhJchwygtRVALlPgZ/rlcW2Xr/MQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@nivo/core": "0.99.0",
+        "@nivo/theming": "0.99.0",
+        "@react-spring/web": "9.4.5 || ^9.7.2 || ^10.0"
+      },
+      "peerDependencies": {
+        "react": "^16.14 || ^17.0 || ^18.0 || ^19.0"
+      }
+    },
+    "node_modules/@nivo/theming": {
+      "version": "0.99.0",
+      "resolved": "https://registry.npmjs.org/@nivo/theming/-/theming-0.99.0.tgz",
+      "integrity": "sha512-KvXlf0nqBzh/g2hAIV9bzscYvpq1uuO3TnFN3RDXGI72CrbbZFTGzprPju3sy/myVsauv+Bb+V4f5TZ0jkYKRg==",
+      "license": "MIT",
+      "dependencies": {
+        "lodash": "^4.17.21"
+      },
+      "peerDependencies": {
+        "react": "^16.14 || ^17.0 || ^18.0 || ^19.0"
+      }
+    },
+    "node_modules/@nivo/tooltip": {
+      "version": "0.99.0",
+      "resolved": "https://registry.npmjs.org/@nivo/tooltip/-/tooltip-0.99.0.tgz",
+      "integrity": "sha512-weoEGR3xAetV4k2P6k96cdamGzKQ5F2Pq+uyDaHr1P3HYArM879Pl+x+TkU0aWjP6wgUZPx/GOBiV1Hb1JxIqg==",
+      "license": "MIT",
+      "dependencies": {
+        "@nivo/core": "0.99.0",
+        "@nivo/theming": "0.99.0",
+        "@react-spring/web": "9.4.5 || ^9.7.2 || ^10.0"
+      },
+      "peerDependencies": {
+        "react": "^16.14 || ^17.0 || ^18.0 || ^19.0"
+      }
+    },
+    "node_modules/@nivo/voronoi": {
+      "version": "0.99.0",
+      "resolved": "https://registry.npmjs.org/@nivo/voronoi/-/voronoi-0.99.0.tgz",
+      "integrity": "sha512-KfmMdidbYzhiUCki1FG4X4nHEFT4loK8G5bMBnmCl9U+S78W+gvkfrgD2Aoqp/Q9yKQvr3Y8UcZKSFZnn3HgjQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@nivo/core": "0.99.0",
+        "@nivo/theming": "0.99.0",
+        "@nivo/tooltip": "0.99.0",
+        "@types/d3-delaunay": "^6.0.4",
+        "@types/d3-scale": "^4.0.8",
+        "d3-delaunay": "^6.0.4",
+        "d3-scale": "^4.0.2"
+      },
+      "peerDependencies": {
+        "react": "^16.14 || ^17.0 || ^18.0 || ^19.0"
       }
     },
     "node_modules/@oxc-project/types": {
@@ -1692,6 +1899,78 @@
         "react-dom": "^19.0.0"
       }
     },
+    "node_modules/@react-spring/animated": {
+      "version": "10.0.3",
+      "resolved": "https://registry.npmjs.org/@react-spring/animated/-/animated-10.0.3.tgz",
+      "integrity": "sha512-7MrxADV3vaUADn2V9iYhaIL6iOWRx9nCJjYrsk2AHD2kwPr6fg7Pt0v+deX5RnCDmCKNnD6W5fasiyM8D+wzJQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@react-spring/shared": "~10.0.3",
+        "@react-spring/types": "~10.0.3"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@react-spring/core": {
+      "version": "10.0.3",
+      "resolved": "https://registry.npmjs.org/@react-spring/core/-/core-10.0.3.tgz",
+      "integrity": "sha512-D4DwNO68oohDf/0HG2G0Uragzb9IA1oXblxrd6MZAcBcUQG2EHUWXewjdECMPLNmQvlYVyyBRH6gPxXM5DX7DQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@react-spring/animated": "~10.0.3",
+        "@react-spring/shared": "~10.0.3",
+        "@react-spring/types": "~10.0.3"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/react-spring/donate"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@react-spring/rafz": {
+      "version": "10.0.3",
+      "resolved": "https://registry.npmjs.org/@react-spring/rafz/-/rafz-10.0.3.tgz",
+      "integrity": "sha512-Ri2/xqt8OnQ2iFKkxKMSF4Nqv0LSWnxXT4jXFzBDsHgeeH/cHxTLupAWUwmV9hAGgmEhBmh5aONtj3J6R/18wg==",
+      "license": "MIT"
+    },
+    "node_modules/@react-spring/shared": {
+      "version": "10.0.3",
+      "resolved": "https://registry.npmjs.org/@react-spring/shared/-/shared-10.0.3.tgz",
+      "integrity": "sha512-geCal66nrkaQzUVhPkGomylo+Jpd5VPK8tPMEDevQEfNSWAQP15swHm+MCRG4wVQrQlTi9lOzKzpRoTL3CA84Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@react-spring/rafz": "~10.0.3",
+        "@react-spring/types": "~10.0.3"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@react-spring/types": {
+      "version": "10.0.3",
+      "resolved": "https://registry.npmjs.org/@react-spring/types/-/types-10.0.3.tgz",
+      "integrity": "sha512-H5Ixkd2OuSIgHtxuHLTt7aJYfhMXKXT/rK32HPD/kSrOB6q6ooeiWAXkBy7L8F3ZxdkBb9ini9zP9UwnEFzWgQ==",
+      "license": "MIT"
+    },
+    "node_modules/@react-spring/web": {
+      "version": "10.0.3",
+      "resolved": "https://registry.npmjs.org/@react-spring/web/-/web-10.0.3.tgz",
+      "integrity": "sha512-ndU+kWY81rHsT7gTFtCJ6mrVhaJ6grFmgTnENipzmKqot4HGf5smPNK+cZZJqoGeDsj9ZsiWPW4geT/NyD484A==",
+      "license": "MIT",
+      "dependencies": {
+        "@react-spring/animated": "~10.0.3",
+        "@react-spring/core": "~10.0.3",
+        "@react-spring/shared": "~10.0.3",
+        "@react-spring/types": "~10.0.3"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/@rolldown/binding-android-arm64": {
       "version": "1.0.0-rc.12",
       "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.12.tgz",
@@ -2267,6 +2546,75 @@
         "tslib": "^2.4.0"
       }
     },
+    "node_modules/@types/d3-color": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
+      "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-delaunay": {
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-delaunay/-/d3-delaunay-6.0.4.tgz",
+      "integrity": "sha512-ZMaSKu4THYCU6sV64Lhg6qjf1orxBthaC161plr5KuPHo3CNm8DTHiLw/5Eq2b6TsNP0W0iJrUOFscY6Q450Hw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-format": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/@types/d3-format/-/d3-format-1.4.5.tgz",
+      "integrity": "sha512-mLxrC1MSWupOSncXN/HOlWUAAIffAEBaI4+PKy2uMPsKe4FNZlk7qrbTjmzJXITQQqBHivaks4Td18azgqnotA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-interpolate": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
+      "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-color": "*"
+      }
+    },
+    "node_modules/@types/d3-path": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.1.1.tgz",
+      "integrity": "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-scale": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.9.tgz",
+      "integrity": "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-time": "*"
+      }
+    },
+    "node_modules/@types/d3-scale-chromatic": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale-chromatic/-/d3-scale-chromatic-3.1.0.tgz",
+      "integrity": "sha512-iWMJgwkK7yTRmWqRB5plb1kadXyQ5Sj8V/zYlFGMUBbIPKQScw+Dku9cAAMgJG+z5GYDoMjWGLVOvjghDEFnKQ==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-shape": {
+      "version": "3.1.8",
+      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.8.tgz",
+      "integrity": "sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-path": "*"
+      }
+    },
+    "node_modules/@types/d3-time": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-1.1.4.tgz",
+      "integrity": "sha512-JIvy2HjRInE+TXOmIGN5LCmeO0hkFZx5f9FZ7kiN+D+YTcc8pptsiLiuHsvwxwC7VVKmJ2ExHUgNlAiV7vQM9g==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-time-format": {
+      "version": "2.3.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-time-format/-/d3-time-format-2.3.4.tgz",
+      "integrity": "sha512-xdDXbpVO74EvadI3UDxjxTdR6QIxm1FKzEA/+F8tL4GWWUg/hgvBqf6chql64U5A9ZUGWo7pEu4eNlyLwbKdhg==",
+      "license": "MIT"
+    },
     "node_modules/@types/geojson": {
       "version": "7946.0.16",
       "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.16.tgz",
@@ -2383,6 +2731,143 @@
       "devOptional": true,
       "license": "MIT"
     },
+    "node_modules/d3-array": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+      "license": "ISC",
+      "dependencies": {
+        "internmap": "1 - 2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-delaunay": {
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/d3-delaunay/-/d3-delaunay-6.0.4.tgz",
+      "integrity": "sha512-mdjtIZ1XLAM8bm/hx3WwjfHt6Sggek7qH043O8KEjDXN40xi3vx/6pYSVTwLjEgiXQTbvaouWKynLBiUZ6SK6A==",
+      "license": "ISC",
+      "dependencies": {
+        "delaunator": "5"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-format": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-1.4.5.tgz",
+      "integrity": "sha512-J0piedu6Z8iB6TbIGfZgDzfXxUFN3qQRMofy2oPdXzQibYGqPB/9iMcxr/TGalU+2RsyDO+U4f33id8tbnSRMQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-path": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
+      "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
+      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.10.0 - 3",
+        "d3-format": "1 - 3",
+        "d3-interpolate": "1.2.0 - 3",
+        "d3-time": "2.1.1 - 3",
+        "d3-time-format": "2 - 4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale-chromatic": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-scale-chromatic/-/d3-scale-chromatic-3.1.0.tgz",
+      "integrity": "sha512-A3s5PWiZ9YCXFye1o246KoscMWqf8BsD9eRiJ3He7C9OBaxKhAd5TFCdEx/7VbKtxxTsu//1mMJFrEt572cEyQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3",
+        "d3-interpolate": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale/node_modules/d3-time": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
+      "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-shape": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
+      "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-path": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-1.1.0.tgz",
+      "integrity": "sha512-Xh0isrZ5rPYYdqhAVk8VLnMEidhz5aP7htAADH6MfzgmmicPkTo8LhkLxci61/lCB7n7UmE3bN0leRt+qvkLxA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/d3-time-format": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-3.0.0.tgz",
+      "integrity": "sha512-UXJh6EKsHBTjopVqZBhFysQcoXSv/5yLONZvkQ5Kk3qbwiUYkdX17Xa1PT6U1ZWXGGfB1ey5L8dKMlFq2DO0Ag==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "d3-time": "1 - 2"
+      }
+    },
+    "node_modules/delaunator": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/delaunator/-/delaunator-5.1.0.tgz",
+      "integrity": "sha512-AGrQ4QSgssa1NGmWmLPqN5NY2KajF5MqxetNEO+o0n3ZwZZeTmt7bBnvzHWrmkZFxGgr4HdyFgelzgi06otLuQ==",
+      "license": "ISC",
+      "dependencies": {
+        "robust-predicates": "^3.0.2"
+      }
+    },
     "node_modules/detect-libc": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
@@ -2467,6 +2952,15 @@
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/internmap": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
+      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/jiti": {
       "version": "2.6.1",
@@ -2756,6 +3250,12 @@
         "type": "opencollective",
         "url": "https://opencollective.com/parcel"
       }
+    },
+    "node_modules/lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "license": "MIT"
     },
     "node_modules/lucide-react": {
       "version": "1.7.0",
@@ -3047,6 +3547,22 @@
         }
       }
     },
+    "node_modules/react-virtualized-auto-sizer": {
+      "version": "1.0.26",
+      "resolved": "https://registry.npmjs.org/react-virtualized-auto-sizer/-/react-virtualized-auto-sizer-1.0.26.tgz",
+      "integrity": "sha512-CblNyiNVw2o+hsa5/49NH2ogGxZ+t+3aweRvNSq7TVjDIlwk7ir4lencEg5HxHeSzwNarSkNkiu0qJSOXtxm5A==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^15.3.0 || ^16.0.0-alpha || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^15.3.0 || ^16.0.0-alpha || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/robust-predicates": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/robust-predicates/-/robust-predicates-3.0.3.tgz",
+      "integrity": "sha512-NS3levdsRIUOmiJ8FZWCP7LG3QpJyrs/TE0Zpf1yvZu8cAJJ6QMW92H1c7kWpdIHo8RvmLxN/o2JXTKHp74lUA==",
+      "license": "Unlicense"
+    },
     "node_modules/rolldown": {
       "version": "1.0.0-rc.12",
       "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.12.tgz",
@@ -3207,6 +3723,18 @@
         "@types/react": {
           "optional": true
         }
+      }
+    },
+    "node_modules/use-debounce": {
+      "version": "10.1.1",
+      "resolved": "https://registry.npmjs.org/use-debounce/-/use-debounce-10.1.1.tgz",
+      "integrity": "sha512-kvds8BHR2k28cFsxW8k3nc/tRga2rs1RHYCqmmGqb90MEeE++oALwzh2COiuBLO1/QXiOuShXoSN2ZpWnMmvuQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16.0.0"
+      },
+      "peerDependencies": {
+        "react": "*"
       }
     },
     "node_modules/use-sidecar": {

--- a/app/listen/package.json
+++ b/app/listen/package.json
@@ -9,6 +9,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@nivo/line": "^0.99.0",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "gl-matrix": "^3.4.4",

--- a/app/listen/src/App.tsx
+++ b/app/listen/src/App.tsx
@@ -32,6 +32,9 @@ const Playlist = React.lazy(() =>
 const CuratedPlaylist = React.lazy(() =>
   import("@/pages/CuratedPlaylist").then((m) => ({ default: m.CuratedPlaylist })),
 );
+const Stats = React.lazy(() =>
+  import("@/pages/Stats").then((m) => ({ default: m.Stats })),
+);
 
 function Spinner() {
   return (
@@ -77,6 +80,14 @@ export function App() {
                     <Route index element={<Home />} />
                     <Route path="explore" element={<Explore />} />
                     <Route path="library" element={<Library />} />
+                    <Route
+                      path="stats"
+                      element={
+                        <Suspense fallback={<Spinner />}>
+                          <Stats />
+                        </Suspense>
+                      }
+                    />
                     <Route path="upload" element={<Upload />} />
                     <Route path="settings" element={<Settings />} />
                     <Route path="shows" element={<Navigate to="/upcoming" replace />} />

--- a/app/listen/src/App.tsx
+++ b/app/listen/src/App.tsx
@@ -12,7 +12,6 @@ import { Home } from "@/pages/Home";
 import { Explore } from "@/pages/Explore";
 import { Library } from "@/pages/Library";
 import { Settings } from "@/pages/Settings";
-import { Shows } from "@/pages/Shows";
 import { Upload } from "@/pages/Upload";
 import { Login } from "@/pages/Login";
 import { Register } from "@/pages/Register";
@@ -34,6 +33,9 @@ const CuratedPlaylist = React.lazy(() =>
 );
 const Stats = React.lazy(() =>
   import("@/pages/Stats").then((m) => ({ default: m.Stats })),
+);
+const Shows = React.lazy(() =>
+  import("@/pages/Shows").then((m) => ({ default: m.Shows })),
 );
 
 function Spinner() {
@@ -91,7 +93,14 @@ export function App() {
                     <Route path="upload" element={<Upload />} />
                     <Route path="settings" element={<Settings />} />
                     <Route path="shows" element={<Navigate to="/upcoming" replace />} />
-                    <Route path="upcoming" element={<Shows />} />
+                    <Route
+                      path="upcoming"
+                      element={
+                        <Suspense fallback={<Spinner />}>
+                          <Shows />
+                        </Suspense>
+                      }
+                    />
                     <Route
                       path="artist/:name"
                       element={

--- a/app/listen/src/components/layout/Shell.tsx
+++ b/app/listen/src/components/layout/Shell.tsx
@@ -2,7 +2,7 @@ import { useState, useRef, useEffect } from "react";
 import { Outlet, NavLink, useLocation, useNavigate } from "react-router";
 import {
   Home, Compass, Rss, Library, Music, Disc, Heart, Users,
-  ListMusic, PanelLeftClose, PanelLeftOpen, ChevronRight,
+  ListMusic, PanelLeftClose, PanelLeftOpen, ChevronRight, BarChart3,
 } from "lucide-react";
 import { useIsDesktop } from "@/hooks/use-breakpoint";
 import { usePlayerActions } from "@/contexts/PlayerContext";
@@ -112,6 +112,17 @@ function Sidebar() {
         >
           <Rss size={20} />
           {expanded && <span className="text-[13px] font-medium">Upcoming</span>}
+        </NavLink>
+
+        <NavLink
+          to="/stats"
+          title="Stats"
+          className={({ isActive }) =>
+            `flex items-center gap-3 rounded-lg transition-colors ${expanded ? "px-3 py-2" : "w-10 h-10 justify-center"} ${navClass(isActive)}`
+          }
+        >
+          <BarChart3 size={20} />
+          {expanded && <span className="text-[13px] font-medium">Stats</span>}
         </NavLink>
 
         {/* Collection with popup */}

--- a/app/listen/src/components/layout/Shell.tsx
+++ b/app/listen/src/components/layout/Shell.tsx
@@ -11,6 +11,7 @@ import { MiniPlayer } from "@/components/player/MiniPlayer";
 import { TopBar } from "@/components/layout/TopBar";
 
 const SIDEBAR_KEY = "listen-sidebar-expanded";
+const SIDEBAR_EVENT = "listen-sidebar-changed";
 
 function getStoredExpanded(): boolean {
   try { return localStorage.getItem(SIDEBAR_KEY) !== "false"; } catch { return true; }
@@ -28,6 +29,7 @@ function Sidebar() {
     const next = !expanded;
     setExpanded(next);
     localStorage.setItem(SIDEBAR_KEY, String(next));
+    window.dispatchEvent(new CustomEvent(SIDEBAR_EVENT, { detail: { expanded: next } }));
   }
 
   // Close collection popup on outside click
@@ -180,6 +182,7 @@ function Sidebar() {
 const MOBILE_NAV = [
   { to: "/", icon: Home, label: "Home" },
   { to: "/explore", icon: Compass, label: "Explore" },
+  { to: "/stats", icon: BarChart3, label: "Stats" },
   { to: "/library", icon: Library, label: "Library" },
   { to: "/upcoming", icon: Rss, label: "Upcoming" },
 ] as const;
@@ -199,11 +202,18 @@ export function Shell() {
   const headerOffsetClass = overlayHeader ? "" : "pt-16";
   const headerChromeClass = "bg-transparent border-transparent border-b-0 shadow-none backdrop-blur-0";
 
-  // Sync with sidebar toggle (Sidebar writes to localStorage, we poll)
+  // Sync with sidebar toggle without polling localStorage.
   useEffect(() => {
-    const check = () => setSidebarExpanded(getStoredExpanded());
-    const id = setInterval(check, 300);
-    return () => clearInterval(id);
+    const sync = () => setSidebarExpanded(getStoredExpanded());
+    const onStorage = (event: StorageEvent) => {
+      if (!event.key || event.key === SIDEBAR_KEY) sync();
+    };
+    window.addEventListener("storage", onStorage);
+    window.addEventListener(SIDEBAR_EVENT, sync as EventListener);
+    return () => {
+      window.removeEventListener("storage", onStorage);
+      window.removeEventListener(SIDEBAR_EVENT, sync as EventListener);
+    };
   }, []);
 
   const sidebarW = sidebarExpanded ? "ml-52" : "ml-14";

--- a/app/listen/src/components/layout/TopBar.tsx
+++ b/app/listen/src/components/layout/TopBar.tsx
@@ -1,6 +1,6 @@
 import { useState, useRef, useEffect, useCallback } from "react";
 import { useNavigate } from "react-router";
-import { Search, Loader2, User, LogOut, Settings, X, Disc, Music, ChevronLeft, ChevronRight, Upload } from "lucide-react";
+import { Search, Loader2, User, LogOut, Settings, X, Disc, Music, ChevronLeft, ChevronRight, Upload, BarChart3 } from "lucide-react";
 import { api } from "@/lib/api";
 import { useAuth } from "@/contexts/AuthContext";
 import { useDismissibleLayer } from "@/hooks/use-dismissible-layer";
@@ -302,6 +302,13 @@ export function TopBar() {
             >
               <Upload size={14} />
               Upload music
+            </AppMenuButton>
+            <AppMenuButton
+              onClick={() => { setShowUserMenu(false); navigate("/stats"); }}
+              className="gap-2.5 px-3 py-2 text-[13px] text-white/70 hover:text-white"
+            >
+              <BarChart3 size={14} />
+              Stats
             </AppMenuButton>
             <AppMenuButton
               onClick={() => { setShowUserMenu(false); navigate("/settings"); }}

--- a/app/listen/src/components/upcoming/UpcomingRows.tsx
+++ b/app/listen/src/components/upcoming/UpcomingRows.tsx
@@ -16,8 +16,9 @@ import "leaflet/dist/leaflet.css";
 import { toast } from "sonner";
 
 import { api } from "@/lib/api";
+import { fetchPlayableSetlist } from "@/lib/upcoming";
 import { cn, encPath } from "@/lib/utils";
-import { usePlayerActions, type Track } from "@/contexts/PlayerContext";
+import { usePlayerActions } from "@/contexts/PlayerContext";
 
 delete (L.Icon.Default.prototype as unknown as Record<string, unknown>)._getIconUrl;
 L.Icon.Default.mergeOptions({
@@ -259,33 +260,6 @@ export function UpcomingMonthGroup({
       </div>
     </div>
   );
-}
-
-export async function fetchPlayableSetlist(artist: string): Promise<Track[]> {
-  const response = await api<{
-    tracks: {
-      library_track_id: number;
-      title: string;
-      artist: string;
-      album: string;
-      path: string;
-      duration?: number;
-      navidrome_id?: string;
-    }[];
-  }>(`/api/artist/${encPath(artist)}/setlist-playable`);
-
-  return (response.tracks || []).map((track) => ({
-    id: track.path || track.navidrome_id || String(track.library_track_id),
-    title: track.title,
-    artist: track.artist,
-    album: track.album,
-    albumCover: track.album
-      ? `/api/cover/${encPath(track.artist)}/${encPath(track.album)}`
-      : `/api/artist/${encPath(track.artist)}/photo`,
-    path: track.path || undefined,
-    navidromeId: track.navidrome_id || undefined,
-    libraryTrackId: track.library_track_id,
-  }));
 }
 
 export function UpcomingEventRow({

--- a/app/listen/src/components/upcoming/UpcomingRows.tsx
+++ b/app/listen/src/components/upcoming/UpcomingRows.tsx
@@ -261,7 +261,7 @@ export function UpcomingMonthGroup({
   );
 }
 
-async function fetchPlayableSetlist(artist: string): Promise<Track[]> {
+export async function fetchPlayableSetlist(artist: string): Promise<Track[]> {
   const response = await api<{
     tracks: {
       library_track_id: number;

--- a/app/listen/src/contexts/PlayerContext.tsx
+++ b/app/listen/src/contexts/PlayerContext.tsx
@@ -36,7 +36,6 @@ import {
   getSmartPlaylistSuggestionsPreference,
   PLAYER_PLAYBACK_PREFS_EVENT,
 } from "@/lib/player-playback-prefs";
-import { fetchInfiniteContinuation, fetchRadioContinuation } from "@/lib/radio";
 export type { PlaySource, RepeatMode, Track } from "@/contexts/player-types";
 
 interface PlayerStateValue {

--- a/app/listen/src/contexts/PlayerContext.tsx
+++ b/app/listen/src/contexts/PlayerContext.tsx
@@ -8,6 +8,27 @@ import {
   useMemo,
   type ReactNode,
 } from "react";
+import type { PlaySource, RepeatMode, Track } from "@/contexts/player-types";
+import {
+  getPredictableNextTrack,
+  getSharedAudio,
+  getStoredQueue,
+  getStoredRecentlyPlayed,
+  getStoredVolume,
+  getStreamUrl,
+  getTrackCacheKey,
+  isContinuousAlbumTransition,
+  MAX_RECENT,
+  NEXT_TRACK_PRELOAD_WINDOW_SECONDS,
+  PLAYER_AUDIO_KEY,
+  PLAYER_PRELOAD_AUDIO_KEY,
+  saveQueue,
+  saveRecentlyPlayed,
+  STORAGE_KEY,
+} from "@/contexts/player-utils";
+import { usePlayEventTracker } from "@/contexts/use-play-event-tracker";
+import { usePlaybackIntelligence } from "@/contexts/use-playback-intelligence";
+import { usePlayerShortcuts } from "@/contexts/use-player-shortcuts";
 import {
   getCrossfadeDurationPreference,
   getInfinitePlaybackPreference,
@@ -16,34 +37,7 @@ import {
   PLAYER_PLAYBACK_PREFS_EVENT,
 } from "@/lib/player-playback-prefs";
 import { fetchInfiniteContinuation, fetchRadioContinuation } from "@/lib/radio";
-
-export interface Track {
-  id: string;
-  title: string;
-  artist: string;
-  album?: string;
-  albumCover?: string;
-  path?: string;
-  navidromeId?: string;
-  libraryTrackId?: number;
-  isSuggested?: boolean;
-  suggestionSource?: "playlist";
-}
-
-type RepeatMode = "off" | "one" | "all";
-type RadioSeedType = "track" | "album" | "artist" | "playlist";
-
-interface RadioSession {
-  seedType: RadioSeedType;
-  seedId?: string | number | null;
-  seedPath?: string | null;
-}
-
-export interface PlaySource {
-  type: "album" | "playlist" | "radio" | "track" | "queue";
-  name: string;
-  radio?: RadioSession;
-}
+export type { PlaySource, RepeatMode, Track } from "@/contexts/player-types";
 
 interface PlayerStateValue {
   currentTime: number;
@@ -103,158 +97,6 @@ export function usePlayer(): PlayerContextValue {
   return { ...state, ...actions };
 }
 
-const STORAGE_KEY = "listen-player-state";
-const RECENTLY_PLAYED_KEY = "listen-recently-played";
-const MAX_RECENT = 10;
-const NEXT_TRACK_PRELOAD_WINDOW_SECONDS = 15;
-const RADIO_REFILL_THRESHOLD = 3;
-const RADIO_REFILL_BATCH_SIZE = 30;
-const SMART_PLAYLIST_SUGGESTION_BATCH_SIZE = 12;
-const PLAYER_AUDIO_KEY = "__listenPlayerAudio";
-const PLAYER_PRELOAD_AUDIO_KEY = "__listenPlayerPreloadAudio";
-
-function getStoredVolume(): number {
-  try {
-    const v = localStorage.getItem("listen-player-volume");
-    if (v !== null) return parseFloat(v);
-  } catch { /* ignore */ }
-  return 0.8;
-}
-
-function getStoredQueue(): { queue: Track[]; currentIndex: number } {
-  try {
-    const raw = localStorage.getItem(STORAGE_KEY);
-    if (raw) {
-      const parsed = JSON.parse(raw);
-      if (Array.isArray(parsed.queue) && parsed.queue.length > 0) {
-        return { queue: parsed.queue, currentIndex: parsed.currentIndex ?? 0 };
-      }
-    }
-  } catch { /* ignore */ }
-  return { queue: [], currentIndex: 0 };
-}
-
-function saveQueue(queue: Track[], currentIndex: number) {
-  try {
-    localStorage.setItem(STORAGE_KEY, JSON.stringify({ queue, currentIndex }));
-  } catch { /* ignore */ }
-}
-
-function getStoredRecentlyPlayed(): Track[] {
-  try {
-    const raw = localStorage.getItem(RECENTLY_PLAYED_KEY);
-    if (raw) return JSON.parse(raw);
-  } catch { /* ignore */ }
-  return [];
-}
-
-function saveRecentlyPlayed(tracks: Track[]) {
-  try {
-    localStorage.setItem(RECENTLY_PLAYED_KEY, JSON.stringify(tracks));
-  } catch { /* ignore */ }
-}
-
-function getSharedAudio(key: string): HTMLAudioElement {
-  const w = window as unknown as Record<string, HTMLAudioElement | undefined>;
-  if (!w[key]) {
-    w[key] = new Audio();
-  }
-  return w[key]!;
-}
-
-function getStreamUrl(track: Track): string {
-  if (track.navidromeId) {
-    return `/api/navidrome/stream/${track.navidromeId}`;
-  }
-
-  const playbackPath = track.path || track.id;
-  if (playbackPath.includes("/")) {
-    return `/api/stream/${encodeURIComponent(playbackPath).replace(/%2F/g, "/")}`;
-  }
-
-  return `/api/navidrome/stream/${track.id}`;
-}
-
-function getTrackCacheKey(track: Track): string {
-  return [track.libraryTrackId ?? "", track.navidromeId ?? "", track.path ?? "", track.id].join("::");
-}
-
-function getPlaySourceSignature(source: PlaySource | null): string | null {
-  if (!source) return null;
-  return [
-    source.type,
-    source.name,
-    source.radio?.seedType ?? "",
-    source.radio?.seedId ?? "",
-    source.radio?.seedPath ?? "",
-  ].join("::");
-}
-
-function collectUniqueTracks(candidates: Track[], queue: Track[], recent: Track[]): Track[] {
-  const existingKeys = new Set(
-    [...queue, ...recent].map((track) => getTrackCacheKey(track)),
-  );
-  const uniqueTracks: Track[] = [];
-  for (const track of candidates) {
-    const key = getTrackCacheKey(track);
-    if (!key || existingKeys.has(key)) continue;
-    existingKeys.add(key);
-    uniqueTracks.push(track);
-  }
-  return uniqueTracks;
-}
-
-function getPredictableNextTrack(
-  queue: Track[],
-  currentIndex: number,
-  repeat: RepeatMode,
-  shuffle: boolean,
-): Track | null {
-  if (shuffle || repeat === "one" || queue.length < 2) return null;
-  if (currentIndex < 0 || currentIndex >= queue.length) return null;
-
-  if (currentIndex < queue.length - 1) {
-    return queue[currentIndex + 1] ?? null;
-  }
-
-  if (repeat === "all") {
-    return queue[0] ?? null;
-  }
-
-  return null;
-}
-
-function isContinuousAlbumTransition(
-  currentTrack: Track | undefined,
-  nextTrack: Track | null,
-  playSource: PlaySource | null,
-  shuffle: boolean,
-): boolean {
-  if (!currentTrack || !nextTrack) return false;
-  if (shuffle) return false;
-  if (playSource?.type !== "album") return false;
-  return (
-    !!currentTrack.album &&
-    !!nextTrack.album &&
-    !!currentTrack.artist &&
-    !!nextTrack.artist &&
-    currentTrack.album === nextTrack.album &&
-    currentTrack.artist === nextTrack.artist
-  );
-}
-
-function isLikelyContinuousAlbumBlock(currentTrack: Track | undefined, nextTrack: Track | undefined): boolean {
-  if (!currentTrack || !nextTrack) return false;
-  return (
-    !!currentTrack.album &&
-    !!nextTrack.album &&
-    !!currentTrack.artist &&
-    !!nextTrack.artist &&
-    currentTrack.album === nextTrack.album &&
-    currentTrack.artist === nextTrack.artist
-  );
-}
-
 export function PlayerProvider({ children }: { children: ReactNode }) {
   const audioRef = useRef<HTMLAudioElement | null>(null);
   const preloadAudioRef = useRef<HTMLAudioElement | null>(null);
@@ -283,16 +125,6 @@ export function PlayerProvider({ children }: { children: ReactNode }) {
   const restoredRef = useRef(stored.current.queue.length > 0);
   const shouldAutoplayRef = useRef(false);
   const lastNonZeroVolumeRef = useRef(Math.max(getStoredVolume(), 0.5));
-  const radioRefillInFlightRef = useRef(false);
-  const radioRefillSignatureRef = useRef<string | null>(null);
-  const continuationInFlightRef = useRef(false);
-  const continuationSignatureRef = useRef<string | null>(null);
-  const playlistSuggestionInFlightRef = useRef(false);
-  const playlistSuggestionSignatureRef = useRef<string | null>(null);
-  const currentIndexRef = useRef(currentIndex);
-  const playSourceRef = useRef(playSource);
-  const queueRef = useRef(queue);
-  const recentlyPlayedRef = useRef(recentlyPlayed);
 
   if (!audioRef.current) {
     audioRef.current = getSharedAudio(PLAYER_AUDIO_KEY);
@@ -304,13 +136,7 @@ export function PlayerProvider({ children }: { children: ReactNode }) {
     preloadAudioRef.current.preload = "auto";
   }
   const audio = audioRef.current;
-
-  useEffect(() => {
-    currentIndexRef.current = currentIndex;
-    playSourceRef.current = playSource;
-    queueRef.current = queue;
-    recentlyPlayedRef.current = recentlyPlayed;
-  }, [currentIndex, playSource, queue, recentlyPlayed]);
+  const currentTrack = queue[currentIndex];
 
   useEffect(() => {
     saveQueue(queue, currentIndex);
@@ -362,8 +188,36 @@ export function PlayerProvider({ children }: { children: ReactNode }) {
     return preloadAudio.currentSrc || preloadAudio.src || null;
   }, []);
 
+  const {
+    flushCurrentPlayEvent,
+    markSeekPosition,
+    recordProgress,
+  } = usePlayEventTracker(audio, currentTrack, playSource);
+
+  const {
+    continueInfinitePlayback,
+    resetPlaybackIntelligence,
+  } = usePlaybackIntelligence({
+    queue,
+    currentIndex,
+    isPlaying,
+    playSource,
+    shuffle,
+    infinitePlaybackEnabled,
+    smartPlaylistSuggestionsEnabled,
+    smartPlaylistSuggestionsCadence,
+    recentlyPlayed,
+    shouldAutoplayRef,
+    setQueue,
+    setCurrentIndex,
+    setCurrentTime,
+    setDuration,
+    setIsPlaying,
+    setIsBuffering,
+  });
+
   useEffect(() => {
-    const track = queue[currentIndex];
+    const track = currentTrack;
     if (!track) return;
     const preloadedSrc = consumePreloadedSource(track);
     const streamUrl = preloadedSrc || getStreamUrl(track);
@@ -385,7 +239,7 @@ export function PlayerProvider({ children }: { children: ReactNode }) {
       addToRecentlyPlayed(track);
       clearPreloadedTrack();
     }
-  }, [addToRecentlyPlayed, audio, clearPreloadedTrack, consumePreloadedSource, currentIndex, queue]);
+  }, [addToRecentlyPlayed, audio, clearPreloadedTrack, consumePreloadedSource, currentTrack]);
 
   useEffect(() => {
     clearPreloadedTrack();
@@ -498,306 +352,15 @@ export function PlayerProvider({ children }: { children: ReactNode }) {
   }, [audio, clearPreloadedTrack]);
 
   useEffect(() => {
-    const currentTrack = queue[currentIndex];
-    if (!isPlaying || !currentTrack) return;
-    if (playSource?.type !== "radio" || !playSource.radio) return;
-
-    const remainingUpcoming = queue.length - currentIndex - 1;
-    if (remainingUpcoming > RADIO_REFILL_THRESHOLD) {
-      radioRefillSignatureRef.current = null;
-      return;
-    }
-    if (radioRefillInFlightRef.current) return;
-
-    const signature = [
-      getPlaySourceSignature(playSource),
-      currentTrack.id,
-      queue.length,
-    ].join("::");
-    if (radioRefillSignatureRef.current === signature) return;
-    radioRefillSignatureRef.current = signature;
-    radioRefillInFlightRef.current = true;
-    const controller = new AbortController();
-
-    fetchRadioContinuation(playSource, RADIO_REFILL_BATCH_SIZE, { signal: controller.signal })
-      .then((tracks) => {
-        if (controller.signal.aborted) return;
-        if (radioRefillSignatureRef.current !== signature) return;
-        if (getPlaySourceSignature(playSourceRef.current) !== getPlaySourceSignature(playSource)) return;
-        setQueue((prev) => {
-          if (radioRefillSignatureRef.current !== signature) return prev;
-          if (getPlaySourceSignature(playSourceRef.current) !== getPlaySourceSignature(playSource)) return prev;
-          const uniqueTracks = collectUniqueTracks(tracks, prev, recentlyPlayedRef.current);
-          return uniqueTracks.length > 0 ? [...prev, ...uniqueTracks] : prev;
-        });
-      })
-      .catch((error) => {
-        if (controller.signal.aborted) return;
-        console.warn("[player] radio refill failed:", error);
-      })
-      .finally(() => {
-        if (!controller.signal.aborted) {
-          radioRefillInFlightRef.current = false;
-        }
-      });
-    return () => {
-      controller.abort();
-      radioRefillInFlightRef.current = false;
+    const onTimeUpdate = () => {
+      setCurrentTime(audio.currentTime);
+      recordProgress(audio.currentTime);
     };
-  }, [currentIndex, isPlaying, playSource, queue.length]);
-
-  useEffect(() => {
-    const currentTrack = queue[currentIndex];
-    const supportsContinuation =
-      infinitePlaybackEnabled &&
-      !shuffle &&
-      !!currentTrack &&
-      (playSource?.type === "album" || playSource?.type === "playlist") &&
-      !!playSource?.radio?.seedId;
-
-    if (!supportsContinuation) return;
-
-    const remainingUpcoming = queue.length - currentIndex - 1;
-    if (remainingUpcoming > RADIO_REFILL_THRESHOLD) {
-      continuationSignatureRef.current = null;
-      return;
-    }
-    if (continuationInFlightRef.current) return;
-
-    const sessionSignature = getPlaySourceSignature(playSource);
-    const signature = [sessionSignature, currentTrack?.id ?? "", queue.length].join("::");
-    if (continuationSignatureRef.current === signature) return;
-    continuationSignatureRef.current = signature;
-    continuationInFlightRef.current = true;
-    const controller = new AbortController();
-
-    fetchInfiniteContinuation(playSource!, RADIO_REFILL_BATCH_SIZE, { signal: controller.signal })
-      .then((tracks) => {
-        if (controller.signal.aborted) return;
-        if (!tracks.length) return;
-        if (continuationSignatureRef.current !== signature) return;
-        if (getPlaySourceSignature(playSourceRef.current) !== sessionSignature) return;
-        setQueue((prev) => {
-          if (continuationSignatureRef.current !== signature) return prev;
-          if (getPlaySourceSignature(playSourceRef.current) !== sessionSignature) return prev;
-          const uniqueTracks = collectUniqueTracks(tracks, prev, recentlyPlayedRef.current);
-          return uniqueTracks.length > 0 ? [...prev, ...uniqueTracks] : prev;
-        });
-      })
-      .catch((error) => {
-        if (controller.signal.aborted) return;
-        console.warn("[player] continuation refill failed:", error);
-      })
-      .finally(() => {
-        if (!controller.signal.aborted) {
-          continuationInFlightRef.current = false;
-        }
-      });
-    return () => {
-      controller.abort();
-      continuationInFlightRef.current = false;
-    };
-  }, [currentIndex, infinitePlaybackEnabled, playSource, queue.length, shuffle]);
-
-  useEffect(() => {
-    const currentTrack = queue[currentIndex];
-    const nextTrack = queue[currentIndex + 1];
-    const supportsSmartInclusion =
-      smartPlaylistSuggestionsEnabled &&
-      !shuffle &&
-      !!currentTrack &&
-      playSource?.type === "playlist" &&
-      !!playSource?.radio?.seedId;
-
-    if (!supportsSmartInclusion) {
-      playlistSuggestionSignatureRef.current = null;
-      return;
-    }
-    if (currentTrack?.isSuggested) {
-      playlistSuggestionSignatureRef.current = null;
-      return;
-    }
-    if (isLikelyContinuousAlbumBlock(currentTrack, nextTrack)) {
-      playlistSuggestionSignatureRef.current = null;
-      return;
-    }
-
-    const playedOriginalCount = queue
-      .slice(0, currentIndex + 1)
-      .filter((track) => !track.isSuggested).length;
-
-    if (
-      playedOriginalCount === 0 ||
-      playedOriginalCount % smartPlaylistSuggestionsCadence !== 0
-    ) {
-      playlistSuggestionSignatureRef.current = null;
-      return;
-    }
-
-    if (nextTrack?.isSuggested) {
-      playlistSuggestionSignatureRef.current = [
-        playSource?.radio?.seedId ?? "",
-        playedOriginalCount,
-        currentTrack?.id ?? "",
-      ].join("::");
-      return;
-    }
-
-    if (playlistSuggestionInFlightRef.current) return;
-
-    const signature = [
-      playSource?.radio?.seedId ?? "",
-      playedOriginalCount,
-      currentTrack?.id ?? "",
-      queue.length,
-    ].join("::");
-    if (playlistSuggestionSignatureRef.current === signature) return;
-    playlistSuggestionSignatureRef.current = signature;
-    playlistSuggestionInFlightRef.current = true;
-    const controller = new AbortController();
-
-    fetchInfiniteContinuation(playSource!, SMART_PLAYLIST_SUGGESTION_BATCH_SIZE, { signal: controller.signal })
-      .then((tracks) => {
-        if (controller.signal.aborted) return;
-        if (!tracks.length) return;
-        if (playlistSuggestionSignatureRef.current !== signature) return;
-        const expectedSeedId = playSource?.radio?.seedId ?? null;
-        setQueue((prev) => {
-          if (playlistSuggestionSignatureRef.current !== signature) return prev;
-          const latestSource = playSourceRef.current;
-          const insertionIndex = currentIndexRef.current + 1;
-          if (
-            latestSource?.type !== "playlist" ||
-            latestSource?.radio?.seedId !== expectedSeedId ||
-            insertionIndex <= 0 ||
-            insertionIndex > prev.length
-          ) {
-            return prev;
-          }
-
-          const existingKeys = new Set(
-            [...prev, ...recentlyPlayedRef.current].map((track) => getTrackCacheKey(track)),
-          );
-          const suggestion = tracks.find((track) => {
-            const key = getTrackCacheKey(track);
-            if (!key || existingKeys.has(key)) return false;
-            return true;
-          });
-          if (!suggestion) return prev;
-          if (prev[insertionIndex]?.isSuggested) return prev;
-
-          const nextQueue = [...prev];
-          nextQueue.splice(insertionIndex, 0, {
-            ...suggestion,
-            isSuggested: true,
-            suggestionSource: "playlist",
-          });
-          return nextQueue;
-        });
-      })
-      .catch((error) => {
-        if (controller.signal.aborted) return;
-        console.warn("[player] playlist suggestion failed:", error);
-      })
-      .finally(() => {
-        if (!controller.signal.aborted) {
-          playlistSuggestionInFlightRef.current = false;
-        }
-      });
-    return () => {
-      controller.abort();
-      playlistSuggestionInFlightRef.current = false;
-    };
-  }, [
-    currentIndex,
-    playSource,
-    queue,
-    shuffle,
-    smartPlaylistSuggestionsCadence,
-    smartPlaylistSuggestionsEnabled,
-  ]);
-
-  const continueInfinitePlayback = useCallback(() => {
-    if (
-      !infinitePlaybackEnabled ||
-      shuffle ||
-      (playSource?.type !== "album" && playSource?.type !== "playlist") ||
-      !playSource?.radio?.seedId
-    ) {
-      return false;
-    }
-    if (continuationInFlightRef.current) {
-      return false;
-    }
-
-    const sessionSignature = getPlaySourceSignature(playSource);
-    const requestSignature = [sessionSignature, currentIndexRef.current, queueRef.current.length, "manual"].join("::");
-
-    shouldAutoplayRef.current = false;
-    setIsPlaying(false);
-    setIsBuffering(true);
-    continuationSignatureRef.current = requestSignature;
-    continuationInFlightRef.current = true;
-
-    fetchInfiniteContinuation(playSource, RADIO_REFILL_BATCH_SIZE)
-      .then((tracks) => {
-        if (continuationSignatureRef.current !== requestSignature) {
-          setIsBuffering(false);
-          return;
-        }
-        if (getPlaySourceSignature(playSourceRef.current) !== sessionSignature) {
-          setIsBuffering(false);
-          return;
-        }
-        if (!tracks.length) {
-          setIsBuffering(false);
-          return;
-        }
-
-        const uniqueTracks = collectUniqueTracks(tracks, queueRef.current, recentlyPlayedRef.current);
-        if (uniqueTracks.length === 0) {
-          setIsBuffering(false);
-          return;
-        }
-
-        setQueue((prev) => {
-          if (continuationSignatureRef.current !== requestSignature) return prev;
-          if (getPlaySourceSignature(playSourceRef.current) !== sessionSignature) return prev;
-          const stillUnique = collectUniqueTracks(uniqueTracks, prev, recentlyPlayedRef.current);
-          return stillUnique.length > 0 ? [...prev, ...stillUnique] : prev;
-        });
-
-        shouldAutoplayRef.current = true;
-        setCurrentIndex((index) => {
-          if (continuationSignatureRef.current !== requestSignature) return index;
-          if (getPlaySourceSignature(playSourceRef.current) !== sessionSignature) return index;
-          return index + 1;
-        });
-        setCurrentTime(0);
-        setDuration(0);
-      })
-      .catch((error) => {
-        console.warn("[player] continuation after end failed:", error);
-        if (continuationSignatureRef.current === requestSignature) {
-          setIsBuffering(false);
-        }
-      })
-      .finally(() => {
-        continuationInFlightRef.current = false;
-        if (continuationSignatureRef.current === requestSignature) {
-          continuationSignatureRef.current = null;
-        }
-      });
-
-    return true;
-  }, [infinitePlaybackEnabled, playSource, shuffle]);
-
-  useEffect(() => {
-    const onTimeUpdate = () => setCurrentTime(audio.currentTime);
     const onDurationChange = () => setDuration(audio.duration || 0);
     const onEnded = () => {
-      const endedTrack = queue[currentIndex];
+      const endedTrack = currentTrack;
       if (endedTrack) {
+        flushCurrentPlayEvent("completed");
         fetch("/api/navidrome/scrobble", {
           method: "POST",
           headers: { "Content-Type": "application/json" },
@@ -875,7 +438,10 @@ export function PlayerProvider({ children }: { children: ReactNode }) {
       setIsBuffering(false);
     };
     const onCanPlay = () => setIsBuffering(false);
-    const onSeeked = () => setIsBuffering(false);
+    const onSeeked = () => {
+      setIsBuffering(false);
+      markSeekPosition(audio.currentTime);
+    };
     const onError = () => {
       console.error("[player] audio error:", audio.error?.code, audio.error?.message);
       setIsPlaying(false);
@@ -909,7 +475,20 @@ export function PlayerProvider({ children }: { children: ReactNode }) {
       audio.removeEventListener("seeked", onSeeked);
       audio.removeEventListener("error", onError);
     };
-  }, [audio, continueInfinitePlayback, crossfadeSeconds, currentIndex, queue, repeat, shuffle]);
+  }, [
+    audio,
+    continueInfinitePlayback,
+    crossfadeSeconds,
+    currentIndex,
+    currentTrack,
+    flushCurrentPlayEvent,
+    markSeekPosition,
+    playSource,
+    queue,
+    recordProgress,
+    repeat,
+    shuffle,
+  ]);
 
   const play = useCallback((track: Track, source?: PlaySource) => {
     try {
@@ -919,7 +498,8 @@ export function PlayerProvider({ children }: { children: ReactNode }) {
     } catch { /* ok */ }
 
     restoredRef.current = false;
-    playlistSuggestionSignatureRef.current = null;
+    resetPlaybackIntelligence();
+    flushCurrentPlayEvent("interrupted");
     clearPreloadedTrack();
     setQueue([track]);
     setCurrentIndex(0);
@@ -932,7 +512,7 @@ export function PlayerProvider({ children }: { children: ReactNode }) {
     setIsPlaying(true);
     setPlaySource(source || { type: "track", name: track.title });
     addToRecentlyPlayed(track);
-  }, [addToRecentlyPlayed, audio, clearPreloadedTrack]);
+  }, [addToRecentlyPlayed, audio, clearPreloadedTrack, flushCurrentPlayEvent, resetPlaybackIntelligence]);
 
   const playAll = useCallback((tracks: Track[], startIndex = 0, source?: PlaySource) => {
     if (tracks.length === 0) return;
@@ -940,7 +520,8 @@ export function PlayerProvider({ children }: { children: ReactNode }) {
     if (!track) return;
 
     restoredRef.current = false;
-    playlistSuggestionSignatureRef.current = null;
+    resetPlaybackIntelligence();
+    flushCurrentPlayEvent("interrupted");
     clearPreloadedTrack();
     setQueue(tracks);
     setCurrentIndex(startIndex);
@@ -953,7 +534,7 @@ export function PlayerProvider({ children }: { children: ReactNode }) {
     setIsPlaying(true);
     setPlaySource(source || (tracks.length > 1 ? { type: "queue", name: "Queue" } : { type: "track", name: track.title }));
     addToRecentlyPlayed(track);
-  }, [addToRecentlyPlayed, audio, clearPreloadedTrack]);
+  }, [addToRecentlyPlayed, audio, clearPreloadedTrack, flushCurrentPlayEvent, resetPlaybackIntelligence]);
 
   const pause = useCallback(() => {
     audio.pause();
@@ -974,6 +555,7 @@ export function PlayerProvider({ children }: { children: ReactNode }) {
 
   const next = useCallback(() => {
     shouldAutoplayRef.current = true;
+    flushCurrentPlayEvent("skipped");
     clearPreloadedTrack();
     if (shuffle && queue.length > 1) {
       let nextIdx: number;
@@ -999,7 +581,7 @@ export function PlayerProvider({ children }: { children: ReactNode }) {
       setIsPlaying(false);
       setIsBuffering(false);
     }
-  }, [clearPreloadedTrack, continueInfinitePlayback, currentIndex, queue.length, repeat, shuffle]);
+  }, [clearPreloadedTrack, continueInfinitePlayback, currentIndex, flushCurrentPlayEvent, queue.length, repeat, shuffle]);
 
   const prev = useCallback(() => {
     if (audio.currentTime > 3) {
@@ -1009,18 +591,20 @@ export function PlayerProvider({ children }: { children: ReactNode }) {
 
     if (currentIndex > 0) {
       shouldAutoplayRef.current = true;
+      flushCurrentPlayEvent("skipped");
       clearPreloadedTrack();
       setCurrentIndex((i) => i - 1);
       setCurrentTime(0);
       setDuration(0);
     }
-  }, [audio, clearPreloadedTrack, currentIndex]);
+  }, [audio, clearPreloadedTrack, currentIndex, flushCurrentPlayEvent]);
 
   const seek = useCallback((time: number) => {
     setIsBuffering(true);
     audio.currentTime = time;
     setCurrentTime(time);
-  }, [audio]);
+    markSeekPosition(time);
+  }, [audio, markSeekPosition]);
 
   const setVolume = useCallback((vol: number) => {
     audio.volume = vol;
@@ -1035,7 +619,8 @@ export function PlayerProvider({ children }: { children: ReactNode }) {
   }, [audio]);
 
   const clearQueue = useCallback(() => {
-    playlistSuggestionSignatureRef.current = null;
+    resetPlaybackIntelligence();
+    flushCurrentPlayEvent("interrupted");
     clearPreloadedTrack();
     audio.pause();
     audio.removeAttribute("src");
@@ -1047,7 +632,7 @@ export function PlayerProvider({ children }: { children: ReactNode }) {
     setIsPlaying(false);
     setIsBuffering(false);
     try { localStorage.removeItem(STORAGE_KEY); } catch { /* ignore */ }
-  }, [audio, clearPreloadedTrack]);
+  }, [audio, clearPreloadedTrack, flushCurrentPlayEvent, resetPlaybackIntelligence]);
 
   const toggleShuffle = useCallback(() => {
     setShuffle((s) => !s);
@@ -1064,13 +649,14 @@ export function PlayerProvider({ children }: { children: ReactNode }) {
   const jumpTo = useCallback((index: number) => {
     if (index >= 0 && index < queue.length) {
       restoredRef.current = false;
+      flushCurrentPlayEvent("skipped");
       clearPreloadedTrack();
       shouldAutoplayRef.current = true;
       setCurrentIndex(index);
       setCurrentTime(0);
       setDuration(0);
     }
-  }, [clearPreloadedTrack, queue.length]);
+  }, [clearPreloadedTrack, flushCurrentPlayEvent, queue.length]);
 
   const playNext = useCallback((track: Track) => {
     setQueue((prev) => {
@@ -1112,66 +698,20 @@ export function PlayerProvider({ children }: { children: ReactNode }) {
     });
   }, []);
 
-  useEffect(() => {
-    const isTypingTarget = (target: EventTarget | null) => {
-      const el = target as HTMLElement | null;
-      if (!el) return false;
-      const tag = el.tagName;
-      return (
-        el.isContentEditable ||
-        tag === "INPUT" ||
-        tag === "TEXTAREA" ||
-        tag === "SELECT" ||
-        tag === "BUTTON"
-      );
-    };
-
-    const onKeyDown = (event: KeyboardEvent) => {
-      if (event.defaultPrevented || event.metaKey || event.ctrlKey || event.altKey) return;
-      if (isTypingTarget(event.target)) return;
-      if (!queue[currentIndex]) return;
-
-      if (event.code === "Space" || event.key.toLowerCase() === "k") {
-        event.preventDefault();
-        if (isPlaying) pause();
-        else resume();
-        return;
-      }
-
-      if (event.shiftKey && event.key === "ArrowRight") {
-        event.preventDefault();
-        next();
-        return;
-      }
-
-      if (event.shiftKey && event.key === "ArrowLeft") {
-        event.preventDefault();
-        prev();
-        return;
-      }
-
-      if (event.key === "ArrowRight") {
-        event.preventDefault();
-        seek(Math.min(audio.duration || duration || 0, audio.currentTime + 10));
-        return;
-      }
-
-      if (event.key === "ArrowLeft") {
-        event.preventDefault();
-        seek(Math.max(0, audio.currentTime - 10));
-        return;
-      }
-
-      if (event.key.toLowerCase() === "m") {
-        event.preventDefault();
-        if (volume === 0) setVolume(lastNonZeroVolumeRef.current || 0.8);
-        else setVolume(0);
-      }
-    };
-
-    window.addEventListener("keydown", onKeyDown);
-    return () => window.removeEventListener("keydown", onKeyDown);
-  }, [audio, currentIndex, duration, isPlaying, next, pause, prev, queue, resume, seek, setVolume, volume]);
+  usePlayerShortcuts({
+    hasCurrentTrack: !!currentTrack,
+    isPlaying,
+    audio,
+    duration,
+    volume,
+    lastNonZeroVolume: lastNonZeroVolumeRef.current,
+    pause,
+    resume,
+    next,
+    prev,
+    seek,
+    setVolume,
+  });
 
   const stateValue = useMemo<PlayerStateValue>(
     () => ({ currentTime, duration, isPlaying, isBuffering, volume }),
@@ -1186,7 +726,7 @@ export function PlayerProvider({ children }: { children: ReactNode }) {
       playSource,
       repeat,
       recentlyPlayed,
-      currentTrack: queue[currentIndex],
+      currentTrack,
       audioElement: audioRef.current,
       play,
       playAll,
@@ -1206,7 +746,7 @@ export function PlayerProvider({ children }: { children: ReactNode }) {
       reorderQueue,
     }),
     [
-      queue, currentIndex, shuffle, repeat, playSource, recentlyPlayed,
+      queue, currentIndex, shuffle, repeat, playSource, recentlyPlayed, currentTrack,
       play, playAll, pause, resume, next, prev, seek, setVolume,
       clearQueue, toggleShuffle, cycleRepeat, jumpTo, playNext,
       addToQueue, removeFromQueue, reorderQueue,

--- a/app/listen/src/contexts/PlayerContext.tsx
+++ b/app/listen/src/contexts/PlayerContext.tsx
@@ -136,6 +136,23 @@ export function PlayerProvider({ children }: { children: ReactNode }) {
   }
   const audio = audioRef.current;
   const currentTrack = queue[currentIndex];
+  const queueRef = useRef(queue);
+  const currentIndexRef = useRef(currentIndex);
+  const currentTrackRef = useRef(currentTrack);
+  const repeatRef = useRef(repeat);
+  const shuffleRef = useRef(shuffle);
+  const playSourceRef = useRef(playSource);
+  const crossfadeSecondsRef = useRef(crossfadeSeconds);
+
+  useEffect(() => {
+    queueRef.current = queue;
+    currentIndexRef.current = currentIndex;
+    currentTrackRef.current = currentTrack;
+    repeatRef.current = repeat;
+    shuffleRef.current = shuffle;
+    playSourceRef.current = playSource;
+    crossfadeSecondsRef.current = crossfadeSeconds;
+  }, [crossfadeSeconds, currentIndex, currentTrack, playSource, queue, repeat, shuffle]);
 
   useEffect(() => {
     saveQueue(queue, currentIndex);
@@ -357,7 +374,7 @@ export function PlayerProvider({ children }: { children: ReactNode }) {
     };
     const onDurationChange = () => setDuration(audio.duration || 0);
     const onEnded = () => {
-      const endedTrack = currentTrack;
+      const endedTrack = currentTrackRef.current;
       if (endedTrack) {
         flushCurrentPlayEvent("completed");
         fetch("/api/navidrome/scrobble", {
@@ -385,25 +402,30 @@ export function PlayerProvider({ children }: { children: ReactNode }) {
         }).catch(() => {});
       }
 
-      const nextTrack = getPredictableNextTrack(queue, currentIndex, repeat, shuffle);
-      const continuousAlbum = isContinuousAlbumTransition(endedTrack, nextTrack, playSource, shuffle);
+      const liveQueue = queueRef.current;
+      const liveCurrentIndex = currentIndexRef.current;
+      const liveRepeat = repeatRef.current;
+      const liveShuffle = shuffleRef.current;
+      const livePlaySource = playSourceRef.current;
+      const nextTrack = getPredictableNextTrack(liveQueue, liveCurrentIndex, liveRepeat, liveShuffle);
+      const continuousAlbum = isContinuousAlbumTransition(endedTrack, nextTrack, livePlaySource, liveShuffle);
 
-      if (repeat === "one") {
+      if (liveRepeat === "one") {
         audio.currentTime = 0;
         audio.play().catch(() => {});
         return;
       }
 
       shouldAutoplayRef.current = true;
-      if (crossfadeSeconds > 0 && nextTrack && !continuousAlbum) {
+      if (crossfadeSecondsRef.current > 0 && nextTrack && !continuousAlbum) {
         setIsBuffering(false);
       }
-      if (shuffle) {
-        if (queue.length > 1) {
+      if (liveShuffle) {
+        if (liveQueue.length > 1) {
           let nextIdx: number;
           do {
-            nextIdx = Math.floor(Math.random() * queue.length);
-          } while (nextIdx === currentIndex && queue.length > 1);
+            nextIdx = Math.floor(Math.random() * liveQueue.length);
+          } while (nextIdx === liveCurrentIndex && liveQueue.length > 1);
           setCurrentIndex(nextIdx);
         } else {
           shouldAutoplayRef.current = false;
@@ -412,9 +434,9 @@ export function PlayerProvider({ children }: { children: ReactNode }) {
         return;
       }
 
-      if (currentIndex < queue.length - 1) {
+      if (liveCurrentIndex < liveQueue.length - 1) {
         setCurrentIndex((i) => i + 1);
-      } else if (repeat === "all") {
+      } else if (liveRepeat === "all") {
         setCurrentIndex(0);
       } else if (continueInfinitePlayback()) {
         return;
@@ -477,16 +499,9 @@ export function PlayerProvider({ children }: { children: ReactNode }) {
   }, [
     audio,
     continueInfinitePlayback,
-    crossfadeSeconds,
-    currentIndex,
-    currentTrack,
     flushCurrentPlayEvent,
     markSeekPosition,
-    playSource,
-    queue,
     recordProgress,
-    repeat,
-    shuffle,
   ]);
 
   const play = useCallback((track: Track, source?: PlaySource) => {

--- a/app/listen/src/contexts/player-types.ts
+++ b/app/listen/src/contexts/player-types.ts
@@ -1,0 +1,29 @@
+export interface Track {
+  id: string;
+  title: string;
+  artist: string;
+  album?: string;
+  albumCover?: string;
+  path?: string;
+  navidromeId?: string;
+  libraryTrackId?: number;
+  isSuggested?: boolean;
+  suggestionSource?: "playlist";
+}
+
+export type RepeatMode = "off" | "one" | "all";
+
+type RadioSeedType = "track" | "album" | "artist" | "playlist";
+
+interface RadioSession {
+  seedType: RadioSeedType;
+  seedId?: string | number | null;
+  seedPath?: string | null;
+}
+
+export interface PlaySource {
+  type: "album" | "playlist" | "radio" | "track" | "queue";
+  name: string;
+  id?: string | number | null;
+  radio?: RadioSession;
+}

--- a/app/listen/src/contexts/player-utils.ts
+++ b/app/listen/src/contexts/player-utils.ts
@@ -83,6 +83,18 @@ export function getTrackCacheKey(track: Track): string {
   return [track.libraryTrackId ?? "", track.navidromeId ?? "", track.path ?? "", track.id].join("::");
 }
 
+export function areTracksFromSameAlbum(currentTrack: Track | undefined, nextTrack: Track | null | undefined): boolean {
+  if (!currentTrack || !nextTrack) return false;
+  return (
+    !!currentTrack.album &&
+    !!nextTrack.album &&
+    !!currentTrack.artist &&
+    !!nextTrack.artist &&
+    currentTrack.album === nextTrack.album &&
+    currentTrack.artist === nextTrack.artist
+  );
+}
+
 export function getPredictableNextTrack(
   queue: Track[],
   currentIndex: number,
@@ -112,12 +124,5 @@ export function isContinuousAlbumTransition(
   if (!currentTrack || !nextTrack) return false;
   if (shuffle) return false;
   if (playSource?.type !== "album") return false;
-  return (
-    !!currentTrack.album &&
-    !!nextTrack.album &&
-    !!currentTrack.artist &&
-    !!nextTrack.artist &&
-    currentTrack.album === nextTrack.album &&
-    currentTrack.artist === nextTrack.artist
-  );
+  return areTracksFromSameAlbum(currentTrack, nextTrack);
 }

--- a/app/listen/src/contexts/player-utils.ts
+++ b/app/listen/src/contexts/player-utils.ts
@@ -1,0 +1,123 @@
+import type { PlaySource, RepeatMode, Track } from "@/contexts/player-types";
+
+export const STORAGE_KEY = "listen-player-state";
+export const RECENTLY_PLAYED_KEY = "listen-recently-played";
+export const MAX_RECENT = 10;
+export const NEXT_TRACK_PRELOAD_WINDOW_SECONDS = 15;
+export const PLAYER_AUDIO_KEY = "__listenPlayerAudio";
+export const PLAYER_PRELOAD_AUDIO_KEY = "__listenPlayerPreloadAudio";
+
+export function getStoredVolume(): number {
+  try {
+    const v = localStorage.getItem("listen-player-volume");
+    if (v !== null) return parseFloat(v);
+  } catch {
+    /* ignore */
+  }
+  return 0.8;
+}
+
+export function getStoredQueue(): { queue: Track[]; currentIndex: number } {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (raw) {
+      const parsed = JSON.parse(raw);
+      if (Array.isArray(parsed.queue) && parsed.queue.length > 0) {
+        return { queue: parsed.queue, currentIndex: parsed.currentIndex ?? 0 };
+      }
+    }
+  } catch {
+    /* ignore */
+  }
+  return { queue: [], currentIndex: 0 };
+}
+
+export function saveQueue(queue: Track[], currentIndex: number) {
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify({ queue, currentIndex }));
+  } catch {
+    /* ignore */
+  }
+}
+
+export function getStoredRecentlyPlayed(): Track[] {
+  try {
+    const raw = localStorage.getItem(RECENTLY_PLAYED_KEY);
+    if (raw) return JSON.parse(raw);
+  } catch {
+    /* ignore */
+  }
+  return [];
+}
+
+export function saveRecentlyPlayed(tracks: Track[]) {
+  try {
+    localStorage.setItem(RECENTLY_PLAYED_KEY, JSON.stringify(tracks));
+  } catch {
+    /* ignore */
+  }
+}
+
+export function getSharedAudio(key: string): HTMLAudioElement {
+  const w = window as unknown as Record<string, HTMLAudioElement | undefined>;
+  if (!w[key]) {
+    w[key] = new Audio();
+  }
+  return w[key]!;
+}
+
+export function getStreamUrl(track: Track): string {
+  if (track.navidromeId) {
+    return `/api/navidrome/stream/${track.navidromeId}`;
+  }
+
+  const playbackPath = track.path || track.id;
+  if (playbackPath.includes("/")) {
+    return `/api/stream/${encodeURIComponent(playbackPath).replace(/%2F/g, "/")}`;
+  }
+
+  return `/api/navidrome/stream/${track.id}`;
+}
+
+export function getTrackCacheKey(track: Track): string {
+  return [track.libraryTrackId ?? "", track.navidromeId ?? "", track.path ?? "", track.id].join("::");
+}
+
+export function getPredictableNextTrack(
+  queue: Track[],
+  currentIndex: number,
+  repeat: RepeatMode,
+  shuffle: boolean,
+): Track | null {
+  if (shuffle || repeat === "one" || queue.length < 2) return null;
+  if (currentIndex < 0 || currentIndex >= queue.length) return null;
+
+  if (currentIndex < queue.length - 1) {
+    return queue[currentIndex + 1] ?? null;
+  }
+
+  if (repeat === "all") {
+    return queue[0] ?? null;
+  }
+
+  return null;
+}
+
+export function isContinuousAlbumTransition(
+  currentTrack: Track | undefined,
+  nextTrack: Track | null,
+  playSource: PlaySource | null,
+  shuffle: boolean,
+): boolean {
+  if (!currentTrack || !nextTrack) return false;
+  if (shuffle) return false;
+  if (playSource?.type !== "album") return false;
+  return (
+    !!currentTrack.album &&
+    !!nextTrack.album &&
+    !!currentTrack.artist &&
+    !!nextTrack.artist &&
+    currentTrack.album === nextTrack.album &&
+    currentTrack.artist === nextTrack.artist
+  );
+}

--- a/app/listen/src/contexts/use-play-event-tracker.ts
+++ b/app/listen/src/contexts/use-play-event-tracker.ts
@@ -8,6 +8,7 @@ interface PlayEventSession {
   track: Track;
   playSource: PlaySource | null;
   startedAt: string;
+  trackDurationSeconds: number | null;
   lastKnownTime: number;
   listenedSeconds: number;
   maxProgressSeconds: number;
@@ -47,6 +48,7 @@ export function usePlayEventTracker(
       track,
       playSource: source,
       startedAt: nowIso(),
+      trackDurationSeconds: Number.isFinite(audio.duration) && audio.duration > 0 ? audio.duration : null,
       lastKnownTime: audio.currentTime || 0,
       listenedSeconds: 0,
       maxProgressSeconds: audio.currentTime || 0,
@@ -58,9 +60,7 @@ export function usePlayEventTracker(
     if (!session) return;
     sessionRef.current = null;
 
-    const trackDurationSeconds = Number.isFinite(audio.duration) && audio.duration > 0
-      ? audio.duration
-      : null;
+    const trackDurationSeconds = session.trackDurationSeconds;
     const playedSeconds = Math.max(0, session.listenedSeconds);
 
     if (playedSeconds < PLAY_EVENT_MIN_SECONDS && reason !== "completed") {
@@ -71,7 +71,7 @@ export function usePlayEventTracker(
       ? Math.min(1, playedSeconds / trackDurationSeconds)
       : null;
     const wasCompleted = reason === "completed" || (completionRatio !== null && completionRatio >= 0.9);
-    const wasSkipped = reason === "skipped" || (!wasCompleted && playedSeconds >= PLAY_EVENT_MIN_SECONDS);
+    const wasSkipped = reason === "skipped" && playedSeconds >= PLAY_EVENT_MIN_SECONDS;
 
     fetch("/api/me/play-events", {
       method: "POST",
@@ -103,11 +103,14 @@ export function usePlayEventTracker(
         app_platform: "listen-web",
       }),
     }).catch(() => {});
-  }, [audio.duration]);
+  }, []);
 
   const recordProgress = useCallback((nextTime: number) => {
     const session = sessionRef.current;
     if (!session) return;
+    if (session.trackDurationSeconds === null && Number.isFinite(audio.duration) && audio.duration > 0) {
+      session.trackDurationSeconds = audio.duration;
+    }
 
     const delta = nextTime - session.lastKnownTime;
     if (delta > 0 && delta <= PLAY_EVENT_DELTA_CAP_SECONDS) {
@@ -115,14 +118,17 @@ export function usePlayEventTracker(
     }
     session.lastKnownTime = nextTime;
     session.maxProgressSeconds = Math.max(session.maxProgressSeconds, nextTime);
-  }, []);
+  }, [audio]);
 
   const markSeekPosition = useCallback((nextTime: number) => {
     const session = sessionRef.current;
     if (!session) return;
+    if (session.trackDurationSeconds === null && Number.isFinite(audio.duration) && audio.duration > 0) {
+      session.trackDurationSeconds = audio.duration;
+    }
     session.lastKnownTime = nextTime;
     session.maxProgressSeconds = Math.max(session.maxProgressSeconds, nextTime);
-  }, []);
+  }, [audio]);
 
   useEffect(() => {
     syncSession(currentTrack, playSource);
@@ -132,6 +138,5 @@ export function usePlayEventTracker(
     flushCurrentPlayEvent,
     markSeekPosition,
     recordProgress,
-    syncSession,
   };
 }

--- a/app/listen/src/contexts/use-play-event-tracker.ts
+++ b/app/listen/src/contexts/use-play-event-tracker.ts
@@ -1,0 +1,137 @@
+import { useCallback, useEffect, useRef } from "react";
+
+import type { PlaySource, Track } from "@/contexts/player-types";
+import { getTrackCacheKey } from "@/contexts/player-utils";
+
+interface PlayEventSession {
+  trackKey: string;
+  track: Track;
+  playSource: PlaySource | null;
+  startedAt: string;
+  lastKnownTime: number;
+  listenedSeconds: number;
+  maxProgressSeconds: number;
+}
+
+type FlushReason = "completed" | "skipped" | "interrupted";
+
+const PLAY_EVENT_MIN_SECONDS = 2;
+const PLAY_EVENT_DELTA_CAP_SECONDS = 5;
+
+function nowIso(): string {
+  return new Date().toISOString();
+}
+
+export function usePlayEventTracker(
+  audio: HTMLAudioElement,
+  currentTrack: Track | undefined,
+  playSource: PlaySource | null,
+) {
+  const sessionRef = useRef<PlayEventSession | null>(null);
+
+  const syncSession = useCallback((track: Track | undefined, source: PlaySource | null) => {
+    if (!track) {
+      sessionRef.current = null;
+      return;
+    }
+
+    const trackKey = getTrackCacheKey(track);
+    const existing = sessionRef.current;
+    if (existing?.trackKey === trackKey) {
+      existing.playSource = source;
+      return;
+    }
+
+    sessionRef.current = {
+      trackKey,
+      track,
+      playSource: source,
+      startedAt: nowIso(),
+      lastKnownTime: audio.currentTime || 0,
+      listenedSeconds: 0,
+      maxProgressSeconds: audio.currentTime || 0,
+    };
+  }, [audio]);
+
+  const flushCurrentPlayEvent = useCallback((reason: FlushReason) => {
+    const session = sessionRef.current;
+    if (!session) return;
+    sessionRef.current = null;
+
+    const trackDurationSeconds = Number.isFinite(audio.duration) && audio.duration > 0
+      ? audio.duration
+      : null;
+    const playedSeconds = Math.max(0, session.listenedSeconds);
+
+    if (playedSeconds < PLAY_EVENT_MIN_SECONDS && reason !== "completed") {
+      return;
+    }
+
+    const completionRatio = trackDurationSeconds && trackDurationSeconds > 0
+      ? Math.min(1, playedSeconds / trackDurationSeconds)
+      : null;
+    const wasCompleted = reason === "completed" || (completionRatio !== null && completionRatio >= 0.9);
+    const wasSkipped = reason === "skipped" || (!wasCompleted && playedSeconds >= PLAY_EVENT_MIN_SECONDS);
+
+    fetch("/api/me/play-events", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      credentials: "include",
+      body: JSON.stringify({
+        track_id: session.track.libraryTrackId ?? null,
+        track_path: session.track.path || session.track.id,
+        title: session.track.title,
+        artist: session.track.artist,
+        album: session.track.album || "",
+        started_at: session.startedAt,
+        ended_at: nowIso(),
+        played_seconds: playedSeconds,
+        track_duration_seconds: trackDurationSeconds,
+        completion_ratio: completionRatio,
+        was_skipped: wasSkipped,
+        was_completed: wasCompleted,
+        play_source_type: session.playSource?.type ?? null,
+        play_source_id: session.playSource?.id != null ? String(session.playSource.id) : null,
+        play_source_name: session.playSource?.name ?? null,
+        context_artist: session.track.artist,
+        context_album: session.track.album || null,
+        context_playlist_id:
+          session.playSource?.type === "playlist" && typeof session.playSource.id === "number"
+            ? session.playSource.id
+            : null,
+        device_type: "web",
+        app_platform: "listen-web",
+      }),
+    }).catch(() => {});
+  }, [audio.duration]);
+
+  const recordProgress = useCallback((nextTime: number) => {
+    const session = sessionRef.current;
+    if (!session) return;
+
+    const delta = nextTime - session.lastKnownTime;
+    if (delta > 0 && delta <= PLAY_EVENT_DELTA_CAP_SECONDS) {
+      session.listenedSeconds += delta;
+    }
+    session.lastKnownTime = nextTime;
+    session.maxProgressSeconds = Math.max(session.maxProgressSeconds, nextTime);
+  }, []);
+
+  const markSeekPosition = useCallback((nextTime: number) => {
+    const session = sessionRef.current;
+    if (!session) return;
+    session.lastKnownTime = nextTime;
+    session.maxProgressSeconds = Math.max(session.maxProgressSeconds, nextTime);
+  }, []);
+
+  useEffect(() => {
+    syncSession(currentTrack, playSource);
+  }, [currentTrack, playSource, syncSession]);
+
+  return {
+    flushCurrentPlayEvent,
+    markSeekPosition,
+    recordProgress,
+    syncSession,
+  };
+}

--- a/app/listen/src/contexts/use-playback-intelligence.ts
+++ b/app/listen/src/contexts/use-playback-intelligence.ts
@@ -3,7 +3,7 @@ import { useCallback, useEffect, useRef } from "react";
 import type { Dispatch, MutableRefObject, SetStateAction } from "react";
 
 import type { PlaySource, Track } from "@/contexts/player-types";
-import { getTrackCacheKey } from "@/contexts/player-utils";
+import { areTracksFromSameAlbum, getTrackCacheKey } from "@/contexts/player-utils";
 import { fetchInfiniteContinuation, fetchRadioContinuation } from "@/lib/radio";
 
 const RADIO_REFILL_THRESHOLD = 3;
@@ -36,15 +36,7 @@ function collectUniqueTracks(candidates: Track[], queue: Track[], recent: Track[
 }
 
 function isLikelyContinuousAlbumBlock(currentTrack: Track | undefined, nextTrack: Track | undefined): boolean {
-  if (!currentTrack || !nextTrack) return false;
-  return (
-    !!currentTrack.album &&
-    !!nextTrack.album &&
-    !!currentTrack.artist &&
-    !!nextTrack.artist &&
-    currentTrack.album === nextTrack.album &&
-    currentTrack.artist === nextTrack.artist
-  );
+  return areTracksFromSameAlbum(currentTrack, nextTrack);
 }
 
 interface UsePlaybackIntelligenceOptions {
@@ -90,6 +82,10 @@ export function usePlaybackIntelligence({
   const continuationSignatureRef = useRef<string | null>(null);
   const playlistSuggestionInFlightRef = useRef(false);
   const playlistSuggestionSignatureRef = useRef<string | null>(null);
+  const radioRefillAbortRef = useRef<AbortController | null>(null);
+  const continuationPrefetchAbortRef = useRef<AbortController | null>(null);
+  const continuationManualAbortRef = useRef<AbortController | null>(null);
+  const playlistSuggestionAbortRef = useRef<AbortController | null>(null);
   const currentIndexRef = useRef(currentIndex);
   const playSourceRef = useRef(playSource);
   const queueRef = useRef(queue);
@@ -103,9 +99,21 @@ export function usePlaybackIntelligence({
   }, [currentIndex, playSource, queue, recentlyPlayed]);
 
   const resetPlaybackIntelligence = useCallback(() => {
+    radioRefillAbortRef.current?.abort();
+    continuationPrefetchAbortRef.current?.abort();
+    continuationManualAbortRef.current?.abort();
+    playlistSuggestionAbortRef.current?.abort();
+    radioRefillAbortRef.current = null;
+    continuationPrefetchAbortRef.current = null;
+    continuationManualAbortRef.current = null;
+    playlistSuggestionAbortRef.current = null;
+    radioRefillInFlightRef.current = false;
+    continuationInFlightRef.current = false;
+    playlistSuggestionInFlightRef.current = false;
     radioRefillSignatureRef.current = null;
     continuationSignatureRef.current = null;
     playlistSuggestionSignatureRef.current = null;
+    shouldAutoplayRef.current = false;
   }, []);
 
   useEffect(() => {
@@ -129,6 +137,7 @@ export function usePlaybackIntelligence({
     radioRefillSignatureRef.current = signature;
     radioRefillInFlightRef.current = true;
     const controller = new AbortController();
+    radioRefillAbortRef.current = controller;
 
     fetchRadioContinuation(playSource, RADIO_REFILL_BATCH_SIZE, { signal: controller.signal })
       .then((tracks) => {
@@ -150,10 +159,16 @@ export function usePlaybackIntelligence({
         if (!controller.signal.aborted) {
           radioRefillInFlightRef.current = false;
         }
+        if (radioRefillAbortRef.current === controller) {
+          radioRefillAbortRef.current = null;
+        }
       });
 
     return () => {
       controller.abort();
+      if (radioRefillAbortRef.current === controller) {
+        radioRefillAbortRef.current = null;
+      }
       radioRefillInFlightRef.current = false;
     };
   }, [currentIndex, isPlaying, playSource, queue.length, setQueue]);
@@ -182,6 +197,7 @@ export function usePlaybackIntelligence({
     continuationSignatureRef.current = signature;
     continuationInFlightRef.current = true;
     const controller = new AbortController();
+    continuationPrefetchAbortRef.current = controller;
 
     fetchInfiniteContinuation(playSource!, RADIO_REFILL_BATCH_SIZE, { signal: controller.signal })
       .then((tracks) => {
@@ -204,10 +220,16 @@ export function usePlaybackIntelligence({
         if (!controller.signal.aborted) {
           continuationInFlightRef.current = false;
         }
+        if (continuationPrefetchAbortRef.current === controller) {
+          continuationPrefetchAbortRef.current = null;
+        }
       });
 
     return () => {
       controller.abort();
+      if (continuationPrefetchAbortRef.current === controller) {
+        continuationPrefetchAbortRef.current = null;
+      }
       continuationInFlightRef.current = false;
     };
   }, [currentIndex, infinitePlaybackEnabled, playSource, queue.length, setQueue, shuffle]);
@@ -268,6 +290,7 @@ export function usePlaybackIntelligence({
     playlistSuggestionSignatureRef.current = signature;
     playlistSuggestionInFlightRef.current = true;
     const controller = new AbortController();
+    playlistSuggestionAbortRef.current = controller;
 
     fetchInfiniteContinuation(playSource!, SMART_PLAYLIST_SUGGESTION_BATCH_SIZE, { signal: controller.signal })
       .then((tracks) => {
@@ -316,10 +339,16 @@ export function usePlaybackIntelligence({
         if (!controller.signal.aborted) {
           playlistSuggestionInFlightRef.current = false;
         }
+        if (playlistSuggestionAbortRef.current === controller) {
+          playlistSuggestionAbortRef.current = null;
+        }
       });
 
     return () => {
       controller.abort();
+      if (playlistSuggestionAbortRef.current === controller) {
+        playlistSuggestionAbortRef.current = null;
+      }
       playlistSuggestionInFlightRef.current = false;
     };
   }, [
@@ -353,25 +382,33 @@ export function usePlaybackIntelligence({
     setIsBuffering(true);
     continuationSignatureRef.current = requestSignature;
     continuationInFlightRef.current = true;
+    continuationManualAbortRef.current?.abort();
+    const controller = new AbortController();
+    continuationManualAbortRef.current = controller;
 
-    fetchInfiniteContinuation(playSource, RADIO_REFILL_BATCH_SIZE)
+    fetchInfiniteContinuation(playSource, RADIO_REFILL_BATCH_SIZE, { signal: controller.signal })
       .then((tracks) => {
+        if (controller.signal.aborted) return;
         if (continuationSignatureRef.current !== requestSignature) {
           setIsBuffering(false);
+          shouldAutoplayRef.current = false;
           return;
         }
         if (getPlaySourceSignature(playSourceRef.current) !== sessionSignature) {
           setIsBuffering(false);
+          shouldAutoplayRef.current = false;
           return;
         }
         if (!tracks.length) {
           setIsBuffering(false);
+          shouldAutoplayRef.current = false;
           return;
         }
 
         const uniqueTracks = collectUniqueTracks(tracks, queueRef.current, recentlyPlayedRef.current);
         if (uniqueTracks.length === 0) {
           setIsBuffering(false);
+          shouldAutoplayRef.current = false;
           return;
         }
 
@@ -392,13 +429,20 @@ export function usePlaybackIntelligence({
         setDuration(0);
       })
       .catch((error) => {
+        if (controller.signal.aborted) return;
         console.warn("[player] continuation after end failed:", error);
         if (continuationSignatureRef.current === requestSignature) {
           setIsBuffering(false);
+          shouldAutoplayRef.current = false;
         }
       })
       .finally(() => {
-        continuationInFlightRef.current = false;
+        if (continuationManualAbortRef.current === controller) {
+          continuationManualAbortRef.current = null;
+        }
+        if (!controller.signal.aborted) {
+          continuationInFlightRef.current = false;
+        }
         if (continuationSignatureRef.current === requestSignature) {
           continuationSignatureRef.current = null;
         }
@@ -408,7 +452,6 @@ export function usePlaybackIntelligence({
   }, [
     infinitePlaybackEnabled,
     playSource,
-    queue.length,
     setCurrentIndex,
     setCurrentTime,
     setDuration,

--- a/app/listen/src/contexts/use-playback-intelligence.ts
+++ b/app/listen/src/contexts/use-playback-intelligence.ts
@@ -1,0 +1,426 @@
+import { useCallback, useEffect, useRef } from "react";
+
+import type { Dispatch, MutableRefObject, SetStateAction } from "react";
+
+import type { PlaySource, Track } from "@/contexts/player-types";
+import { getTrackCacheKey } from "@/contexts/player-utils";
+import { fetchInfiniteContinuation, fetchRadioContinuation } from "@/lib/radio";
+
+const RADIO_REFILL_THRESHOLD = 3;
+const RADIO_REFILL_BATCH_SIZE = 30;
+const SMART_PLAYLIST_SUGGESTION_BATCH_SIZE = 12;
+
+function getPlaySourceSignature(source: PlaySource | null): string | null {
+  if (!source) return null;
+  return [
+    source.type,
+    source.name,
+    source.radio?.seedType ?? "",
+    source.radio?.seedId ?? "",
+    source.radio?.seedPath ?? "",
+  ].join("::");
+}
+
+function collectUniqueTracks(candidates: Track[], queue: Track[], recent: Track[]): Track[] {
+  const existingKeys = new Set(
+    [...queue, ...recent].map((track) => getTrackCacheKey(track)),
+  );
+  const uniqueTracks: Track[] = [];
+  for (const track of candidates) {
+    const key = getTrackCacheKey(track);
+    if (!key || existingKeys.has(key)) continue;
+    existingKeys.add(key);
+    uniqueTracks.push(track);
+  }
+  return uniqueTracks;
+}
+
+function isLikelyContinuousAlbumBlock(currentTrack: Track | undefined, nextTrack: Track | undefined): boolean {
+  if (!currentTrack || !nextTrack) return false;
+  return (
+    !!currentTrack.album &&
+    !!nextTrack.album &&
+    !!currentTrack.artist &&
+    !!nextTrack.artist &&
+    currentTrack.album === nextTrack.album &&
+    currentTrack.artist === nextTrack.artist
+  );
+}
+
+interface UsePlaybackIntelligenceOptions {
+  queue: Track[];
+  currentIndex: number;
+  isPlaying: boolean;
+  playSource: PlaySource | null;
+  shuffle: boolean;
+  infinitePlaybackEnabled: boolean;
+  smartPlaylistSuggestionsEnabled: boolean;
+  smartPlaylistSuggestionsCadence: number;
+  recentlyPlayed: Track[];
+  shouldAutoplayRef: MutableRefObject<boolean>;
+  setQueue: Dispatch<SetStateAction<Track[]>>;
+  setCurrentIndex: Dispatch<SetStateAction<number>>;
+  setCurrentTime: Dispatch<SetStateAction<number>>;
+  setDuration: Dispatch<SetStateAction<number>>;
+  setIsPlaying: Dispatch<SetStateAction<boolean>>;
+  setIsBuffering: Dispatch<SetStateAction<boolean>>;
+}
+
+export function usePlaybackIntelligence({
+  queue,
+  currentIndex,
+  isPlaying,
+  playSource,
+  shuffle,
+  infinitePlaybackEnabled,
+  smartPlaylistSuggestionsEnabled,
+  smartPlaylistSuggestionsCadence,
+  recentlyPlayed,
+  shouldAutoplayRef,
+  setQueue,
+  setCurrentIndex,
+  setCurrentTime,
+  setDuration,
+  setIsPlaying,
+  setIsBuffering,
+}: UsePlaybackIntelligenceOptions) {
+  const radioRefillInFlightRef = useRef(false);
+  const radioRefillSignatureRef = useRef<string | null>(null);
+  const continuationInFlightRef = useRef(false);
+  const continuationSignatureRef = useRef<string | null>(null);
+  const playlistSuggestionInFlightRef = useRef(false);
+  const playlistSuggestionSignatureRef = useRef<string | null>(null);
+  const currentIndexRef = useRef(currentIndex);
+  const playSourceRef = useRef(playSource);
+  const queueRef = useRef(queue);
+  const recentlyPlayedRef = useRef(recentlyPlayed);
+
+  useEffect(() => {
+    currentIndexRef.current = currentIndex;
+    playSourceRef.current = playSource;
+    queueRef.current = queue;
+    recentlyPlayedRef.current = recentlyPlayed;
+  }, [currentIndex, playSource, queue, recentlyPlayed]);
+
+  const resetPlaybackIntelligence = useCallback(() => {
+    radioRefillSignatureRef.current = null;
+    continuationSignatureRef.current = null;
+    playlistSuggestionSignatureRef.current = null;
+  }, []);
+
+  useEffect(() => {
+    const currentTrack = queue[currentIndex];
+    if (!isPlaying || !currentTrack) return;
+    if (playSource?.type !== "radio" || !playSource.radio) return;
+
+    const remainingUpcoming = queue.length - currentIndex - 1;
+    if (remainingUpcoming > RADIO_REFILL_THRESHOLD) {
+      radioRefillSignatureRef.current = null;
+      return;
+    }
+    if (radioRefillInFlightRef.current) return;
+
+    const signature = [
+      getPlaySourceSignature(playSource),
+      currentTrack.id,
+      queue.length,
+    ].join("::");
+    if (radioRefillSignatureRef.current === signature) return;
+    radioRefillSignatureRef.current = signature;
+    radioRefillInFlightRef.current = true;
+    const controller = new AbortController();
+
+    fetchRadioContinuation(playSource, RADIO_REFILL_BATCH_SIZE, { signal: controller.signal })
+      .then((tracks) => {
+        if (controller.signal.aborted) return;
+        if (radioRefillSignatureRef.current !== signature) return;
+        if (getPlaySourceSignature(playSourceRef.current) !== getPlaySourceSignature(playSource)) return;
+        setQueue((prev) => {
+          if (radioRefillSignatureRef.current !== signature) return prev;
+          if (getPlaySourceSignature(playSourceRef.current) !== getPlaySourceSignature(playSource)) return prev;
+          const uniqueTracks = collectUniqueTracks(tracks, prev, recentlyPlayedRef.current);
+          return uniqueTracks.length > 0 ? [...prev, ...uniqueTracks] : prev;
+        });
+      })
+      .catch((error) => {
+        if (controller.signal.aborted) return;
+        console.warn("[player] radio refill failed:", error);
+      })
+      .finally(() => {
+        if (!controller.signal.aborted) {
+          radioRefillInFlightRef.current = false;
+        }
+      });
+
+    return () => {
+      controller.abort();
+      radioRefillInFlightRef.current = false;
+    };
+  }, [currentIndex, isPlaying, playSource, queue.length, setQueue]);
+
+  useEffect(() => {
+    const currentTrack = queue[currentIndex];
+    const supportsContinuation =
+      infinitePlaybackEnabled &&
+      !shuffle &&
+      !!currentTrack &&
+      (playSource?.type === "album" || playSource?.type === "playlist") &&
+      !!playSource?.radio?.seedId;
+
+    if (!supportsContinuation) return;
+
+    const remainingUpcoming = queue.length - currentIndex - 1;
+    if (remainingUpcoming > RADIO_REFILL_THRESHOLD) {
+      continuationSignatureRef.current = null;
+      return;
+    }
+    if (continuationInFlightRef.current) return;
+
+    const sessionSignature = getPlaySourceSignature(playSource);
+    const signature = [sessionSignature, currentTrack?.id ?? "", queue.length].join("::");
+    if (continuationSignatureRef.current === signature) return;
+    continuationSignatureRef.current = signature;
+    continuationInFlightRef.current = true;
+    const controller = new AbortController();
+
+    fetchInfiniteContinuation(playSource!, RADIO_REFILL_BATCH_SIZE, { signal: controller.signal })
+      .then((tracks) => {
+        if (controller.signal.aborted) return;
+        if (!tracks.length) return;
+        if (continuationSignatureRef.current !== signature) return;
+        if (getPlaySourceSignature(playSourceRef.current) !== sessionSignature) return;
+        setQueue((prev) => {
+          if (continuationSignatureRef.current !== signature) return prev;
+          if (getPlaySourceSignature(playSourceRef.current) !== sessionSignature) return prev;
+          const uniqueTracks = collectUniqueTracks(tracks, prev, recentlyPlayedRef.current);
+          return uniqueTracks.length > 0 ? [...prev, ...uniqueTracks] : prev;
+        });
+      })
+      .catch((error) => {
+        if (controller.signal.aborted) return;
+        console.warn("[player] continuation refill failed:", error);
+      })
+      .finally(() => {
+        if (!controller.signal.aborted) {
+          continuationInFlightRef.current = false;
+        }
+      });
+
+    return () => {
+      controller.abort();
+      continuationInFlightRef.current = false;
+    };
+  }, [currentIndex, infinitePlaybackEnabled, playSource, queue.length, setQueue, shuffle]);
+
+  useEffect(() => {
+    const currentTrack = queue[currentIndex];
+    const nextTrack = queue[currentIndex + 1];
+    const supportsSmartInclusion =
+      smartPlaylistSuggestionsEnabled &&
+      !shuffle &&
+      !!currentTrack &&
+      playSource?.type === "playlist" &&
+      !!playSource?.radio?.seedId;
+
+    if (!supportsSmartInclusion) {
+      playlistSuggestionSignatureRef.current = null;
+      return;
+    }
+    if (currentTrack?.isSuggested) {
+      playlistSuggestionSignatureRef.current = null;
+      return;
+    }
+    if (isLikelyContinuousAlbumBlock(currentTrack, nextTrack)) {
+      playlistSuggestionSignatureRef.current = null;
+      return;
+    }
+
+    const playedOriginalCount = queue
+      .slice(0, currentIndex + 1)
+      .filter((track) => !track.isSuggested).length;
+
+    if (
+      playedOriginalCount === 0 ||
+      playedOriginalCount % smartPlaylistSuggestionsCadence !== 0
+    ) {
+      playlistSuggestionSignatureRef.current = null;
+      return;
+    }
+
+    if (nextTrack?.isSuggested) {
+      playlistSuggestionSignatureRef.current = [
+        playSource?.radio?.seedId ?? "",
+        playedOriginalCount,
+        currentTrack?.id ?? "",
+      ].join("::");
+      return;
+    }
+
+    if (playlistSuggestionInFlightRef.current) return;
+
+    const signature = [
+      playSource?.radio?.seedId ?? "",
+      playedOriginalCount,
+      currentTrack?.id ?? "",
+      queue.length,
+    ].join("::");
+    if (playlistSuggestionSignatureRef.current === signature) return;
+    playlistSuggestionSignatureRef.current = signature;
+    playlistSuggestionInFlightRef.current = true;
+    const controller = new AbortController();
+
+    fetchInfiniteContinuation(playSource!, SMART_PLAYLIST_SUGGESTION_BATCH_SIZE, { signal: controller.signal })
+      .then((tracks) => {
+        if (controller.signal.aborted) return;
+        if (!tracks.length) return;
+        if (playlistSuggestionSignatureRef.current !== signature) return;
+        const expectedSeedId = playSource?.radio?.seedId ?? null;
+        setQueue((prev) => {
+          if (playlistSuggestionSignatureRef.current !== signature) return prev;
+          const latestSource = playSourceRef.current;
+          const insertionIndex = currentIndexRef.current + 1;
+          if (
+            latestSource?.type !== "playlist" ||
+            latestSource?.radio?.seedId !== expectedSeedId ||
+            insertionIndex <= 0 ||
+            insertionIndex > prev.length
+          ) {
+            return prev;
+          }
+
+          const existingKeys = new Set(
+            [...prev, ...recentlyPlayedRef.current].map((track) => getTrackCacheKey(track)),
+          );
+          const suggestion = tracks.find((track) => {
+            const key = getTrackCacheKey(track);
+            if (!key || existingKeys.has(key)) return false;
+            return true;
+          });
+          if (!suggestion) return prev;
+          if (prev[insertionIndex]?.isSuggested) return prev;
+
+          const nextQueue = [...prev];
+          nextQueue.splice(insertionIndex, 0, {
+            ...suggestion,
+            isSuggested: true,
+            suggestionSource: "playlist",
+          });
+          return nextQueue;
+        });
+      })
+      .catch((error) => {
+        if (controller.signal.aborted) return;
+        console.warn("[player] playlist suggestion failed:", error);
+      })
+      .finally(() => {
+        if (!controller.signal.aborted) {
+          playlistSuggestionInFlightRef.current = false;
+        }
+      });
+
+    return () => {
+      controller.abort();
+      playlistSuggestionInFlightRef.current = false;
+    };
+  }, [
+    currentIndex,
+    playSource,
+    queue,
+    setQueue,
+    shuffle,
+    smartPlaylistSuggestionsCadence,
+    smartPlaylistSuggestionsEnabled,
+  ]);
+
+  const continueInfinitePlayback = useCallback(() => {
+    if (
+      !infinitePlaybackEnabled ||
+      shuffle ||
+      (playSource?.type !== "album" && playSource?.type !== "playlist") ||
+      !playSource?.radio?.seedId
+    ) {
+      return false;
+    }
+    if (continuationInFlightRef.current) {
+      return false;
+    }
+
+    const sessionSignature = getPlaySourceSignature(playSource);
+    const requestSignature = [sessionSignature, currentIndexRef.current, queueRef.current.length, "manual"].join("::");
+
+    shouldAutoplayRef.current = false;
+    setIsPlaying(false);
+    setIsBuffering(true);
+    continuationSignatureRef.current = requestSignature;
+    continuationInFlightRef.current = true;
+
+    fetchInfiniteContinuation(playSource, RADIO_REFILL_BATCH_SIZE)
+      .then((tracks) => {
+        if (continuationSignatureRef.current !== requestSignature) {
+          setIsBuffering(false);
+          return;
+        }
+        if (getPlaySourceSignature(playSourceRef.current) !== sessionSignature) {
+          setIsBuffering(false);
+          return;
+        }
+        if (!tracks.length) {
+          setIsBuffering(false);
+          return;
+        }
+
+        const uniqueTracks = collectUniqueTracks(tracks, queueRef.current, recentlyPlayedRef.current);
+        if (uniqueTracks.length === 0) {
+          setIsBuffering(false);
+          return;
+        }
+
+        setQueue((prev) => {
+          if (continuationSignatureRef.current !== requestSignature) return prev;
+          if (getPlaySourceSignature(playSourceRef.current) !== sessionSignature) return prev;
+          const stillUnique = collectUniqueTracks(uniqueTracks, prev, recentlyPlayedRef.current);
+          return stillUnique.length > 0 ? [...prev, ...stillUnique] : prev;
+        });
+
+        shouldAutoplayRef.current = true;
+        setCurrentIndex((index) => {
+          if (continuationSignatureRef.current !== requestSignature) return index;
+          if (getPlaySourceSignature(playSourceRef.current) !== sessionSignature) return index;
+          return index + 1;
+        });
+        setCurrentTime(0);
+        setDuration(0);
+      })
+      .catch((error) => {
+        console.warn("[player] continuation after end failed:", error);
+        if (continuationSignatureRef.current === requestSignature) {
+          setIsBuffering(false);
+        }
+      })
+      .finally(() => {
+        continuationInFlightRef.current = false;
+        if (continuationSignatureRef.current === requestSignature) {
+          continuationSignatureRef.current = null;
+        }
+      });
+
+    return true;
+  }, [
+    infinitePlaybackEnabled,
+    playSource,
+    queue.length,
+    setCurrentIndex,
+    setCurrentTime,
+    setDuration,
+    setIsBuffering,
+    setIsPlaying,
+    setQueue,
+    shuffle,
+    shouldAutoplayRef,
+  ]);
+
+  return {
+    continueInfinitePlayback,
+    resetPlaybackIntelligence,
+  };
+}

--- a/app/listen/src/contexts/use-player-shortcuts.ts
+++ b/app/listen/src/contexts/use-player-shortcuts.ts
@@ -1,0 +1,92 @@
+import { useEffect } from "react";
+
+interface UsePlayerShortcutsOptions {
+  hasCurrentTrack: boolean;
+  isPlaying: boolean;
+  audio: HTMLAudioElement;
+  duration: number;
+  volume: number;
+  lastNonZeroVolume: number;
+  pause: () => void;
+  resume: () => void;
+  next: () => void;
+  prev: () => void;
+  seek: (time: number) => void;
+  setVolume: (vol: number) => void;
+}
+
+export function usePlayerShortcuts({
+  hasCurrentTrack,
+  isPlaying,
+  audio,
+  duration,
+  volume,
+  lastNonZeroVolume,
+  pause,
+  resume,
+  next,
+  prev,
+  seek,
+  setVolume,
+}: UsePlayerShortcutsOptions) {
+  useEffect(() => {
+    const isTypingTarget = (target: EventTarget | null) => {
+      const el = target as HTMLElement | null;
+      if (!el) return false;
+      const tag = el.tagName;
+      return (
+        el.isContentEditable ||
+        tag === "INPUT" ||
+        tag === "TEXTAREA" ||
+        tag === "SELECT" ||
+        tag === "BUTTON"
+      );
+    };
+
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.defaultPrevented || event.metaKey || event.ctrlKey || event.altKey) return;
+      if (isTypingTarget(event.target)) return;
+      if (!hasCurrentTrack) return;
+
+      if (event.code === "Space" || event.key.toLowerCase() === "k") {
+        event.preventDefault();
+        if (isPlaying) pause();
+        else resume();
+        return;
+      }
+
+      if (event.shiftKey && event.key === "ArrowRight") {
+        event.preventDefault();
+        next();
+        return;
+      }
+
+      if (event.shiftKey && event.key === "ArrowLeft") {
+        event.preventDefault();
+        prev();
+        return;
+      }
+
+      if (event.key === "ArrowRight") {
+        event.preventDefault();
+        seek(Math.min(audio.duration || duration || 0, audio.currentTime + 10));
+        return;
+      }
+
+      if (event.key === "ArrowLeft") {
+        event.preventDefault();
+        seek(Math.max(0, audio.currentTime - 10));
+        return;
+      }
+
+      if (event.key.toLowerCase() === "m") {
+        event.preventDefault();
+        if (volume === 0) setVolume(lastNonZeroVolume || 0.8);
+        else setVolume(0);
+      }
+    };
+
+    window.addEventListener("keydown", onKeyDown);
+    return () => window.removeEventListener("keydown", onKeyDown);
+  }, [audio, duration, hasCurrentTrack, isPlaying, lastNonZeroVolume, next, pause, prev, resume, seek, setVolume, volume]);
+}

--- a/app/listen/src/lib/upcoming.ts
+++ b/app/listen/src/lib/upcoming.ts
@@ -1,0 +1,30 @@
+import type { Track } from "@/contexts/PlayerContext";
+import { api } from "@/lib/api";
+import { encPath } from "@/lib/utils";
+
+export async function fetchPlayableSetlist(artist: string): Promise<Track[]> {
+  const response = await api<{
+    tracks: {
+      library_track_id: number;
+      title: string;
+      artist: string;
+      album: string;
+      path: string;
+      duration?: number;
+      navidrome_id?: string;
+    }[];
+  }>(`/api/artist/${encPath(artist)}/setlist-playable`);
+
+  return (response.tracks || []).map((track) => ({
+    id: track.path || track.navidrome_id || String(track.library_track_id),
+    title: track.title,
+    artist: track.artist,
+    album: track.album,
+    albumCover: track.album
+      ? `/api/cover/${encPath(track.artist)}/${encPath(track.album)}`
+      : `/api/artist/${encPath(track.artist)}/photo`,
+    path: track.path || undefined,
+    navidromeId: track.navidrome_id || undefined,
+    libraryTrackId: track.library_track_id,
+  }));
+}

--- a/app/listen/src/pages/Artist.tsx
+++ b/app/listen/src/pages/Artist.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useState } from "react";
 import { useNavigate, useParams } from "react-router";
 import {
+  Calendar,
   ChevronDown,
   Play,
   Radio,
@@ -18,6 +19,7 @@ import { ArtistCard } from "@/components/cards/ArtistCard";
 import {
   artistShowToUpcomingItem,
   groupByMonth,
+  itemKey,
   UpcomingMonthGroup,
   type ArtistShowEvent,
 } from "@/components/upcoming/UpcomingRows";
@@ -25,6 +27,7 @@ import { AppModal, ModalBody, ModalCloseButton, ModalHeader } from "@/components
 import { usePlayerActions, type Track } from "@/contexts/PlayerContext";
 import { useApi } from "@/hooks/use-api";
 import { api } from "@/lib/api";
+import { fetchPlayableSetlist } from "@/lib/upcoming";
 import { fetchArtistRadio } from "@/lib/radio";
 import { encPath, formatCompact } from "@/lib/utils";
 
@@ -66,6 +69,18 @@ interface ArtistTopTrack {
   album: string;
   duration: number;
   track: number;
+}
+
+interface StatsArtist {
+  artist_name: string;
+  play_count: number;
+  complete_play_count: number;
+  minutes_listened: number;
+}
+
+interface StatsListResponse<T> {
+  window: string;
+  items: T[];
 }
 
 function shuffleArray<T>(items: T[]): T[] {
@@ -139,6 +154,9 @@ export function Artist() {
   );
   const { data: showsData } = useApi<{ events: ArtistShowEvent[] }>(
     decodedName ? `/api/artist/${encPath(decodedName)}/shows?limit=12` : null,
+  );
+  const { data: topArtistsStats } = useApi<StatsListResponse<StatsArtist>>(
+    decodedName ? "/api/me/stats/top-artists?window=30d&limit=12" : null,
   );
 
   const coverFallback = data?.albums?.[0]
@@ -217,6 +235,25 @@ export function Artist() {
     .slice(0, 5);
   const hasShows = visibleShowItems.length > 0;
   const hasRelated = similarArtists.length > 0;
+  const attendingArtistShows = visibleShowItems.filter((item) => item.user_attending);
+  const nextAttendingArtistShow = attendingArtistShows[0];
+  const artistHotNow = Boolean(
+    topArtistsStats?.items?.some((item) => item.artist_name.toLowerCase() === decodedName.toLowerCase()),
+  );
+
+  async function handlePlayArtistSetlist() {
+    try {
+      const queue = await fetchPlayableSetlist(decodedName);
+      if (!queue.length) {
+        toast.info("No probable setlist tracks matched your library");
+        return;
+      }
+      playAll(queue, 0, { type: "playlist", name: `${decodedName} Probable Setlist` });
+      toast.success(`Playing probable setlist: ${queue.length} tracks`);
+    } catch {
+      toast.error("Failed to load probable setlist");
+    }
+  }
 
   useEffect(() => {
     if (!similarArtists.length) {
@@ -442,7 +479,61 @@ export function Artist() {
 
         {hasShows && (
           <section>
-            <h2 className="text-lg font-semibold text-foreground mb-4">Shows</h2>
+            <div className="space-y-4 mb-4">
+              <div className="flex items-center justify-between gap-4">
+                <h2 className="text-lg font-semibold text-foreground">Shows</h2>
+                {artistHotNow ? (
+                  <div className="rounded-full border border-primary/20 bg-primary/10 px-3 py-1 text-[11px] uppercase tracking-[0.16em] text-primary">
+                    Heavy rotation
+                  </div>
+                ) : null}
+              </div>
+
+              {nextAttendingArtistShow ? (
+                <div className="rounded-[24px] border border-primary/15 bg-[radial-gradient(circle_at_top_left,rgba(6,182,212,0.14),transparent_40%),rgba(255,255,255,0.03)] p-5">
+                  <div className="flex flex-col gap-4 lg:flex-row lg:items-end lg:justify-between">
+                    <div>
+                      <div className="inline-flex items-center gap-2 rounded-full border border-primary/20 bg-primary/10 px-3 py-1 text-[10px] font-medium uppercase tracking-[0.16em] text-primary">
+                        <Calendar size={12} />
+                        Show prep
+                      </div>
+                      <h3 className="mt-3 text-xl font-bold text-foreground">{nextAttendingArtistShow.title}</h3>
+                      <p className="mt-1 text-sm text-muted-foreground">
+                        {nextAttendingArtistShow.subtitle} · {new Date(`${nextAttendingArtistShow.date}T12:00:00`).toLocaleDateString("en-US", {
+                          month: "long",
+                          day: "numeric",
+                          year: "numeric",
+                        })}
+                      </p>
+                      <p className="mt-3 text-sm leading-6 text-white/70">
+                        {nextAttendingArtistShow.probable_setlist?.length
+                          ? "You’re going to this show and we already have a probable setlist ready."
+                          : "You’re going to this show. As soon as a probable setlist is available, this becomes an instant prep surface."}
+                      </p>
+                    </div>
+
+                    <div className="flex flex-wrap gap-2">
+                      {nextAttendingArtistShow.probable_setlist?.length ? (
+                        <button
+                          onClick={() => void handlePlayArtistSetlist()}
+                          className="inline-flex items-center gap-2 rounded-full bg-primary px-4 py-2 text-sm font-medium text-primary-foreground transition-colors hover:bg-primary/90"
+                        >
+                          <Play size={14} fill="currentColor" />
+                          Play probable setlist
+                        </button>
+                      ) : null}
+                      <button
+                        onClick={() => setExpandedShowId(itemKey(nextAttendingArtistShow, 0))}
+                        className="inline-flex items-center gap-2 rounded-full border border-white/10 px-4 py-2 text-sm text-white/65 transition-colors hover:border-white/20 hover:text-foreground"
+                      >
+                        View show details
+                      </button>
+                    </div>
+                  </div>
+                </div>
+              ) : null}
+            </div>
+
             <div className="space-y-3">
               {groupByMonth(visibleShowItems).map(([month, monthItems]) => (
                 <UpcomingMonthGroup

--- a/app/listen/src/pages/Home.tsx
+++ b/app/listen/src/pages/Home.tsx
@@ -124,6 +124,26 @@ interface UpcomingResponse {
   };
 }
 
+interface ReplayTrack {
+  track_id: number | null;
+  track_path: string | null;
+  title: string;
+  artist: string;
+  album: string;
+  play_count: number;
+  complete_play_count: number;
+  minutes_listened: number;
+}
+
+interface ReplayMix {
+  window: string;
+  title: string;
+  subtitle: string;
+  track_count: number;
+  minutes_listened: number;
+  items: ReplayTrack[];
+}
+
 interface PlaylistDetailTrack {
   id?: number;
   track_id?: number;
@@ -351,6 +371,8 @@ export function Home() {
     useApi<UserPlaylist[]>("/api/playlists");
   const { data: upcoming } =
     useApi<UpcomingResponse>("/api/me/upcoming");
+  const { data: replay } =
+    useApi<ReplayMix>("/api/me/stats/replay?window=30d&limit=18");
 
   const continueItems = currentTrack
     ? [currentTrack, ...recentlyPlayed.filter((track) => track.id !== currentTrack.id)]
@@ -369,6 +391,7 @@ export function Home() {
       })
     : null;
   const homeInsights = (upcoming?.insights || []).slice(0, 2);
+  const replayPreview = (replay?.items || []).slice(0, 4);
   const libraryAdditions: LibraryAddition[] = [
     ...((playlists || []).map((playlist) => ({
       type: "playlist" as const,
@@ -474,6 +497,22 @@ export function Home() {
     } catch {
       toast.error("Failed to load probable setlist");
     }
+  }
+
+  function playReplayMix() {
+    if (!replay?.items?.length) return;
+    const queue: Track[] = replay.items.map((item) => ({
+      id: item.track_path || String(item.track_id || `${item.artist}-${item.title}`),
+      title: item.title,
+      artist: item.artist,
+      album: item.album,
+      path: item.track_path || undefined,
+      libraryTrackId: item.track_id || undefined,
+      albumCover: item.artist && item.album
+        ? `/api/cover/${encPath(item.artist)}/${encPath(item.album)}`
+        : undefined,
+    }));
+    playAll(queue, 0, { type: "playlist", name: replay.title });
   }
 
   return (
@@ -677,6 +716,87 @@ export function Home() {
                 </div>
               </div>
             ))}
+          </div>
+        </section>
+      ) : null}
+
+      {replayPreview.length > 0 ? (
+        <section className="space-y-4">
+          <SectionHeader
+            title={replay?.title || "Replay this month"}
+            subtitle={replay?.subtitle || "A playable recap of your current listening window."}
+            actionLabel="Open Stats"
+            onAction={() => navigate("/stats")}
+          />
+
+          <div className="grid gap-4 lg:grid-cols-[minmax(0,1fr)_minmax(320px,0.9fr)]">
+            <div className="overflow-hidden rounded-[28px] border border-white/10 bg-[radial-gradient(circle_at_top_left,rgba(6,182,212,0.14),transparent_42%),linear-gradient(180deg,rgba(255,255,255,0.05),rgba(255,255,255,0.02))] p-5">
+              <div className="inline-flex items-center gap-2 rounded-full border border-primary/20 bg-primary/10 px-3 py-1 text-[11px] font-medium uppercase tracking-[0.18em] text-primary">
+                <Sparkles size={12} />
+                Replay
+              </div>
+              <h2 className="mt-4 text-2xl font-bold text-foreground">{replay?.title}</h2>
+              <p className="mt-2 text-sm leading-6 text-muted-foreground">{replay?.subtitle}</p>
+              <div className="mt-4 flex flex-wrap gap-2">
+                <div className="rounded-2xl border border-white/10 bg-white/[0.04] px-3 py-2">
+                  <div className="text-[10px] uppercase tracking-[0.16em] text-white/35">Tracks</div>
+                  <div className="mt-1 text-sm font-semibold text-foreground">{replay?.track_count ?? 0}</div>
+                </div>
+                <div className="rounded-2xl border border-white/10 bg-white/[0.04] px-3 py-2">
+                  <div className="text-[10px] uppercase tracking-[0.16em] text-white/35">Time listened</div>
+                  <div className="mt-1 text-sm font-semibold text-foreground">
+                    {Math.round(replay?.minutes_listened ?? 0)}m
+                  </div>
+                </div>
+              </div>
+              <button
+                onClick={playReplayMix}
+                className="mt-5 inline-flex items-center gap-2 rounded-full bg-primary px-4 py-2 text-sm font-medium text-primary-foreground transition-colors hover:bg-primary/90"
+              >
+                <Play size={15} fill="currentColor" />
+                Play replay
+              </button>
+            </div>
+
+            <div className="overflow-hidden rounded-[28px] border border-white/10 bg-white/[0.03] p-4">
+              <div className="mb-3 flex items-center gap-2 text-[11px] uppercase tracking-wider text-white/40">
+                <Clock3 size={12} />
+                Replay picks
+              </div>
+              <div className="space-y-1">
+                {replayPreview.map((item) => (
+                  <button
+                    key={`${item.track_id ?? item.track_path ?? item.title}`}
+                    onClick={() =>
+                      play(
+                        {
+                          id: item.track_path || String(item.track_id || `${item.artist}-${item.title}`),
+                          title: item.title,
+                          artist: item.artist,
+                          album: item.album,
+                          path: item.track_path || undefined,
+                          libraryTrackId: item.track_id || undefined,
+                          albumCover: item.artist && item.album
+                            ? `/api/cover/${encPath(item.artist)}/${encPath(item.album)}`
+                            : undefined,
+                        },
+                        { type: "track", name: item.title },
+                      )
+                    }
+                    className="flex w-full items-center gap-3 rounded-2xl px-3 py-2 text-left transition-colors hover:bg-white/5"
+                  >
+                    <div className="flex h-11 w-11 shrink-0 items-center justify-center rounded-xl border border-white/10 bg-white/[0.03] text-sm font-semibold text-white/45">
+                      {item.play_count}
+                    </div>
+                    <div className="min-w-0 flex-1">
+                      <div className="truncate text-sm font-medium text-foreground">{item.title}</div>
+                      <div className="truncate text-xs text-muted-foreground">{item.artist}</div>
+                    </div>
+                    <Play size={15} className="shrink-0 text-white/30" />
+                  </button>
+                ))}
+              </div>
+            </div>
           </div>
         </section>
       ) : null}

--- a/app/listen/src/pages/Home.tsx
+++ b/app/listen/src/pages/Home.tsx
@@ -13,6 +13,7 @@ import { toast } from "sonner";
 
 import { useApi } from "@/hooks/use-api";
 import { api } from "@/lib/api";
+import { fetchPlayableSetlist } from "@/lib/upcoming";
 import { usePlayer, usePlayerActions, type Track } from "@/contexts/PlayerContext";
 import { AlbumCard } from "@/components/cards/AlbumCard";
 import { ArtistCard } from "@/components/cards/ArtistCard";
@@ -99,12 +100,27 @@ interface UpcomingItem {
   user_attending?: boolean;
 }
 
+interface UpcomingInsight {
+  type: "one_month" | "one_week" | "show_prep";
+  show_id: number;
+  artist: string;
+  date: string;
+  title: string;
+  subtitle: string;
+  message: string;
+  has_setlist?: boolean;
+  weight?: "normal" | "high";
+}
+
 interface UpcomingResponse {
   items: UpcomingItem[];
+  insights: UpcomingInsight[];
   summary: {
     followed_artists: number;
     show_count: number;
     release_count: number;
+    attending_count: number;
+    insight_count: number;
   };
 }
 
@@ -352,6 +368,7 @@ export function Home() {
         day: "numeric",
       })
     : null;
+  const homeInsights = (upcoming?.insights || []).slice(0, 2);
   const libraryAdditions: LibraryAddition[] = [
     ...((playlists || []).map((playlist) => ({
       type: "playlist" as const,
@@ -427,6 +444,35 @@ export function Home() {
       refetchFollowedCurated();
     } catch {
       toast.error("Failed to update playlist");
+    }
+  }
+
+  async function acknowledgeInsight(insight: UpcomingInsight) {
+    try {
+      await api(`/api/me/shows/${insight.show_id}/reminders`, "POST", {
+        reminder_type: insight.type,
+      });
+      toast.success("Saved for later");
+      navigate("/upcoming");
+    } catch {
+      toast.error("Failed to save reminder");
+    }
+  }
+
+  async function playInsightSetlist(insight: UpcomingInsight) {
+    try {
+      const queue = await fetchPlayableSetlist(insight.artist);
+      if (!queue.length) {
+        toast.info("No probable setlist tracks matched your library");
+        return;
+      }
+      playAll(queue, 0, { type: "playlist", name: `${insight.artist} Probable Setlist` });
+      await api(`/api/me/shows/${insight.show_id}/reminders`, "POST", {
+        reminder_type: insight.type,
+      });
+      toast.success(`Playing probable setlist: ${queue.length} tracks`);
+    } catch {
+      toast.error("Failed to load probable setlist");
     }
   }
 
@@ -574,6 +620,63 @@ export function Home() {
                 ))}
               </div>
             </div>
+          </div>
+        </section>
+      ) : null}
+
+      {homeInsights.length > 0 ? (
+        <section className="space-y-4">
+          <SectionHeader
+            title="Show prep"
+            subtitle="A couple of timely prompts from the shows you're planning to attend."
+            actionLabel="Open Upcoming"
+            onAction={() => navigate("/upcoming")}
+          />
+
+          <div className="grid gap-4 lg:grid-cols-2">
+            {homeInsights.map((insight) => (
+              <div
+                key={`${insight.type}:${insight.show_id}`}
+                className="rounded-[24px] border border-white/10 bg-[radial-gradient(circle_at_top_left,rgba(6,182,212,0.16),transparent_42%),rgba(255,255,255,0.03)] p-5"
+              >
+                <div className="flex items-start justify-between gap-3">
+                  <div>
+                    <div className="inline-flex items-center gap-2 rounded-full border border-primary/15 bg-primary/10 px-3 py-1 text-[10px] font-medium uppercase tracking-[0.16em] text-primary">
+                      <Sparkles size={12} />
+                      {insight.type === "show_prep" ? "Show prep" : insight.type === "one_week" ? "This week" : "One month"}
+                    </div>
+                    <h3 className="mt-3 text-lg font-bold text-foreground">{insight.title}</h3>
+                    <p className="mt-1 text-sm text-white/60">{insight.subtitle}</p>
+                  </div>
+                  {insight.weight === "high" ? (
+                    <div className="rounded-full border border-primary/20 bg-primary/10 px-3 py-1 text-[10px] uppercase tracking-[0.16em] text-primary">
+                      Heavy rotation
+                    </div>
+                  ) : null}
+                </div>
+
+                <p className="mt-4 text-sm leading-6 text-muted-foreground">{insight.message}</p>
+
+                <div className="mt-5 flex flex-wrap gap-2">
+                  {insight.has_setlist ? (
+                    <button
+                      onClick={() => void playInsightSetlist(insight)}
+                      className="inline-flex items-center gap-2 rounded-full bg-primary px-4 py-2 text-sm font-medium text-primary-foreground transition-colors hover:bg-primary/90"
+                    >
+                      <Play size={14} fill="currentColor" />
+                      Play probable setlist
+                    </button>
+                  ) : null}
+                  <button
+                    onClick={() => void acknowledgeInsight(insight)}
+                    className="inline-flex items-center gap-2 rounded-full border border-white/10 px-4 py-2 text-sm text-white/65 transition-colors hover:border-white/20 hover:text-foreground"
+                  >
+                    <Calendar size={14} />
+                    Save for later
+                  </button>
+                </div>
+              </div>
+            ))}
           </div>
         </section>
       ) : null}

--- a/app/listen/src/pages/Shows.tsx
+++ b/app/listen/src/pages/Shows.tsx
@@ -1,20 +1,39 @@
 import { type ReactNode, useMemo, useState } from "react";
-import { Calendar, Loader2, RadioTower, Sparkles } from "lucide-react";
+import { Calendar, Check, Loader2, Play, RadioTower, Sparkles } from "lucide-react";
 
+import { usePlayerActions } from "@/contexts/PlayerContext";
 import { useApi } from "@/hooks/use-api";
 import { cn } from "@/lib/utils";
 import {
+  fetchPlayableSetlist,
   groupByMonth,
   UpcomingMonthGroup,
   type UpcomingItem,
 } from "@/components/upcoming/UpcomingRows";
+import { api } from "@/lib/api";
+import { toast } from "sonner";
+
+interface UpcomingInsight {
+  type: "one_month" | "one_week" | "show_prep";
+  show_id: number;
+  artist: string;
+  date: string;
+  title: string;
+  subtitle: string;
+  message: string;
+  has_setlist?: boolean;
+  weight?: "normal" | "high";
+}
 
 interface UpcomingResponse {
   items: UpcomingItem[];
+  insights: UpcomingInsight[];
   summary: {
     followed_artists: number;
     show_count: number;
     release_count: number;
+    attending_count: number;
+    insight_count: number;
   };
 }
 
@@ -24,9 +43,13 @@ export function Shows() {
   const [filter, setFilter] = useState<Filter>("all");
   const [search, setSearch] = useState("");
   const [expandedId, setExpandedId] = useState<string | null>(null);
+  const [dismissedInsights, setDismissedInsights] = useState<Record<string, boolean>>({});
+  const [actingInsightKey, setActingInsightKey] = useState<string | null>(null);
   const { data, loading } = useApi<UpcomingResponse>("/api/me/upcoming");
+  const { playAll } = usePlayerActions();
 
   const items = data?.items ?? [];
+  const insights = data?.insights ?? [];
   const summary = data?.summary;
 
   const filtered = useMemo(() => {
@@ -62,6 +85,44 @@ export function Shows() {
     .sort((a, b) => (a.date < b.date ? 1 : -1));
 
   const hasFollowedArtists = (summary?.followed_artists ?? 0) > 0;
+  const visibleInsights = insights.filter((insight) => !dismissedInsights[insightKey(insight)]);
+
+  async function acknowledgeInsight(insight: UpcomingInsight) {
+    const key = insightKey(insight);
+    setActingInsightKey(key);
+    try {
+      await api(`/api/me/shows/${insight.show_id}/reminders`, "POST", {
+        reminder_type: insight.type,
+      });
+      setDismissedInsights((current) => ({ ...current, [key]: true }));
+    } catch {
+      toast.error("Failed to save reminder");
+    } finally {
+      setActingInsightKey(null);
+    }
+  }
+
+  async function handleInsightPlay(insight: UpcomingInsight) {
+    const key = insightKey(insight);
+    setActingInsightKey(key);
+    try {
+      const queue = await fetchPlayableSetlist(insight.artist);
+      if (!queue.length) {
+        toast.info("No probable setlist tracks matched your library");
+        return;
+      }
+      playAll(queue, 0, { type: "playlist", name: `${insight.artist} Probable Setlist` });
+      await api(`/api/me/shows/${insight.show_id}/reminders`, "POST", {
+        reminder_type: insight.type,
+      });
+      setDismissedInsights((current) => ({ ...current, [key]: true }));
+      toast.success(`Playing probable setlist: ${queue.length} tracks`);
+    } catch {
+      toast.error("Failed to load probable setlist");
+    } finally {
+      setActingInsightKey(null);
+    }
+  }
 
   return (
     <div className="space-y-6">
@@ -84,10 +145,74 @@ export function Shows() {
               <SummaryPill label="Shows" value={summary.show_count} accent="cyan" />
               <SummaryPill label="Releases" value={summary.release_count} accent="cyan" />
               <SummaryPill label="Attending" value={attendingShows.length} accent="cyan" />
+              <SummaryPill label="Insights" value={visibleInsights.length} accent="cyan" />
             </>
           ) : null}
         </div>
       </div>
+
+      {visibleInsights.length > 0 ? (
+        <section className="space-y-4">
+          <div className="flex items-center gap-2">
+            <Sparkles size={15} className="text-primary" />
+            <h2 className="text-sm font-semibold uppercase tracking-[0.18em] text-primary">Show prep</h2>
+          </div>
+          <div className="grid gap-3 xl:grid-cols-2">
+            {visibleInsights.map((insight) => {
+              const key = insightKey(insight);
+              const busy = actingInsightKey === key;
+              return (
+                <div
+                  key={key}
+                  className={cn(
+                    "rounded-[1.25rem] border p-4 transition-colors",
+                    insight.weight === "high"
+                      ? "border-primary/25 bg-[radial-gradient(circle_at_top_left,rgba(6,182,212,0.18),transparent_38%),rgba(255,255,255,0.03)]"
+                      : "border-white/8 bg-white/[0.03]",
+                  )}
+                >
+                  <div className="flex items-start justify-between gap-3">
+                    <div>
+                      <div className="inline-flex items-center gap-2 rounded-full border border-primary/15 bg-primary/10 px-2.5 py-1 text-[10px] font-medium uppercase tracking-[0.16em] text-primary">
+                        {insight.type === "show_prep" ? "Show prep" : insight.type === "one_week" ? "This week" : "One month"}
+                      </div>
+                      <h3 className="mt-3 text-lg font-semibold text-foreground">{insight.title}</h3>
+                      <p className="mt-1 text-sm text-white/55">{insight.subtitle}</p>
+                      <p className="mt-3 text-sm leading-6 text-white/70">{insight.message}</p>
+                    </div>
+                    {insight.weight === "high" ? (
+                      <span className="rounded-full border border-primary/20 bg-primary/12 px-2 py-1 text-[10px] font-medium uppercase tracking-[0.14em] text-primary">
+                        Listening a lot
+                      </span>
+                    ) : null}
+                  </div>
+
+                  <div className="mt-4 flex flex-wrap items-center gap-2">
+                    {insight.has_setlist ? (
+                      <button
+                        onClick={() => void handleInsightPlay(insight)}
+                        disabled={busy}
+                        className="inline-flex items-center gap-2 rounded-full bg-primary px-4 py-2 text-sm font-medium text-primary-foreground transition hover:brightness-105 disabled:opacity-60"
+                      >
+                        {busy ? <Loader2 size={14} className="animate-spin" /> : <Play size={14} className="fill-current" />}
+                        Play probable setlist
+                      </button>
+                    ) : null}
+                    <button
+                      onClick={() => void acknowledgeInsight(insight)}
+                      disabled={busy}
+                      className="inline-flex items-center gap-2 rounded-full border border-white/10 px-4 py-2 text-sm text-white/65 transition hover:border-white/20 hover:text-foreground disabled:opacity-60"
+                    >
+                      {busy ? <Loader2 size={14} className="animate-spin" /> : <Check size={14} />}
+                      Got it
+                    </button>
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        </section>
+      ) : null}
 
       {nextAttendingShow ? (
         <div className="overflow-hidden rounded-[1.5rem] border border-primary/15 bg-[radial-gradient(circle_at_top_left,rgba(6,182,212,0.16),transparent_42%),linear-gradient(180deg,rgba(255,255,255,0.04),rgba(255,255,255,0.02))] p-5">
@@ -236,6 +361,10 @@ function SummaryPill({
       <div className="mt-1 text-sm font-semibold">{value}</div>
     </div>
   );
+}
+
+function insightKey(insight: UpcomingInsight) {
+  return `${insight.type}:${insight.show_id}`;
 }
 
 function EmptyState({

--- a/app/listen/src/pages/Shows.tsx
+++ b/app/listen/src/pages/Shows.tsx
@@ -68,7 +68,7 @@ export function Shows() {
     return next;
   }, [filter, items, search]);
 
-  const today = new Date().toISOString().slice(0, 10);
+  const today = useMemo(() => new Date().toISOString().slice(0, 10), []);
   const comingUp = filtered.filter((item) => item.is_upcoming || item.date >= today);
   const attendingShows = items.filter((item) => item.type === "show" && item.user_attending);
   const nextAttendingShow = attendingShows
@@ -109,14 +109,14 @@ export function Shows() {
       const queue = await fetchPlayableSetlist(insight.artist);
       if (!queue.length) {
         toast.info("No probable setlist tracks matched your library");
-        return;
+      } else {
+        playAll(queue, 0, { type: "playlist", name: `${insight.artist} Probable Setlist` });
+        await api(`/api/me/shows/${insight.show_id}/reminders`, "POST", {
+          reminder_type: insight.type,
+        });
+        setDismissedInsights((current) => ({ ...current, [key]: true }));
+        toast.success(`Playing probable setlist: ${queue.length} tracks`);
       }
-      playAll(queue, 0, { type: "playlist", name: `${insight.artist} Probable Setlist` });
-      await api(`/api/me/shows/${insight.show_id}/reminders`, "POST", {
-        reminder_type: insight.type,
-      });
-      setDismissedInsights((current) => ({ ...current, [key]: true }));
-      toast.success(`Playing probable setlist: ${queue.length} tracks`);
     } catch {
       toast.error("Failed to load probable setlist");
     } finally {

--- a/app/listen/src/pages/Shows.tsx
+++ b/app/listen/src/pages/Shows.tsx
@@ -5,12 +5,12 @@ import { usePlayerActions } from "@/contexts/PlayerContext";
 import { useApi } from "@/hooks/use-api";
 import { cn } from "@/lib/utils";
 import {
-  fetchPlayableSetlist,
   groupByMonth,
   UpcomingMonthGroup,
   type UpcomingItem,
 } from "@/components/upcoming/UpcomingRows";
 import { api } from "@/lib/api";
+import { fetchPlayableSetlist } from "@/lib/upcoming";
 import { toast } from "sonner";
 
 interface UpcomingInsight {

--- a/app/listen/src/pages/Stats.tsx
+++ b/app/listen/src/pages/Stats.tsx
@@ -1,6 +1,6 @@
 import { Children, type ReactNode, useMemo, useState } from "react";
 import { ResponsiveLine } from "@nivo/line";
-import { BarChart3, Clock3, Disc3, Music2, SkipForward, TrendingUp, User2 } from "lucide-react";
+import { BarChart3, Clock3, Disc3, Music2, Play, SkipForward, TrendingUp, User2 } from "lucide-react";
 import { Link } from "react-router";
 
 import { useApi } from "@/hooks/use-api";
@@ -72,6 +72,15 @@ interface StatsGenre {
 interface StatsListResponse<T> {
   window: StatsWindow;
   items: T[];
+}
+
+interface ReplayMix {
+  window: StatsWindow;
+  title: string;
+  subtitle: string;
+  track_count: number;
+  minutes_listened: number;
+  items: StatsTrack[];
 }
 
 const WINDOW_OPTIONS: { value: StatsWindow; label: string }[] = [
@@ -265,32 +274,45 @@ function TrendChart({ points }: { points: StatsTrendPoint[] }) {
 
 export function Stats() {
   const [window, setWindow] = useState<StatsWindow>("30d");
-  const { play } = usePlayerActions();
+  const { play, playAll } = usePlayerActions();
   const { data: overview, loading: overviewLoading } = useApi<StatsOverview>(`/api/me/stats/overview?window=${window}`);
   const { data: trends, loading: trendsLoading } = useApi<StatsTrends>(`/api/me/stats/trends?window=${window}`);
   const { data: topTracks, loading: tracksLoading } = useApi<StatsListResponse<StatsTrack>>(`/api/me/stats/top-tracks?window=${window}&limit=10`);
   const { data: topArtists, loading: artistsLoading } = useApi<StatsListResponse<StatsArtist>>(`/api/me/stats/top-artists?window=${window}&limit=8`);
   const { data: topAlbums, loading: albumsLoading } = useApi<StatsListResponse<StatsAlbum>>(`/api/me/stats/top-albums?window=${window}&limit=8`);
   const { data: topGenres, loading: genresLoading } = useApi<StatsListResponse<StatsGenre>>(`/api/me/stats/top-genres?window=${window}&limit=8`);
+  const { data: replay, loading: replayLoading } = useApi<ReplayMix>(`/api/me/stats/replay?window=${window}&limit=30`);
 
   const topTrackItems = topTracks?.items ?? [];
   const topArtistItems = topArtists?.items ?? [];
   const topAlbumItems = topAlbums?.items ?? [];
   const topGenreItems = topGenres?.items ?? [];
+  const replayItems = replay?.items ?? [];
+
+  const toPlayerTrack = (item: StatsTrack): Track => ({
+    id: item.track_path || String(item.track_id || `${item.artist}-${item.title}`),
+    title: item.title,
+    artist: item.artist,
+    album: item.album,
+    path: item.track_path || undefined,
+    libraryTrackId: item.track_id || undefined,
+  });
 
   const playTopTrack = (item: StatsTrack) => {
-    const track: Track = {
-      id: item.track_path || String(item.track_id || `${item.artist}-${item.title}`),
-      title: item.title,
-      artist: item.artist,
-      album: item.album,
-      path: item.track_path || undefined,
-      libraryTrackId: item.track_id || undefined,
-    };
+    const track = toPlayerTrack(item);
     play(track, { type: "track", name: item.title, id: item.track_id ?? item.track_path });
   };
 
-  const loading = overviewLoading || trendsLoading || tracksLoading || artistsLoading || albumsLoading || genresLoading;
+  const playReplay = () => {
+    if (!replayItems.length) return;
+    playAll(
+      replayItems.map(toPlayerTrack),
+      0,
+      { type: "playlist", name: replay?.title || "Replay" },
+    );
+  };
+
+  const loading = overviewLoading || trendsLoading || tracksLoading || artistsLoading || albumsLoading || genresLoading || replayLoading;
 
   return (
     <div className="space-y-8">
@@ -334,6 +356,61 @@ export function Stats() {
           hint={overview?.top_artist ? `${overview.top_artist.play_count} plays` : "No artist data yet"}
         />
       </div>
+
+      <Section
+        title={replay?.title || "Replay"}
+        subtitle={replay?.subtitle || "Turn this listening window into a playable recap."}
+      >
+        <div className="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
+          <div className="grid gap-3 sm:grid-cols-3">
+            <div className="rounded-2xl border border-white/10 bg-black/10 px-4 py-3">
+              <div className="text-[10px] uppercase tracking-[0.16em] text-white/35">Tracks</div>
+              <div className="mt-1 text-lg font-semibold text-foreground">{replay?.track_count ?? 0}</div>
+            </div>
+            <div className="rounded-2xl border border-white/10 bg-black/10 px-4 py-3">
+              <div className="text-[10px] uppercase tracking-[0.16em] text-white/35">Minutes</div>
+              <div className="mt-1 text-lg font-semibold text-foreground">{formatMinutes(replay?.minutes_listened ?? 0)}</div>
+            </div>
+            <div className="rounded-2xl border border-white/10 bg-black/10 px-4 py-3">
+              <div className="text-[10px] uppercase tracking-[0.16em] text-white/35">Window</div>
+              <div className="mt-1 text-lg font-semibold text-foreground">{WINDOW_OPTIONS.find((item) => item.value === window)?.label ?? window}</div>
+            </div>
+          </div>
+
+          <button
+            onClick={playReplay}
+            disabled={!replayItems.length}
+            className="inline-flex items-center justify-center gap-2 rounded-full bg-primary px-5 py-2.5 text-sm font-medium text-primary-foreground transition-colors hover:bg-primary/90 disabled:opacity-50"
+          >
+            <Play size={14} fill="currentColor" />
+            Play replay
+          </button>
+        </div>
+
+        {replayItems.length > 0 ? (
+          <div className="mt-5 grid gap-2 md:grid-cols-2 xl:grid-cols-3">
+            {replayItems.slice(0, 6).map((item, index) => (
+              <button
+                key={`${item.track_id ?? item.track_path ?? item.title}-${index}`}
+                onClick={() => playTopTrack(item)}
+                className="flex items-center gap-3 rounded-xl border border-transparent bg-black/10 px-3 py-2 text-left transition-colors hover:border-white/10 hover:bg-white/5"
+              >
+                <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-xl border border-white/10 bg-white/[0.03] text-xs font-semibold text-white/45">
+                  {index + 1}
+                </div>
+                <div className="min-w-0 flex-1">
+                  <div className="truncate text-sm font-medium text-foreground">{item.title}</div>
+                  <div className="truncate text-xs text-muted-foreground">{item.artist}</div>
+                </div>
+              </button>
+            ))}
+          </div>
+        ) : (
+          <div className="mt-4 rounded-2xl border border-dashed border-white/10 bg-black/10 px-4 py-5 text-sm text-muted-foreground">
+            Keep listening and your replay object will start to take shape.
+          </div>
+        )}
+      </Section>
 
       <Section
         title="Daily trend"

--- a/app/listen/src/pages/Stats.tsx
+++ b/app/listen/src/pages/Stats.tsx
@@ -83,6 +83,11 @@ interface ReplayMix {
   items: StatsTrack[];
 }
 
+interface RecapHighlight {
+  title: string;
+  body: string;
+}
+
 const WINDOW_OPTIONS: { value: StatsWindow; label: string }[] = [
   { value: "7d", label: "7D" },
   { value: "30d", label: "30D" },
@@ -272,6 +277,51 @@ function TrendChart({ points }: { points: StatsTrendPoint[] }) {
   );
 }
 
+function buildRecapHighlights(
+  overview: StatsOverview | undefined,
+  replay: ReplayMix | undefined,
+  topArtists: StatsArtist[],
+  topTracks: StatsTrack[],
+): RecapHighlight[] {
+  const highlights: RecapHighlight[] = [];
+
+  if (overview?.top_artist?.artist_name) {
+    highlights.push({
+      title: `${overview.top_artist.artist_name} led this window`,
+      body: `${overview.top_artist.play_count} plays and ${formatMinutes(overview.top_artist.minutes_listened)} listened.`,
+    });
+  }
+
+  if (topTracks[0]) {
+    highlights.push({
+      title: `"${topTracks[0].title}" kept coming back`,
+      body: `${topTracks[0].artist} · ${topTracks[0].play_count} plays in this window.`,
+    });
+  }
+
+  if (overview) {
+    const cadence =
+      overview.active_days >= 20
+        ? "You've been listening almost every day."
+        : overview.active_days >= 10
+          ? "This window has had a steady rhythm."
+          : "This window is still taking shape.";
+    highlights.push({
+      title: `${formatMinutes(overview.minutes_listened)} listened`,
+      body: `${cadence} ${overview.complete_play_count} completed plays so far.`,
+    });
+  }
+
+  if (replay?.track_count) {
+    highlights.push({
+      title: `${replay.track_count} tracks define this replay`,
+      body: `${topArtists.length ? `Spread across ${Math.min(topArtists.length, 8)} key artists.` : "A first replay object is ready to play."}`,
+    });
+  }
+
+  return highlights.slice(0, 3);
+}
+
 export function Stats() {
   const [window, setWindow] = useState<StatsWindow>("30d");
   const { play, playAll } = usePlayerActions();
@@ -288,6 +338,10 @@ export function Stats() {
   const topAlbumItems = topAlbums?.items ?? [];
   const topGenreItems = topGenres?.items ?? [];
   const replayItems = replay?.items ?? [];
+  const recapHighlights = useMemo(
+    () => buildRecapHighlights(overview ?? undefined, replay ?? undefined, topArtistItems, topTrackItems),
+    [overview, replay, topArtistItems, topTrackItems],
+  );
 
   const toPlayerTrack = (item: StatsTrack): Track => ({
     id: item.track_path || String(item.track_id || `${item.artist}-${item.title}`),
@@ -410,6 +464,27 @@ export function Stats() {
             Keep listening and your replay object will start to take shape.
           </div>
         )}
+      </Section>
+
+      <Section
+        title="Your window so far"
+        subtitle="A more readable summary of what this period says about your listening."
+      >
+        <div className="grid gap-3 lg:grid-cols-3">
+          {recapHighlights.length > 0 ? recapHighlights.map((item) => (
+            <div
+              key={item.title}
+              className="rounded-2xl border border-white/10 bg-black/10 p-4"
+            >
+              <div className="text-sm font-semibold text-foreground">{item.title}</div>
+              <div className="mt-2 text-sm leading-6 text-muted-foreground">{item.body}</div>
+            </div>
+          )) : (
+            <div className="rounded-2xl border border-dashed border-white/10 bg-black/10 p-4 text-sm text-muted-foreground lg:col-span-3">
+              Keep listening and this window will start to tell a clearer story.
+            </div>
+          )}
+        </div>
       </Section>
 
       <Section

--- a/app/listen/src/pages/Stats.tsx
+++ b/app/listen/src/pages/Stats.tsx
@@ -1,10 +1,11 @@
 import { Children, type ReactNode, useMemo, useState } from "react";
 import { ResponsiveLine } from "@nivo/line";
-import { BarChart3, Clock3, Disc3, Music2, Play, SkipForward, TrendingUp, User2 } from "lucide-react";
+import { BarChart3, Clock3, Disc3, Music2, Play, SkipForward, Tag, TrendingUp } from "lucide-react";
 import { Link } from "react-router";
 
 import { useApi } from "@/hooks/use-api";
 import { usePlayerActions, type Track } from "@/contexts/PlayerContext";
+import { encPath } from "../../../shared/web/utils";
 
 type StatsWindow = "7d" | "30d" | "90d" | "365d" | "all_time";
 
@@ -39,6 +40,7 @@ interface StatsTrends {
 interface StatsTrack {
   track_id: number | null;
   track_path: string | null;
+  navidrome_id?: string | null;
   title: string;
   artist: string;
   album: string;
@@ -186,10 +188,12 @@ function WindowPicker({
 function TopList({
   title,
   emptyText,
+  loading = false,
   children,
 }: {
   title: string;
   emptyText: string;
+  loading?: boolean;
   children: ReactNode;
 }) {
   const hasVisibleItems = Children.count(children) > 0;
@@ -198,13 +202,13 @@ function TopList({
     <div className="rounded-2xl border border-white/10 bg-black/10 p-4">
       <h3 className="text-sm font-semibold text-foreground">{title}</h3>
       <div className="mt-3 space-y-2">
-        {hasVisibleItems ? children : <p className="text-sm text-muted-foreground">{emptyText}</p>}
+        {loading ? <p className="text-sm text-muted-foreground">Loading...</p> : hasVisibleItems ? children : <p className="text-sm text-muted-foreground">{emptyText}</p>}
       </div>
     </div>
   );
 }
 
-function TrendChart({ points }: { points: StatsTrendPoint[] }) {
+function TrendChart({ points, loading }: { points: StatsTrendPoint[]; loading?: boolean }) {
   const data = useMemo(() => [
     {
       id: "Minutes",
@@ -214,6 +218,14 @@ function TrendChart({ points }: { points: StatsTrendPoint[] }) {
       })),
     },
   ], [points]);
+
+  if (loading) {
+    return (
+      <div className="flex h-72 items-center justify-center rounded-2xl border border-dashed border-white/10 bg-black/10 text-sm text-muted-foreground">
+        Loading trend data...
+      </div>
+    );
+  }
 
   if (points.length === 0) {
     return (
@@ -292,14 +304,14 @@ function buildRecapHighlights(
     });
   }
 
-  if (topTracks[0]) {
+  if (topTracks[0] && topTracks[0].play_count > 0) {
     highlights.push({
       title: `"${topTracks[0].title}" kept coming back`,
       body: `${topTracks[0].artist} · ${topTracks[0].play_count} plays in this window.`,
     });
   }
 
-  if (overview) {
+  if (overview && overview.play_count > 0) {
     const cadence =
       overview.active_days >= 20
         ? "You've been listening almost every day."
@@ -312,7 +324,7 @@ function buildRecapHighlights(
     });
   }
 
-  if (replay?.track_count) {
+  if (replay?.track_count && replay.track_count > 0) {
     highlights.push({
       title: `${replay.track_count} tracks define this replay`,
       body: `${topArtists.length ? `Spread across ${Math.min(topArtists.length, 8)} key artists.` : "A first replay object is ready to play."}`,
@@ -323,15 +335,15 @@ function buildRecapHighlights(
 }
 
 export function Stats() {
-  const [window, setWindow] = useState<StatsWindow>("30d");
+  const [selectedWindow, setSelectedWindow] = useState<StatsWindow>("30d");
   const { play, playAll } = usePlayerActions();
-  const { data: overview, loading: overviewLoading } = useApi<StatsOverview>(`/api/me/stats/overview?window=${window}`);
-  const { data: trends, loading: trendsLoading } = useApi<StatsTrends>(`/api/me/stats/trends?window=${window}`);
-  const { data: topTracks, loading: tracksLoading } = useApi<StatsListResponse<StatsTrack>>(`/api/me/stats/top-tracks?window=${window}&limit=10`);
-  const { data: topArtists, loading: artistsLoading } = useApi<StatsListResponse<StatsArtist>>(`/api/me/stats/top-artists?window=${window}&limit=8`);
-  const { data: topAlbums, loading: albumsLoading } = useApi<StatsListResponse<StatsAlbum>>(`/api/me/stats/top-albums?window=${window}&limit=8`);
-  const { data: topGenres, loading: genresLoading } = useApi<StatsListResponse<StatsGenre>>(`/api/me/stats/top-genres?window=${window}&limit=8`);
-  const { data: replay, loading: replayLoading } = useApi<ReplayMix>(`/api/me/stats/replay?window=${window}&limit=30`);
+  const { data: overview, loading: overviewLoading } = useApi<StatsOverview>(`/api/me/stats/overview?window=${selectedWindow}`);
+  const { data: trends, loading: trendsLoading } = useApi<StatsTrends>(`/api/me/stats/trends?window=${selectedWindow}`);
+  const { data: topTracks, loading: tracksLoading } = useApi<StatsListResponse<StatsTrack>>(`/api/me/stats/top-tracks?window=${selectedWindow}&limit=10`);
+  const { data: topArtists, loading: artistsLoading } = useApi<StatsListResponse<StatsArtist>>(`/api/me/stats/top-artists?window=${selectedWindow}&limit=8`);
+  const { data: topAlbums, loading: albumsLoading } = useApi<StatsListResponse<StatsAlbum>>(`/api/me/stats/top-albums?window=${selectedWindow}&limit=8`);
+  const { data: topGenres, loading: genresLoading } = useApi<StatsListResponse<StatsGenre>>(`/api/me/stats/top-genres?window=${selectedWindow}&limit=8`);
+  const { data: replay, loading: replayLoading } = useApi<ReplayMix>(`/api/me/stats/replay?window=${selectedWindow}&limit=30`);
 
   const topTrackItems = topTracks?.items ?? [];
   const topArtistItems = topArtists?.items ?? [];
@@ -350,6 +362,7 @@ export function Stats() {
     album: item.album,
     path: item.track_path || undefined,
     libraryTrackId: item.track_id || undefined,
+    navidromeId: item.navidrome_id || undefined,
   });
 
   const playTopTrack = (item: StatsTrack) => {
@@ -366,7 +379,7 @@ export function Stats() {
     );
   };
 
-  const loading = overviewLoading || trendsLoading || tracksLoading || artistsLoading || albumsLoading || genresLoading || replayLoading;
+  const allSectionsLoaded = !overviewLoading && !trendsLoading && !tracksLoading && !artistsLoading && !albumsLoading && !genresLoading && !replayLoading;
 
   return (
     <div className="space-y-8">
@@ -381,32 +394,32 @@ export function Stats() {
             A first look at your listening profile across minutes, trends, artists, albums, and tracks.
           </p>
         </div>
-        <WindowPicker value={window} onChange={setWindow} />
+        <WindowPicker value={selectedWindow} onChange={setSelectedWindow} />
       </div>
 
       <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
         <OverviewCard
           icon={Clock3}
           label="Time listened"
-          value={overview ? formatMinutes(overview.minutes_listened) : loading ? "..." : "0m"}
+          value={overview ? formatMinutes(overview.minutes_listened) : overviewLoading ? "..." : "0m"}
           hint={overview ? `${overview.active_days} active days` : "Listening time in the selected window"}
         />
         <OverviewCard
           icon={Music2}
           label="Qualified plays"
-          value={overview ? String(overview.play_count) : loading ? "..." : "0"}
+          value={overview ? String(overview.play_count) : overviewLoading ? "..." : "0"}
           hint={overview ? `${overview.complete_play_count} completed plays` : "Valid plays recorded"}
         />
         <OverviewCard
           icon={SkipForward}
           label="Skip rate"
-          value={overview ? formatPercent(overview.skip_rate) : loading ? "..." : "0%"}
+          value={overview ? formatPercent(overview.skip_rate) : overviewLoading ? "..." : "0%"}
           hint={overview ? `${overview.skip_count} skips` : "Tracks you moved on from"}
         />
         <OverviewCard
           icon={TrendingUp}
           label="Top artist"
-          value={overview?.top_artist?.artist_name ?? (loading ? "..." : "—")}
+          value={overview?.top_artist?.artist_name ?? (overviewLoading ? "..." : "—")}
           hint={overview?.top_artist ? `${overview.top_artist.play_count} plays` : "No artist data yet"}
         />
       </div>
@@ -427,7 +440,7 @@ export function Stats() {
             </div>
             <div className="rounded-2xl border border-white/10 bg-black/10 px-4 py-3">
               <div className="text-[10px] uppercase tracking-[0.16em] text-white/35">Window</div>
-              <div className="mt-1 text-lg font-semibold text-foreground">{WINDOW_OPTIONS.find((item) => item.value === window)?.label ?? window}</div>
+              <div className="mt-1 text-lg font-semibold text-foreground">{WINDOW_OPTIONS.find((item) => item.value === selectedWindow)?.label ?? selectedWindow}</div>
             </div>
           </div>
 
@@ -441,7 +454,11 @@ export function Stats() {
           </button>
         </div>
 
-        {replayItems.length > 0 ? (
+        {replayLoading ? (
+          <div className="mt-4 rounded-2xl border border-dashed border-white/10 bg-black/10 px-4 py-5 text-sm text-muted-foreground">
+            Loading replay...
+          </div>
+        ) : replayItems.length > 0 ? (
           <div className="mt-5 grid gap-2 md:grid-cols-2 xl:grid-cols-3">
             {replayItems.slice(0, 6).map((item, index) => (
               <button
@@ -491,7 +508,7 @@ export function Stats() {
         title="Daily trend"
         subtitle="Your listening curve across the selected time window."
       >
-        <TrendChart points={trends?.points ?? []} />
+        <TrendChart points={trends?.points ?? []} loading={trendsLoading} />
       </Section>
 
       <div className="grid gap-4 xl:grid-cols-2">
@@ -499,7 +516,7 @@ export function Stats() {
           title="Top tracks"
           subtitle="The songs that defined this window."
         >
-          <TopList title="Tracks" emptyText="No top tracks yet.">
+          <TopList title="Tracks" emptyText="No top tracks yet." loading={tracksLoading}>
             {topTrackItems.map((item, index) => (
               <button
                 key={`${item.track_id ?? item.track_path ?? item.title}-${index}`}
@@ -526,11 +543,11 @@ export function Stats() {
           title="Top artists"
           subtitle="Who you kept coming back to."
         >
-          <TopList title="Artists" emptyText="No top artists yet.">
+          <TopList title="Artists" emptyText="No top artists yet." loading={artistsLoading}>
             {topArtistItems.map((item, index) => (
               <Link
                 key={`${item.artist_name}-${index}`}
-                to={`/artist/${encodeURIComponent(item.artist_name)}`}
+                to={`/artist/${encPath(item.artist_name)}`}
                 className="flex items-center gap-3 rounded-xl border border-transparent px-3 py-2 transition-colors hover:border-white/10 hover:bg-white/5"
               >
                 <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-xl border border-white/10 bg-white/[0.03] text-xs font-semibold text-white/45">
@@ -552,11 +569,11 @@ export function Stats() {
           title="Top albums"
           subtitle="Records that shaped the window."
         >
-          <TopList title="Albums" emptyText="No top albums yet.">
+          <TopList title="Albums" emptyText="No top albums yet." loading={albumsLoading}>
             {topAlbumItems.map((item, index) => (
               <Link
                 key={`${item.artist}-${item.album}-${index}`}
-                to={`/album/${encodeURIComponent(item.artist)}/${encodeURIComponent(item.album)}`}
+                to={`/album/${encPath(item.artist)}/${encPath(item.album)}`}
                 className="flex items-center gap-3 rounded-xl border border-transparent px-3 py-2 transition-colors hover:border-white/10 hover:bg-white/5"
               >
                 <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-xl border border-white/10 bg-white/[0.03] text-xs font-semibold text-white/45">
@@ -579,14 +596,14 @@ export function Stats() {
           title="Top genres"
           subtitle="Your strongest stylistic pull in this window."
         >
-          <TopList title="Genres" emptyText="No top genres yet.">
+          <TopList title="Genres" emptyText="No top genres yet." loading={genresLoading}>
             {topGenreItems.map((item, index) => (
               <div
                 key={`${item.genre_name}-${index}`}
                 className="flex items-center gap-3 rounded-xl border border-transparent px-3 py-2"
               >
                 <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-xl border border-white/10 bg-white/[0.03] text-xs font-semibold text-white/45">
-                  <User2 size={14} />
+                  <Tag size={14} />
                 </div>
                 <div className="min-w-0 flex-1">
                   <div className="truncate text-sm font-medium text-foreground">{item.genre_name}</div>
@@ -599,7 +616,7 @@ export function Stats() {
         </Section>
       </div>
 
-      {!loading && !overview?.play_count ? (
+      {allSectionsLoaded && !overview?.play_count ? (
         <div className="rounded-3xl border border-dashed border-white/10 bg-white/[0.02] p-8 text-center">
           <h2 className="text-lg font-semibold text-foreground">Your stats are waiting for you</h2>
           <p className="mt-2 text-sm text-muted-foreground">

--- a/app/listen/src/pages/Stats.tsx
+++ b/app/listen/src/pages/Stats.tsx
@@ -1,0 +1,460 @@
+import { Children, type ReactNode, useMemo, useState } from "react";
+import { ResponsiveLine } from "@nivo/line";
+import { BarChart3, Clock3, Disc3, Music2, SkipForward, TrendingUp, User2 } from "lucide-react";
+import { Link } from "react-router";
+
+import { useApi } from "@/hooks/use-api";
+import { usePlayerActions, type Track } from "@/contexts/PlayerContext";
+
+type StatsWindow = "7d" | "30d" | "90d" | "365d" | "all_time";
+
+interface StatsOverview {
+  window: StatsWindow;
+  play_count: number;
+  complete_play_count: number;
+  skip_count: number;
+  minutes_listened: number;
+  active_days: number;
+  skip_rate: number;
+  top_artist: {
+    artist_name: string;
+    play_count: number;
+    minutes_listened: number;
+  } | null;
+}
+
+interface StatsTrendPoint {
+  day: string;
+  play_count: number;
+  complete_play_count: number;
+  skip_count: number;
+  minutes_listened: number;
+}
+
+interface StatsTrends {
+  window: StatsWindow;
+  points: StatsTrendPoint[];
+}
+
+interface StatsTrack {
+  track_id: number | null;
+  track_path: string | null;
+  title: string;
+  artist: string;
+  album: string;
+  play_count: number;
+  complete_play_count: number;
+  minutes_listened: number;
+}
+
+interface StatsArtist {
+  artist_name: string;
+  play_count: number;
+  complete_play_count: number;
+  minutes_listened: number;
+}
+
+interface StatsAlbum {
+  artist: string;
+  album: string;
+  play_count: number;
+  complete_play_count: number;
+  minutes_listened: number;
+}
+
+interface StatsGenre {
+  genre_name: string;
+  play_count: number;
+  complete_play_count: number;
+  minutes_listened: number;
+}
+
+interface StatsListResponse<T> {
+  window: StatsWindow;
+  items: T[];
+}
+
+const WINDOW_OPTIONS: { value: StatsWindow; label: string }[] = [
+  { value: "7d", label: "7D" },
+  { value: "30d", label: "30D" },
+  { value: "90d", label: "90D" },
+  { value: "365d", label: "1Y" },
+  { value: "all_time", label: "All time" },
+];
+
+function formatMinutes(minutes: number): string {
+  if (!Number.isFinite(minutes) || minutes <= 0) return "0m";
+  if (minutes >= 60) {
+    const hours = Math.floor(minutes / 60);
+    const remaining = Math.round(minutes % 60);
+    return remaining > 0 ? `${hours}h ${remaining}m` : `${hours}h`;
+  }
+  return `${Math.round(minutes)}m`;
+}
+
+function formatPercent(value: number): string {
+  return `${Math.round((value || 0) * 100)}%`;
+}
+
+function OverviewCard({
+  icon: Icon,
+  label,
+  value,
+  hint,
+}: {
+  icon: React.ComponentType<{ size?: number; className?: string }>;
+  label: string;
+  value: string;
+  hint?: string;
+}) {
+  return (
+    <div className="rounded-3xl border border-white/10 bg-white/[0.03] p-5">
+      <div className="flex items-start justify-between gap-3">
+        <div>
+          <p className="text-[11px] font-bold uppercase tracking-[0.2em] text-white/35">{label}</p>
+          <p className="mt-3 text-2xl font-bold text-foreground">{value}</p>
+          {hint ? <p className="mt-2 text-sm text-muted-foreground">{hint}</p> : null}
+        </div>
+        <div className="flex h-10 w-10 items-center justify-center rounded-2xl border border-primary/15 bg-primary/10 text-primary">
+          <Icon size={18} />
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function Section({
+  title,
+  subtitle,
+  children,
+}: {
+  title: string;
+  subtitle?: string;
+  children: ReactNode;
+}) {
+  return (
+    <section className="rounded-3xl border border-white/10 bg-white/[0.03] p-5 sm:p-6">
+      <div className="mb-5">
+        <h2 className="text-lg font-semibold text-foreground">{title}</h2>
+        {subtitle ? <p className="mt-1 text-sm text-muted-foreground">{subtitle}</p> : null}
+      </div>
+      {children}
+    </section>
+  );
+}
+
+function WindowPicker({
+  value,
+  onChange,
+}: {
+  value: StatsWindow;
+  onChange: (value: StatsWindow) => void;
+}) {
+  return (
+    <div className="inline-flex rounded-2xl border border-white/10 bg-white/[0.03] p-1">
+      {WINDOW_OPTIONS.map((option) => (
+        <button
+          key={option.value}
+          onClick={() => onChange(option.value)}
+          className={`rounded-xl px-3 py-1.5 text-sm transition-colors ${
+            value === option.value
+              ? "bg-primary text-primary-foreground"
+              : "text-white/50 hover:text-white hover:bg-white/5"
+          }`}
+        >
+          {option.label}
+        </button>
+      ))}
+    </div>
+  );
+}
+
+function TopList({
+  title,
+  emptyText,
+  children,
+}: {
+  title: string;
+  emptyText: string;
+  children: ReactNode;
+}) {
+  const hasVisibleItems = Children.count(children) > 0;
+
+  return (
+    <div className="rounded-2xl border border-white/10 bg-black/10 p-4">
+      <h3 className="text-sm font-semibold text-foreground">{title}</h3>
+      <div className="mt-3 space-y-2">
+        {hasVisibleItems ? children : <p className="text-sm text-muted-foreground">{emptyText}</p>}
+      </div>
+    </div>
+  );
+}
+
+function TrendChart({ points }: { points: StatsTrendPoint[] }) {
+  const data = useMemo(() => [
+    {
+      id: "Minutes",
+      data: points.map((point) => ({
+        x: point.day,
+        y: Number(point.minutes_listened.toFixed(2)),
+      })),
+    },
+  ], [points]);
+
+  if (points.length === 0) {
+    return (
+      <div className="flex h-72 items-center justify-center rounded-2xl border border-dashed border-white/10 bg-black/10 text-sm text-muted-foreground">
+        Start listening and your daily curve will appear here.
+      </div>
+    );
+  }
+
+  return (
+    <div className="h-72 rounded-2xl border border-white/10 bg-black/10 p-3">
+      <ResponsiveLine
+        data={data}
+        margin={{ top: 20, right: 20, bottom: 40, left: 50 }}
+        xScale={{ type: "point" }}
+        yScale={{ type: "linear", min: 0, max: "auto", stacked: false, reverse: false }}
+        axisTop={null}
+        axisRight={null}
+        colors={["#22d3ee"]}
+        enableGridX={false}
+        pointSize={7}
+        pointColor="#22d3ee"
+        pointBorderWidth={0}
+        useMesh
+        theme={{
+          text: { fill: "rgba(255,255,255,0.45)", fontSize: 11 },
+          axis: {
+            ticks: { text: { fill: "rgba(255,255,255,0.35)" } },
+            legend: { text: { fill: "rgba(255,255,255,0.35)" } },
+            domain: { line: { stroke: "rgba(255,255,255,0.08)" } },
+          },
+          grid: { line: { stroke: "rgba(255,255,255,0.06)" } },
+          crosshair: { line: { stroke: "rgba(255,255,255,0.2)", strokeWidth: 1 } },
+          tooltip: {
+            container: {
+              background: "#0f1117",
+              color: "#fff",
+              border: "1px solid rgba(255,255,255,0.08)",
+              borderRadius: "14px",
+            },
+          },
+        }}
+        axisBottom={{
+          tickRotation: points.length > 14 ? -45 : 0,
+          format: (value) => {
+            const date = new Date(`${String(value)}T12:00:00`);
+            return date.toLocaleDateString("en-US", { month: "short", day: "numeric" });
+          },
+        }}
+        axisLeft={{
+          format: (value) => `${Math.round(Number(value))}m`,
+        }}
+        tooltip={({ point }) => (
+          <div className="px-3 py-2">
+            <div className="text-xs font-semibold text-white">{String(point.data.xFormatted)}</div>
+            <div className="mt-1 text-sm text-cyan-300">{point.data.yFormatted} minutes</div>
+          </div>
+        )}
+      />
+    </div>
+  );
+}
+
+export function Stats() {
+  const [window, setWindow] = useState<StatsWindow>("30d");
+  const { play } = usePlayerActions();
+  const { data: overview, loading: overviewLoading } = useApi<StatsOverview>(`/api/me/stats/overview?window=${window}`);
+  const { data: trends, loading: trendsLoading } = useApi<StatsTrends>(`/api/me/stats/trends?window=${window}`);
+  const { data: topTracks, loading: tracksLoading } = useApi<StatsListResponse<StatsTrack>>(`/api/me/stats/top-tracks?window=${window}&limit=10`);
+  const { data: topArtists, loading: artistsLoading } = useApi<StatsListResponse<StatsArtist>>(`/api/me/stats/top-artists?window=${window}&limit=8`);
+  const { data: topAlbums, loading: albumsLoading } = useApi<StatsListResponse<StatsAlbum>>(`/api/me/stats/top-albums?window=${window}&limit=8`);
+  const { data: topGenres, loading: genresLoading } = useApi<StatsListResponse<StatsGenre>>(`/api/me/stats/top-genres?window=${window}&limit=8`);
+
+  const topTrackItems = topTracks?.items ?? [];
+  const topArtistItems = topArtists?.items ?? [];
+  const topAlbumItems = topAlbums?.items ?? [];
+  const topGenreItems = topGenres?.items ?? [];
+
+  const playTopTrack = (item: StatsTrack) => {
+    const track: Track = {
+      id: item.track_path || String(item.track_id || `${item.artist}-${item.title}`),
+      title: item.title,
+      artist: item.artist,
+      album: item.album,
+      path: item.track_path || undefined,
+      libraryTrackId: item.track_id || undefined,
+    };
+    play(track, { type: "track", name: item.title, id: item.track_id ?? item.track_path });
+  };
+
+  const loading = overviewLoading || trendsLoading || tracksLoading || artistsLoading || albumsLoading || genresLoading;
+
+  return (
+    <div className="space-y-8">
+      <div className="flex flex-col gap-4 lg:flex-row lg:items-end lg:justify-between">
+        <div>
+          <div className="inline-flex items-center gap-2 rounded-full border border-primary/20 bg-primary/10 px-3 py-1 text-[11px] font-bold uppercase tracking-[0.2em] text-primary">
+            <BarChart3 size={12} />
+            Stats
+          </div>
+          <h1 className="mt-3 text-3xl font-bold text-foreground">Your listening, quantified</h1>
+          <p className="mt-1 max-w-2xl text-sm text-muted-foreground">
+            A first look at your listening profile across minutes, trends, artists, albums, and tracks.
+          </p>
+        </div>
+        <WindowPicker value={window} onChange={setWindow} />
+      </div>
+
+      <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
+        <OverviewCard
+          icon={Clock3}
+          label="Time listened"
+          value={overview ? formatMinutes(overview.minutes_listened) : loading ? "..." : "0m"}
+          hint={overview ? `${overview.active_days} active days` : "Listening time in the selected window"}
+        />
+        <OverviewCard
+          icon={Music2}
+          label="Qualified plays"
+          value={overview ? String(overview.play_count) : loading ? "..." : "0"}
+          hint={overview ? `${overview.complete_play_count} completed plays` : "Valid plays recorded"}
+        />
+        <OverviewCard
+          icon={SkipForward}
+          label="Skip rate"
+          value={overview ? formatPercent(overview.skip_rate) : loading ? "..." : "0%"}
+          hint={overview ? `${overview.skip_count} skips` : "Tracks you moved on from"}
+        />
+        <OverviewCard
+          icon={TrendingUp}
+          label="Top artist"
+          value={overview?.top_artist?.artist_name ?? (loading ? "..." : "—")}
+          hint={overview?.top_artist ? `${overview.top_artist.play_count} plays` : "No artist data yet"}
+        />
+      </div>
+
+      <Section
+        title="Daily trend"
+        subtitle="Your listening curve across the selected time window."
+      >
+        <TrendChart points={trends?.points ?? []} />
+      </Section>
+
+      <div className="grid gap-4 xl:grid-cols-2">
+        <Section
+          title="Top tracks"
+          subtitle="The songs that defined this window."
+        >
+          <TopList title="Tracks" emptyText="No top tracks yet.">
+            {topTrackItems.map((item, index) => (
+              <button
+                key={`${item.track_id ?? item.track_path ?? item.title}-${index}`}
+                onClick={() => playTopTrack(item)}
+                className="flex w-full items-center gap-3 rounded-xl border border-transparent px-3 py-2 text-left transition-colors hover:border-white/10 hover:bg-white/5"
+              >
+                <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-xl border border-white/10 bg-white/[0.03] text-xs font-semibold text-white/45">
+                  {index + 1}
+                </div>
+                <div className="min-w-0 flex-1">
+                  <div className="truncate text-sm font-medium text-foreground">{item.title}</div>
+                  <div className="truncate text-xs text-muted-foreground">{item.artist} · {item.album}</div>
+                </div>
+                <div className="shrink-0 text-right">
+                  <div className="text-sm font-medium text-foreground">{item.play_count}</div>
+                  <div className="text-[11px] text-muted-foreground">{formatMinutes(item.minutes_listened)}</div>
+                </div>
+              </button>
+            ))}
+          </TopList>
+        </Section>
+
+        <Section
+          title="Top artists"
+          subtitle="Who you kept coming back to."
+        >
+          <TopList title="Artists" emptyText="No top artists yet.">
+            {topArtistItems.map((item, index) => (
+              <Link
+                key={`${item.artist_name}-${index}`}
+                to={`/artist/${encodeURIComponent(item.artist_name)}`}
+                className="flex items-center gap-3 rounded-xl border border-transparent px-3 py-2 transition-colors hover:border-white/10 hover:bg-white/5"
+              >
+                <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-xl border border-white/10 bg-white/[0.03] text-xs font-semibold text-white/45">
+                  {index + 1}
+                </div>
+                <div className="min-w-0 flex-1">
+                  <div className="truncate text-sm font-medium text-foreground">{item.artist_name}</div>
+                  <div className="text-xs text-muted-foreground">{formatMinutes(item.minutes_listened)}</div>
+                </div>
+                <div className="text-sm font-medium text-foreground">{item.play_count}</div>
+              </Link>
+            ))}
+          </TopList>
+        </Section>
+      </div>
+
+      <div className="grid gap-4 xl:grid-cols-2">
+        <Section
+          title="Top albums"
+          subtitle="Records that shaped the window."
+        >
+          <TopList title="Albums" emptyText="No top albums yet.">
+            {topAlbumItems.map((item, index) => (
+              <Link
+                key={`${item.artist}-${item.album}-${index}`}
+                to={`/album/${encodeURIComponent(item.artist)}/${encodeURIComponent(item.album)}`}
+                className="flex items-center gap-3 rounded-xl border border-transparent px-3 py-2 transition-colors hover:border-white/10 hover:bg-white/5"
+              >
+                <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-xl border border-white/10 bg-white/[0.03] text-xs font-semibold text-white/45">
+                  <Disc3 size={14} />
+                </div>
+                <div className="min-w-0 flex-1">
+                  <div className="truncate text-sm font-medium text-foreground">{item.album}</div>
+                  <div className="truncate text-xs text-muted-foreground">{item.artist}</div>
+                </div>
+                <div className="text-right">
+                  <div className="text-sm font-medium text-foreground">{item.play_count}</div>
+                  <div className="text-[11px] text-muted-foreground">{formatMinutes(item.minutes_listened)}</div>
+                </div>
+              </Link>
+            ))}
+          </TopList>
+        </Section>
+
+        <Section
+          title="Top genres"
+          subtitle="Your strongest stylistic pull in this window."
+        >
+          <TopList title="Genres" emptyText="No top genres yet.">
+            {topGenreItems.map((item, index) => (
+              <div
+                key={`${item.genre_name}-${index}`}
+                className="flex items-center gap-3 rounded-xl border border-transparent px-3 py-2"
+              >
+                <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-xl border border-white/10 bg-white/[0.03] text-xs font-semibold text-white/45">
+                  <User2 size={14} />
+                </div>
+                <div className="min-w-0 flex-1">
+                  <div className="truncate text-sm font-medium text-foreground">{item.genre_name}</div>
+                  <div className="text-xs text-muted-foreground">{formatMinutes(item.minutes_listened)}</div>
+                </div>
+                <div className="text-sm font-medium text-foreground">{item.play_count}</div>
+              </div>
+            ))}
+          </TopList>
+        </Section>
+      </div>
+
+      {!loading && !overview?.play_count ? (
+        <div className="rounded-3xl border border-dashed border-white/10 bg-white/[0.02] p-8 text-center">
+          <h2 className="text-lg font-semibold text-foreground">Your stats are waiting for you</h2>
+          <p className="mt-2 text-sm text-muted-foreground">
+            Start listening and this page will turn into your personal listening dashboard.
+          </p>
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/app/shared/web/use-api.ts
+++ b/app/shared/web/use-api.ts
@@ -1,4 +1,5 @@
 import type { ApiMethod } from "./api";
+import type { ApiRequestOptions } from "./api";
 
 export interface UseApiState<T> {
   data: T | null;
@@ -11,6 +12,7 @@ type ApiFn = <T = unknown>(
   url: string,
   method?: ApiMethod,
   body?: unknown,
+  options?: ApiRequestOptions,
 ) => Promise<T>;
 
 interface ReactHookDeps {
@@ -46,6 +48,7 @@ export function createUseApi(reactHooks: ReactHookDeps, apiFn: ApiFn) {
 
     useEffect(() => {
       if (!url) return;
+      const controller = new AbortController();
       let cancelled = false;
 
       if (!hasFetched.current) {
@@ -53,7 +56,7 @@ export function createUseApi(reactHooks: ReactHookDeps, apiFn: ApiFn) {
       }
       setError(null);
 
-      apiFn<T>(url, method, body)
+      apiFn<T>(url, method, body, { signal: controller.signal })
         .then((nextData) => {
           if (!cancelled) {
             setData(nextData);
@@ -61,7 +64,7 @@ export function createUseApi(reactHooks: ReactHookDeps, apiFn: ApiFn) {
           }
         })
         .catch((e: Error) => {
-          if (!cancelled) {
+          if (!cancelled && controller.signal.aborted !== true) {
             setError(e.message);
           }
         })
@@ -73,6 +76,7 @@ export function createUseApi(reactHooks: ReactHookDeps, apiFn: ApiFn) {
 
       return () => {
         cancelled = true;
+        controller.abort();
       };
     }, [url, method, trigger]);
 

--- a/app/tests/test_play_event_contracts.py
+++ b/app/tests/test_play_event_contracts.py
@@ -1,0 +1,58 @@
+"""Contracts for rich user play-event tracking."""
+
+from unittest.mock import patch
+
+
+class TestPlayEventContract:
+    def test_play_event_endpoint_persists_event_payload(self, test_app):
+        payload = {
+            "track_id": 12,
+            "track_path": "Converge/Jane Doe/01 - Concubine.flac",
+            "title": "Concubine",
+            "artist": "Converge",
+            "album": "Jane Doe",
+            "started_at": "2026-04-01T10:00:00Z",
+            "ended_at": "2026-04-01T10:01:34Z",
+            "played_seconds": 73.2,
+            "track_duration_seconds": 94.0,
+            "completion_ratio": 0.779,
+            "was_skipped": True,
+            "was_completed": False,
+            "play_source_type": "album",
+            "play_source_id": "44",
+            "play_source_name": "Jane Doe",
+            "context_artist": "Converge",
+            "context_album": "Jane Doe",
+            "context_playlist_id": None,
+            "device_type": "web",
+            "app_platform": "listen-web",
+        }
+
+        with patch("crate.db.user_library.record_play_event", return_value=77) as mock_record:
+            resp = test_app.post("/api/me/play-events", json=payload)
+
+        assert resp.status_code == 200
+        assert resp.json() == {"ok": True, "id": 77}
+        mock_record.assert_called_once_with(
+            1,
+            track_id=12,
+            track_path="Converge/Jane Doe/01 - Concubine.flac",
+            title="Concubine",
+            artist="Converge",
+            album="Jane Doe",
+            started_at="2026-04-01T10:00:00Z",
+            ended_at="2026-04-01T10:01:34Z",
+            played_seconds=73.2,
+            track_duration_seconds=94.0,
+            completion_ratio=0.779,
+            was_skipped=True,
+            was_completed=False,
+            play_source_type="album",
+            play_source_id="44",
+            play_source_name="Jane Doe",
+            context_artist="Converge",
+            context_album="Jane Doe",
+            context_playlist_id=None,
+            device_type="web",
+            app_platform="listen-web",
+        )

--- a/app/tests/test_play_event_contracts.py
+++ b/app/tests/test_play_event_contracts.py
@@ -28,7 +28,10 @@ class TestPlayEventContract:
             "app_platform": "listen-web",
         }
 
-        with patch("crate.db.user_library.record_play_event", return_value=77) as mock_record:
+        with patch("crate.db.user_library.record_play_event", return_value=77) as mock_record, patch(
+            "crate.db.create_task_dedup",
+            return_value="task123",
+        ) as mock_enqueue:
             resp = test_app.post("/api/me/play-events", json=payload)
 
         assert resp.status_code == 200
@@ -40,8 +43,8 @@ class TestPlayEventContract:
             title="Concubine",
             artist="Converge",
             album="Jane Doe",
-            started_at="2026-04-01T10:00:00Z",
-            ended_at="2026-04-01T10:01:34Z",
+            started_at="2026-04-01T10:00:00+00:00",
+            ended_at="2026-04-01T10:01:34+00:00",
             played_seconds=73.2,
             track_duration_seconds=94.0,
             completion_ratio=0.779,
@@ -56,3 +59,24 @@ class TestPlayEventContract:
             device_type="web",
             app_platform="listen-web",
         )
+        mock_enqueue.assert_called_once_with("refresh_user_listening_stats", {"user_id": 1})
+
+    def test_play_event_endpoint_rejects_inconsistent_completion_flags(self, test_app):
+        payload = {
+            "track_id": 12,
+            "track_path": "Converge/Jane Doe/01 - Concubine.flac",
+            "title": "Concubine",
+            "artist": "Converge",
+            "album": "Jane Doe",
+            "started_at": "2026-04-01T10:00:00Z",
+            "ended_at": "2026-04-01T10:01:34Z",
+            "played_seconds": 73.2,
+            "track_duration_seconds": 94.0,
+            "completion_ratio": 0.779,
+            "was_skipped": True,
+            "was_completed": True,
+        }
+
+        resp = test_app.post("/api/me/play-events", json=payload)
+
+        assert resp.status_code == 422

--- a/app/tests/test_stats_api_contracts.py
+++ b/app/tests/test_stats_api_contracts.py
@@ -1,0 +1,55 @@
+"""Contract tests for stats API MVP."""
+
+from unittest.mock import patch
+
+
+class TestStatsApiContracts:
+    def test_stats_overview_returns_backend_payload(self, test_app):
+        payload = {
+            "window": "30d",
+            "play_count": 48,
+            "complete_play_count": 21,
+            "skip_count": 9,
+            "minutes_listened": 183.5,
+            "active_days": 12,
+            "skip_rate": 0.1875,
+            "top_artist": {"artist_name": "Converge", "play_count": 10, "minutes_listened": 31.0},
+        }
+
+        with patch("crate.db.user_library.get_stats_overview", return_value=payload) as mock_get:
+            resp = test_app.get("/api/me/stats/overview?window=30d")
+
+        assert resp.status_code == 200
+        assert resp.json() == payload
+        mock_get.assert_called_once_with(1, window="30d")
+
+    def test_stats_top_tracks_wraps_items_and_window(self, test_app):
+        items = [{
+            "track_id": 99,
+            "track_path": "/music/Converge/Jane Doe/01 - Concubine.flac",
+            "title": "Concubine",
+            "artist": "Converge",
+            "album": "Jane Doe",
+            "play_count": 7,
+            "complete_play_count": 3,
+            "minutes_listened": 8.2,
+            "first_played_at": "2026-03-01T10:00:00Z",
+            "last_played_at": "2026-04-01T10:00:00Z",
+        }]
+
+        with patch("crate.db.user_library.get_top_tracks", return_value=items) as mock_get:
+            resp = test_app.get("/api/me/stats/top-tracks?window=90d&limit=5")
+
+        assert resp.status_code == 200
+        assert resp.json() == {"window": "90d", "items": items}
+        mock_get.assert_called_once_with(1, window="90d", limit=5)
+
+    def test_stats_invalid_window_returns_400(self, test_app):
+        with patch(
+            "crate.db.user_library.get_stats_trends",
+            side_effect=ValueError("Unsupported stats window: banana"),
+        ):
+            resp = test_app.get("/api/me/stats/trends?window=banana")
+
+        assert resp.status_code == 400
+        assert resp.json()["detail"] == "Unsupported stats window: banana"

--- a/app/tests/test_stats_api_contracts.py
+++ b/app/tests/test_stats_api_contracts.py
@@ -53,3 +53,29 @@ class TestStatsApiContracts:
 
         assert resp.status_code == 400
         assert resp.json()["detail"] == "Unsupported stats window: banana"
+
+    def test_stats_replay_returns_playable_payload(self, test_app):
+        payload = {
+            "window": "30d",
+            "title": "Replay this month",
+            "subtitle": "The tracks that defined your last 30 days.",
+            "track_count": 2,
+            "minutes_listened": 42.5,
+            "items": [{
+                "track_id": 99,
+                "track_path": "/music/Converge/Jane Doe/01 - Concubine.flac",
+                "title": "Concubine",
+                "artist": "Converge",
+                "album": "Jane Doe",
+                "play_count": 7,
+                "complete_play_count": 3,
+                "minutes_listened": 8.2,
+            }],
+        }
+
+        with patch("crate.db.user_library.get_replay_mix", return_value=payload) as mock_get:
+            resp = test_app.get("/api/me/stats/replay?window=30d&limit=25")
+
+        assert resp.status_code == 200
+        assert resp.json() == payload
+        mock_get.assert_called_once_with(1, window="30d", limit=25)

--- a/app/tests/test_upcoming_intelligence_contracts.py
+++ b/app/tests/test_upcoming_intelligence_contracts.py
@@ -1,0 +1,45 @@
+"""Contract coverage for Upcoming intelligence surfaces."""
+
+from datetime import datetime, timedelta, timezone
+from unittest.mock import patch
+
+from crate.api.me import _build_upcoming_insights
+
+
+class TestUpcomingIntelligenceContracts:
+    def test_build_upcoming_insights_emits_show_prep_for_attending_hot_artist(self):
+        show_date = (datetime.now(timezone.utc) + timedelta(days=6)).strftime("%Y-%m-%d")
+        shows = [{
+            "id": 42,
+            "artist_name": "Converge",
+            "venue": "Roadburn",
+            "date": show_date,
+            "probable_setlist": [{"title": "Concubine"}],
+        }]
+
+        with patch("crate.db.get_show_reminders", return_value=[]), patch(
+            "crate.db.user_library.get_top_artists",
+            return_value=[{"artist_name": "Converge"}],
+        ):
+            insights = _build_upcoming_insights(1, shows, {42})
+
+        insight_types = {item["type"] for item in insights}
+        assert "one_week" in insight_types
+        assert "show_prep" in insight_types
+        show_prep = next(item for item in insights if item["type"] == "show_prep")
+        assert show_prep["weight"] == "high"
+        assert show_prep["has_setlist"] is True
+
+    def test_create_show_reminder_endpoint_accepts_supported_types(self, test_app):
+        with patch("crate.db.create_show_reminder", return_value=True) as mock_create:
+            resp = test_app.post("/api/me/shows/42/reminders", json={"reminder_type": "show_prep"})
+
+        assert resp.status_code == 200
+        assert resp.json() == {"ok": True, "added": True}
+        mock_create.assert_called_once_with(1, 42, "show_prep")
+
+    def test_create_show_reminder_endpoint_rejects_unknown_types(self, test_app):
+        resp = test_app.post("/api/me/shows/42/reminders", json={"reminder_type": "banana"})
+
+        assert resp.status_code == 400
+        assert resp.json()["detail"] == "Unsupported reminder type"

--- a/app/tests/test_user_stats_aggregates.py
+++ b/app/tests/test_user_stats_aggregates.py
@@ -8,7 +8,7 @@ pytestmark = pytest.mark.skipif(not PG_AVAILABLE, reason="PostgreSQL not availab
 
 
 class TestUserListeningAggregates:
-    def test_record_play_event_recomputes_daily_and_entity_stats(self, pg_db):
+    def test_recompute_user_listening_aggregates_populates_daily_and_entity_stats(self, pg_db):
         pg_db.upsert_artist({"name": "Converge"})
         album_id = pg_db.upsert_album({
             "artist": "Converge",
@@ -54,6 +54,7 @@ class TestUserListeningAggregates:
         )
 
         assert event_id is not None
+        pg_db.recompute_user_listening_aggregates(1)
 
         with pg_db.get_db_ctx() as cur:
             cur.execute(

--- a/app/tests/test_user_stats_aggregates.py
+++ b/app/tests/test_user_stats_aggregates.py
@@ -1,0 +1,94 @@
+"""Integration tests for listening aggregate tables."""
+
+import pytest
+
+from tests.conftest import PG_AVAILABLE
+
+pytestmark = pytest.mark.skipif(not PG_AVAILABLE, reason="PostgreSQL not available")
+
+
+class TestUserListeningAggregates:
+    def test_record_play_event_recomputes_daily_and_entity_stats(self, pg_db):
+        pg_db.upsert_artist({"name": "Converge"})
+        album_id = pg_db.upsert_album({
+            "artist": "Converge",
+            "name": "Jane Doe",
+            "path": "/music/Converge/Jane Doe",
+        })
+        pg_db.upsert_track({
+            "album_id": album_id,
+            "artist": "Converge",
+            "album": "Jane Doe",
+            "filename": "01 - Concubine.flac",
+            "title": "Concubine",
+            "track_number": 1,
+            "format": "flac",
+            "genre": "Metalcore",
+            "duration": 94.0,
+            "path": "/music/Converge/Jane Doe/01 - Concubine.flac",
+        })
+
+        track = pg_db.get_library_tracks(album_id)[0]
+
+        event_id = pg_db.record_play_event(
+            1,
+            track_id=track["id"],
+            track_path=track["path"],
+            title=track["title"],
+            artist=track["artist"],
+            album=track["album"],
+            started_at="2026-04-01T10:00:00+00:00",
+            ended_at="2026-04-01T10:01:10+00:00",
+            played_seconds=70.0,
+            track_duration_seconds=94.0,
+            completion_ratio=0.74,
+            was_skipped=True,
+            was_completed=False,
+            play_source_type="album",
+            play_source_id=str(album_id),
+            play_source_name="Jane Doe",
+            context_artist="Converge",
+            context_album="Jane Doe",
+            device_type="web",
+            app_platform="listen-web",
+        )
+
+        assert event_id is not None
+
+        with pg_db.get_db_ctx() as cur:
+            cur.execute(
+                "SELECT * FROM user_daily_listening WHERE user_id = %s AND day = %s",
+                (1, "2026-04-01"),
+            )
+            daily = cur.fetchone()
+            assert daily["play_count"] == 1
+            assert daily["skip_count"] == 1
+            assert daily["complete_play_count"] == 0
+            assert round(daily["minutes_listened"], 2) == round(70.0 / 60.0, 2)
+            assert daily["unique_tracks"] == 1
+            assert daily["unique_artists"] == 1
+            assert daily["unique_albums"] == 1
+
+            cur.execute(
+                """
+                SELECT artist_name, play_count, minutes_listened
+                FROM user_artist_stats
+                WHERE user_id = %s AND window = 'all_time'
+                """,
+                (1,),
+            )
+            artist_stats = cur.fetchone()
+            assert artist_stats["artist_name"] == "Converge"
+            assert artist_stats["play_count"] == 1
+
+            cur.execute(
+                """
+                SELECT genre_name, play_count
+                FROM user_genre_stats
+                WHERE user_id = %s AND window = 'all_time'
+                """,
+                (1,),
+            )
+            genre_stats = cur.fetchone()
+            assert genre_stats["genre_name"] == "Metalcore"
+            assert genre_stats["play_count"] == 1

--- a/docs/plans/2026-03-30-listen-refactor-and-bug-roadmap.md
+++ b/docs/plans/2026-03-30-listen-refactor-and-bug-roadmap.md
@@ -437,6 +437,7 @@ Follow-up architectural decision:
   - current `play_history` is too thin for a serious stats, Wrapped, or personalization surface
   - future work should move toward richer per-user playback events with played seconds, completion/skip state, and playback source context
   - see `docs/plans/2026-03-31-listen-user-stats-and-wrapped-design.md`
+  - execution roadmap for stats + upcoming intelligence now lives in `docs/plans/2026-04-01-stats-and-upcoming-intelligence-roadmap.md`
 - system playlists created in `admin` are not yet surfaced in `listen` discovery/library:
   - most visible surfaces are now wired (`Home`, `Explore`, `Library`, playlist detail)
   - still worth checking that discovery keeps a good editorial hierarchy as more system playlists appear

--- a/docs/plans/2026-04-01-stats-and-upcoming-intelligence-roadmap.md
+++ b/docs/plans/2026-04-01-stats-and-upcoming-intelligence-roadmap.md
@@ -174,6 +174,8 @@ Current implementation notes:
 
 ## Batch 3 - Stats API MVP
 
+**Current status**: first implementation batch delivered
+
 ### Goal
 
 Expose useful, stable stats endpoints before building visual surfaces.
@@ -187,6 +189,23 @@ Expose useful, stable stats endpoints before building visual surfaces.
 - `GET /api/me/stats/top-albums`
 - `GET /api/me/stats/top-genres`
 - `GET /api/me/stats/recent-wins` or similar lightweight summary endpoint
+
+Current implementation notes:
+
+- the MVP API now ships:
+  - `GET /api/me/stats/overview`
+  - `GET /api/me/stats/trends`
+  - `GET /api/me/stats/top-tracks`
+  - `GET /api/me/stats/top-artists`
+  - `GET /api/me/stats/top-albums`
+  - `GET /api/me/stats/top-genres`
+- supported windows currently are:
+  - `7d`
+  - `30d`
+  - `90d`
+  - `365d`
+  - `all_time`
+- `recent-wins` is still deferred
 
 ### Output expectations
 

--- a/docs/plans/2026-04-01-stats-and-upcoming-intelligence-roadmap.md
+++ b/docs/plans/2026-04-01-stats-and-upcoming-intelligence-roadmap.md
@@ -86,6 +86,8 @@ A show reminder is more valuable if it knows:
 
 ## Batch 1 - Rich Play Event Tracking
 
+**Current status**: first implementation batch delivered
+
 ### Goal
 
 Replace the current thin play history model with an event model that can support real stats.
@@ -131,6 +133,8 @@ Replace the current thin play history model with an event model that can support
 
 ## Batch 2 - Daily And Windowed Aggregates
 
+**Current status**: first implementation batch delivered
+
 ### Goal
 
 Create fast derived data for overview and trends.
@@ -146,6 +150,13 @@ Create fast derived data for overview and trends.
 - define update strategy:
   - synchronous lightweight update for daily counters where safe
   - background task/materialization refresh for heavier windows
+
+Current implementation notes:
+
+- aggregate tables now exist in the schema
+- aggregates are recomputed per user when a new play event is recorded
+- `GET /api/me/stats` already benefits from aggregate data for all-time totals/top artists
+- this is intentionally synchronous for the first batch and may move to a task/materialization strategy later
 
 ### Windows
 

--- a/docs/plans/2026-04-01-stats-and-upcoming-intelligence-roadmap.md
+++ b/docs/plans/2026-04-01-stats-and-upcoming-intelligence-roadmap.md
@@ -230,6 +230,8 @@ Current implementation notes:
 
 ## Batch 4 - Stats UI MVP In Listen
 
+**Current status**: first implementation batch delivered
+
 ### Goal
 
 Ship a first useful stats surface before Wrapped.
@@ -245,6 +247,19 @@ Ship a first useful stats surface before Wrapped.
   - trend chart
   - time-window selector
 - keep the first version functional, not overly narrative
+
+Current implementation notes:
+
+- `listen` now has a first `Stats` page wired to the MVP stats API
+- the first version includes:
+  - overview cards
+  - daily trend chart
+  - top tracks
+  - top artists
+  - top albums
+  - top genres
+  - time-window switching
+- replay objects and narrative recap surfaces are still deferred to later batches
 
 ### Notes
 

--- a/docs/plans/2026-04-01-stats-and-upcoming-intelligence-roadmap.md
+++ b/docs/plans/2026-04-01-stats-and-upcoming-intelligence-roadmap.md
@@ -1,0 +1,407 @@
+# Crate Stats And Upcoming Intelligence Roadmap
+
+**Date**: 2026-04-01
+**Status**: Active
+**Scope**: `listen` identity surfaces, listening telemetry, reminders, show-prep, and Wrapped foundations
+
+## Goal
+
+Build the next major product layer for `listen` around two linked ideas:
+
+- rich per-user listening telemetry that can power stats, replay, mixes, and Wrapped
+- a stronger `Upcoming` surface that uses those signals for reminders and pre-show listening value
+
+This roadmap assumes:
+
+- playback remains anchored in Crate-owned library identity (`track_id`)
+- Navidrome can remain a playback backend, but not the source of truth for stats product logic
+- `Upcoming` stays user-facing inside `listen`, not an admin-only surface
+- backend support should ship in thin, mergeable batches before the UI becomes ambitious
+
+## Why These Two Iterations Belong Together
+
+`Stats / Wrapped` and `Upcoming` solve different product problems, but they reinforce each other:
+
+- stats create durable identity and retention
+- upcoming creates ambient utility around real-world music events
+- listening telemetry lets Crate decide when a show reminder is relevant
+- attending a show becomes a strong context for likely-setlist playback and recap surfaces
+
+Together, they push `listen` past direct library playback into a product that feels alive between explicit play actions.
+
+## Source Documents
+
+This roadmap consolidates and sequences the work proposed in:
+
+- [2026-03-31-listen-user-stats-and-wrapped-design.md](/Users/diego/Code/Ninja/musicdock/worktrees/stats-upcoming-intelligence/docs/plans/2026-03-31-listen-user-stats-and-wrapped-design.md)
+- [2026-03-31-listen-product-gap-analysis.md](/Users/diego/Code/Ninja/musicdock/worktrees/stats-upcoming-intelligence/docs/plans/2026-03-31-listen-product-gap-analysis.md)
+- [2026-03-30-listen-refactor-and-bug-roadmap.md](/Users/diego/Code/Ninja/musicdock/worktrees/stats-upcoming-intelligence/docs/plans/2026-03-30-listen-refactor-and-bug-roadmap.md)
+
+## Product Outcomes
+
+By the end of this roadmap, Crate should be able to support:
+
+- a trustworthy `Stats` surface inside `listen`
+- monthly / yearly / all-time summaries and replay objects
+- future `Wrapped` narratives without rebuilding the data layer
+- reminders for upcoming attended shows
+- show-prep prompts tied to probable setlists and real listening behavior
+- richer Home surfaces such as:
+  - listening trends
+  - replay mixes
+  - upcoming reminders
+  - pre-show listening prompts
+
+## Guiding Principles
+
+### 1. Track identity first
+
+All serious listening telemetry should use `track_id` as the primary identity. `track_path` can stay as compatibility/debug metadata, but should not be the foundation of stats.
+
+### 2. Count clearly and explainably
+
+If Crate says a user has listened to something, the counting rule should be easy to explain:
+
+- started
+- qualified
+- completed
+- skipped
+
+Wrapped and stats become untrustworthy very quickly if the counting criteria are fuzzy.
+
+### 3. Build data infrastructure before visual storytelling
+
+The first milestone is not a flashy Wrapped UI. The first milestone is a durable event model and stable aggregates.
+
+### 4. Upcoming should use listening context, not just date proximity
+
+A show reminder is more valuable if it knows:
+
+- the user is actually attending
+- the user has listened heavily to that artist recently
+- a probable setlist exists
+- the show is close enough to warrant prep or reminder UX
+
+## Batches
+
+## Batch 1 - Rich Play Event Tracking
+
+### Goal
+
+Replace the current thin play history model with an event model that can support real stats.
+
+### Backend
+
+- add `user_play_events` table
+- keep `play_history` temporarily for backward compatibility
+- add helper functions in user library / stats DB layer
+- add `POST /api/me/play-events`
+- define consistent event payload fields:
+  - `track_id`
+  - `track_path`
+  - `started_at`
+  - `ended_at`
+  - `played_seconds`
+  - `track_duration_seconds`
+  - `completion_ratio`
+  - `was_skipped`
+  - `was_completed`
+  - `play_source_type`
+  - `play_source_id`
+  - `play_source_name`
+  - `device_type`
+  - `app_platform`
+
+### Listen
+
+- instrument `PlayerContext` for:
+  - start
+  - stop
+  - skip
+  - completion
+- move from “report only on track end” to “flush an explicit play event”
+- ensure events survive normal pause/resume behavior without double counting
+
+### Acceptance
+
+- track completion and skip produce distinct events
+- event rows use `track_id`
+- recently played still works
+- no visible regression in player behavior
+
+## Batch 2 - Daily And Windowed Aggregates
+
+### Goal
+
+Create fast derived data for overview and trends.
+
+### Backend
+
+- add `user_daily_listening`
+- add aggregate tables or materializations for:
+  - `user_track_stats`
+  - `user_artist_stats`
+  - `user_album_stats`
+  - `user_genre_stats`
+- define update strategy:
+  - synchronous lightweight update for daily counters where safe
+  - background task/materialization refresh for heavier windows
+
+### Windows
+
+- `7d`
+- `30d`
+- `90d`
+- `365d`
+- `all_time`
+- `monthly:<yyyy-mm>`
+
+### Acceptance
+
+- top artists/tracks/albums can be queried quickly by window
+- daily minutes / play counts are queryable without scanning raw events
+
+## Batch 3 - Stats API MVP
+
+### Goal
+
+Expose useful, stable stats endpoints before building visual surfaces.
+
+### Backend endpoints
+
+- `GET /api/me/stats/overview`
+- `GET /api/me/stats/trends`
+- `GET /api/me/stats/top-tracks`
+- `GET /api/me/stats/top-artists`
+- `GET /api/me/stats/top-albums`
+- `GET /api/me/stats/top-genres`
+- `GET /api/me/stats/recent-wins` or similar lightweight summary endpoint
+
+### Output expectations
+
+- overview:
+  - minutes listened
+  - play count
+  - complete plays
+  - skip rate
+  - streak / active days if available
+- trends:
+  - daily listening curve
+  - weekly or monthly comparatives
+- entity endpoints:
+  - stable sorted lists
+  - counts and minutes
+  - optional movement vs previous period later
+
+### Acceptance
+
+- endpoints are fast enough for an in-app dashboard
+- contracts are testable without the UI
+
+## Batch 4 - Stats UI MVP In Listen
+
+### Goal
+
+Ship a first useful stats surface before Wrapped.
+
+### Listen
+
+- add `Stats` page
+- include:
+  - overview cards
+  - top artists
+  - top tracks
+  - top albums
+  - trend chart
+  - time-window selector
+- keep the first version functional, not overly narrative
+
+### Notes
+
+- this is the “stats.fm / volt.fm utility” layer
+- Wrapped storytelling comes later
+
+### Acceptance
+
+- a user can understand their last 30 days and all-time profile
+- the page feels credible and not obviously placeholder
+
+## Batch 5 - Replay Objects And Listening Recaps
+
+### Goal
+
+Turn stats into playable objects.
+
+### Backend
+
+- derive replay mixes from stats/history:
+  - monthly replay
+  - yearly replay
+  - all-time replay
+- define replay generation rules:
+  - qualified plays only
+  - duplicate caps
+  - recent freshness rules where needed
+
+### Listen
+
+- add replay surfaces to `Home` and/or `Stats`
+- add simple recap modules such as:
+  - “Your month so far”
+  - “Your top artists this month”
+  - “Replay March 2026”
+
+### Acceptance
+
+- stats are not just a dashboard; they produce listening objects
+
+## Batch 6 - Upcoming Intelligence Foundation
+
+### Goal
+
+Turn `Upcoming` from a useful page into an active assistant around attended shows.
+
+### Backend
+
+- extend attendance model if needed with reminder state
+- add reminder metadata:
+  - `one_month_sent_at`
+  - `one_week_sent_at`
+  - `day_before_sent_at`
+- define a background task that scans future attended shows and emits reminder candidates
+
+### Candidate API
+
+- `GET /api/me/upcoming/reminders`
+- or fold reminders into `GET /api/me/upcoming`
+
+### Reminder types
+
+- `show_reminder`
+- `setlist_ready`
+- `pre_show_prep`
+
+### Acceptance
+
+- the system can know which attended shows deserve a reminder
+- reminder state is persisted and not re-sent repeatedly
+
+## Batch 7 - Show Prep And Setlist Prompts
+
+### Goal
+
+Use listening context to make `Upcoming` feel uniquely Crate.
+
+### Surfaces
+
+- in `Upcoming`
+- in `Home`
+- optional lightweight in `Artist`
+
+### UX examples
+
+- “Roadburn is in 30 days. Want to warm up with the probable setlist?”
+- “You’re going to see Kneecap next week. Play the likely setlist.”
+- “You’ve barely listened to this artist lately. Start a prep session?”
+
+### Logic inputs
+
+- attendance state
+- event proximity
+- probable setlist availability
+- recent listening intensity from `user_play_events`
+
+### Acceptance
+
+- pre-show prompts feel relevant, not spammy
+- setlist playback is directly actionable
+
+## Batch 8 - Wrapped / Year In Review
+
+### Goal
+
+Build the narrative layer on top of proven aggregates.
+
+### Output
+
+- yearly summary
+- top tracks / artists / albums / genres
+- total minutes
+- listening personality-style insights only if grounded in real data
+- optional shareable cards later
+
+### Important rule
+
+Wrapped should be a productized story over validated stats, not a separate counting system.
+
+### Acceptance
+
+- the numbers shown in Wrapped match the stats foundation
+- the product feels special without becoming gimmicky
+
+## Dependency Order
+
+The critical path is:
+
+1. Batch 1
+2. Batch 2
+3. Batch 3
+4. Batch 4
+
+Then the roadmap can branch:
+
+- `Replay / Wrapped` path:
+  - Batch 5
+  - Batch 8
+- `Upcoming intelligence` path:
+  - Batch 6
+  - Batch 7
+
+This means we should not block all of `Upcoming` on Wrapped, but both should share the same telemetry foundation.
+
+## Risks
+
+### Player instrumentation complexity
+
+`PlayerContext` is already a hotspot. Play-event instrumentation should be added carefully and may justify extracting a small reporting/controller layer early.
+
+### Double counting
+
+Seek, pause, replay, and skip behavior can easily inflate stats if the event model is naïve.
+
+### Data volume
+
+Raw `user_play_events` will grow much faster than `play_history`. Retention, indexing, and aggregation strategy matter from the start.
+
+### False precision
+
+It is better to ship fewer, trustworthy metrics than many opaque ones.
+
+### Reminder fatigue
+
+`Upcoming` reminders should be sparse and valuable. This is not a notification treadmill.
+
+## Recommended First Implementation Batch
+
+Start with Batch 1 only.
+
+Concrete first cut:
+
+- schema for `user_play_events`
+- backend endpoint `POST /api/me/play-events`
+- `listen` instrumentation in `PlayerContext`
+- keep existing `play_history` posting temporarily if needed for compatibility
+- basic tests for:
+  - completed play
+  - skipped play
+  - duplicate protection around fast track changes
+
+This gives us the highest-leverage foundation with the lowest product ambiguity.
+
+## Out Of Scope For This Iteration
+
+- social features
+- public profile stats
+- clips / stories / feed mechanics
+- AI-generated listening personalities without explicit rules
+- giant notification systems outside show-related reminders

--- a/docs/plans/2026-04-01-stats-and-upcoming-intelligence-roadmap.md
+++ b/docs/plans/2026-04-01-stats-and-upcoming-intelligence-roadmap.md
@@ -302,6 +302,8 @@ Turn stats into playable objects.
 
 ## Batch 6 - Upcoming Intelligence Foundation
 
+**Current status**: first implementation batch delivered
+
 ### Goal
 
 Turn `Upcoming` from a useful page into an active assistant around attended shows.
@@ -314,6 +316,25 @@ Turn `Upcoming` from a useful page into an active assistant around attended show
   - `one_week_sent_at`
   - `day_before_sent_at`
 - define a background task that scans future attended shows and emits reminder candidates
+
+Current implementation notes:
+
+- schema now includes `user_show_reminders`
+- `GET /api/me/upcoming` now returns:
+  - `insights`
+  - `summary.attending_count`
+  - `summary.insight_count`
+- `POST /api/me/shows/{show_id}/reminders` persists reminder consumption / acknowledgement
+- insight generation currently uses:
+  - attendance state
+  - show proximity
+  - probable setlist availability
+  - a lightweight `top artists in last 30d` signal from stats aggregates
+- `listen` now renders a first `Show prep` section in `Upcoming` with:
+  - one-month reminders
+  - one-week reminders
+  - show-prep prompts
+  - direct probable setlist playback when available
 
 ### Candidate API
 
@@ -332,6 +353,8 @@ Turn `Upcoming` from a useful page into an active assistant around attended show
 - reminder state is persisted and not re-sent repeatedly
 
 ## Batch 7 - Show Prep And Setlist Prompts
+
+**Current status**: partially delivered on top of Batch 6
 
 ### Goal
 


### PR DESCRIPTION
## Summary
- add rich `user_play_events` tracking and aggregate listening stats foundations
- ship a first Stats surface in Listen with overview, trends, top entities, replay, and recap modules
- add Upcoming intelligence foundations with reminders, show-prep insights, and probable setlist entry points across Upcoming, Home, and Artist
- rebase the branch onto `main` and refactor player intelligence boundaries so `PlayerContext` delegates more playback logic to focused hooks

## Backend
- add `user_play_events` plus aggregate tables for daily listening and top tracks/artists/albums/genres
- add stats API endpoints under `/api/me/stats/*`, including replay
- extend `/api/me/upcoming` with insights and summary counters
- add `POST /api/me/shows/{show_id}/reminders`

## Listen
- add `Stats` page with window switching, trend chart, replay playback, and recap cards
- add replay surfaces in Home
- add show-prep insight surfaces in Upcoming, Home, and Artist
- extract playback intelligence from `PlayerContext` into focused hooks/utilities as part of the rebase resolution

## Validation
- `npm run build` in `app/listen` OK
- `env PYTHONPYCACHEPREFIX=/tmp/pycache python3 -m py_compile app/crate/api/me.py app/crate/db/core.py app/crate/db/user_library.py app/crate/db/shows.py app/crate/db/__init__.py` OK
- `docker run --rm --entrypoint pytest crate-stats-tests tests/test_play_event_contracts.py tests/test_stats_api_contracts.py tests/test_upcoming_intelligence_contracts.py -q` OK (`7 passed`)

## Notes
- this PR includes the branch rebase onto `main`, because `main` moved after the previous large Listen/Radio merge
- replay/recap is MVP-level and intentionally stops short of full Wrapped storytelling
- Upcoming reminders are persisted and acknowledged, but background reminder delivery is still a later iteration

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New Stats page with overview, trends chart, top tracks/artists/albums/genres, replay mix, and window selector (7d/30d/90d/365d/all_time)
  * Play-event tracking to improve replay and stats accuracy
  * “Show prep” insights on Home/Shows with probable setlist playback and dismiss/acknowledge reminders
  * Create reminders for shows from the UI

* **Tests**
  * Added contract and integration tests covering stats, play-event recording, reminders, and aggregate recomputation

* **Documentation**
  * Added roadmap outlining stats and upcoming-intelligence plans
<!-- end of auto-generated comment: release notes by coderabbit.ai -->