### PR TITLE
fix: frontend bugs and performance batch

### DIFF
--- a/app/listen/src/App.tsx
+++ b/app/listen/src/App.tsx
@@ -64,21 +64,26 @@ function ProtectedRoute({ children }: { children: React.ReactNode }) {
 export function App() {
   return (
     <AuthProvider>
-      <PlayerProvider>
-        <LikedTracksProvider>
-          <UserSyncProvider>
-            <SavedAlbumsProvider>
-              <PlaylistComposerProvider>
-                <Routes>
-                  <Route path="/login" element={<Login />} />
-                  <Route path="/register" element={<Register />} />
-                  <Route
-                    element={
-                      <ProtectedRoute>
+      <Routes>
+        <Route path="/login" element={<Login />} />
+        <Route path="/register" element={<Register />} />
+        <Route
+          element={
+            <ProtectedRoute>
+              <PlayerProvider>
+                <LikedTracksProvider>
+                  <UserSyncProvider>
+                    <SavedAlbumsProvider>
+                      <PlaylistComposerProvider>
                         <Shell />
-                      </ProtectedRoute>
-                    }
-                  >
+                      </PlaylistComposerProvider>
+                    </SavedAlbumsProvider>
+                  </UserSyncProvider>
+                </LikedTracksProvider>
+              </PlayerProvider>
+            </ProtectedRoute>
+          }
+        >
                     <Route index element={<Home />} />
                     <Route path="explore" element={<Explore />} />
                     <Route path="library" element={<Library />} />
@@ -143,11 +148,6 @@ export function App() {
                     />
                   </Route>
                 </Routes>
-              </PlaylistComposerProvider>
-            </SavedAlbumsProvider>
-          </UserSyncProvider>
-        </LikedTracksProvider>
-      </PlayerProvider>
     </AuthProvider>
   );
 }

--- a/app/listen/src/components/cards/AlbumCard.tsx
+++ b/app/listen/src/components/cards/AlbumCard.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { memo, useState } from "react";
 import { useNavigate } from "react-router";
 import { Heart, Loader2, Play } from "lucide-react";
 
@@ -31,7 +31,7 @@ interface AlbumData {
   }>;
 }
 
-export function AlbumCard({ artist, album, albumId, year, cover, compact }: AlbumCardProps) {
+export const AlbumCard = memo(function AlbumCard({ artist, album, albumId, year, cover, compact }: AlbumCardProps) {
   const navigate = useNavigate();
   const { playAll } = usePlayerActions();
   const { isSaved, toggleAlbumSaved } = useSavedAlbums();
@@ -120,4 +120,4 @@ export function AlbumCard({ artist, album, albumId, year, cover, compact }: Albu
       </div>
     </div>
   );
-}
+});

--- a/app/listen/src/components/cards/TrackRow.tsx
+++ b/app/listen/src/components/cards/TrackRow.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from "react";
+import { memo, useEffect, useRef, useState } from "react";
 import { Play, Pause, Plus, ListPlus, Heart, ListMusic } from "lucide-react";
 import { usePlayer, usePlayerActions, type Track } from "@/contexts/PlayerContext";
 import { useLikedTracks } from "@/contexts/LikedTracksContext";
@@ -34,7 +34,7 @@ interface TrackRowProps {
   onCreatePlaylist?: (track: TrackRowData) => void | Promise<void>;
 }
 
-export function TrackRow({
+export const TrackRow = memo(function TrackRow({
   track,
   index,
   showArtist = false,
@@ -246,4 +246,4 @@ export function TrackRow({
       </div>
     </div>
   );
-}
+});

--- a/app/listen/src/components/player/LyricsPanel.tsx
+++ b/app/listen/src/components/player/LyricsPanel.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef } from "react";
+import { useState, useEffect, useRef, useMemo } from "react";
 import { X, Loader2 } from "lucide-react";
 import { usePlayer, usePlayerActions } from "@/contexts/PlayerContext";
 import { extractPalette } from "@/lib/palette";
@@ -117,25 +117,23 @@ export function LyricsPanel({ open, onClose }: LyricsPanelProps) {
     };
   }, [open, currentTrack?.albumCover, useAlbumPalette]);
 
-  // Auto-scroll to active line
+  // Find active line index
+  const activeIndex = useMemo(() => {
+    if (!lyrics?.synced) return -1;
+    for (let i = lyrics.synced.length - 1; i >= 0; i--) {
+      if (currentTime >= lyrics.synced[i]!.time) return i;
+    }
+    return -1;
+  }, [currentTime, lyrics?.synced]);
+
+  // Auto-scroll only when active line changes (not every currentTime tick)
   useEffect(() => {
     if (activeRef.current && containerRef.current) {
       activeRef.current.scrollIntoView({ behavior: "smooth", block: "center" });
     }
-  }, [currentTime]);
+  }, [activeIndex]);
 
   if (!open) return null;
-
-  // Find active line index
-  let activeIndex = -1;
-  if (lyrics?.synced) {
-    for (let i = lyrics.synced.length - 1; i >= 0; i--) {
-      if (currentTime >= lyrics.synced[i]!.time) {
-        activeIndex = i;
-        break;
-      }
-    }
-  }
 
   const primary = palette?.primary ?? [0.024, 0.714, 0.831];
   const secondary = palette?.secondary ?? [0.4, 0.9, 1.0];

--- a/app/listen/src/contexts/use-play-event-tracker.ts
+++ b/app/listen/src/contexts/use-play-event-tracker.ts
@@ -70,7 +70,7 @@ export function usePlayEventTracker(
     const completionRatio = trackDurationSeconds && trackDurationSeconds > 0
       ? Math.min(1, playedSeconds / trackDurationSeconds)
       : null;
-    const wasCompleted = reason === "completed" || (completionRatio !== null && completionRatio >= 0.9);
+    const wasCompleted = reason === "completed";
     const wasSkipped = reason === "skipped" && playedSeconds >= PLAY_EVENT_MIN_SECONDS;
 
     fetch("/api/me/play-events", {


### PR DESCRIPTION
## Summary

Frontend bug fixes and performance improvements.

### Bug fixes
- **#84** LyricsPanel scrollIntoView now triggers on `activeIndex` change only (was every ~250ms currentTime tick)
- **#86** `wasCompleted` only true when `reason === "completed"`, not when completion ratio > 90% on a skipped track
- **#15** Data-fetching providers (LikedTracks, SavedAlbums, UserSync, PlaylistComposer) moved inside ProtectedRoute — no more 401 API calls on login/register pages

### Performance
- **#93** `TrackRow` and `AlbumCard` wrapped in `React.memo` — prevents re-renders in long lists when parent state changes (player currentTime, liked tracks context, etc.)

## Test plan
- [x] `npm run build` passes
- [x] Login/Register pages don't trigger authenticated API calls