### PR TITLE
fix: high impact — dead code removal and dedup extraction

### DIFF
--- a/app/listen/src/components/player/PlayerBar.tsx
+++ b/app/listen/src/components/player/PlayerBar.tsx
@@ -16,7 +16,6 @@ import { AppMenuButton, AppPopover } from "@/components/ui/AppPopover";
 import { type PlaylistComposerTrack } from "@/components/playlists/PlaylistCreateModal";
 import { encPath } from "@/lib/utils";
 import { toast } from "sonner";
-import { FullscreenPlayer } from "@/components/player/FullscreenPlayer";
 import { QueuePanel } from "@/components/player/QueuePanel";
 import { LyricsPanel } from "@/components/player/LyricsPanel";
 import { ExtendedPlayer } from "@/components/player/ExtendedPlayer";
@@ -69,7 +68,6 @@ export function PlayerBar() {
   const { frequencies } = useAudioVisualizer(audioElement, isPlaying);
 
   const navigate = useNavigate();
-  const [fsOpen, setFsOpen] = useState(false);
   const [extendedOpen, setExtendedOpen] = useState(false);
   const [showVolume, setShowVolume] = useState(false);
   const [showMenu, setShowMenu] = useState(false);
@@ -472,7 +470,6 @@ export function PlayerBar() {
       <QueuePanel open={showQueue} onClose={() => setShowQueue(false)} />
       <LyricsPanel open={showLyrics} onClose={() => setShowLyrics(false)} />
       <ExtendedPlayer open={extendedOpen} onClose={() => setExtendedOpen(false)} />
-      <FullscreenPlayer open={fsOpen} onClose={() => setFsOpen(false)} />
     </>
   );
 }

--- a/app/listen/src/components/playlists/PlaylistListRow.tsx
+++ b/app/listen/src/components/playlists/PlaylistListRow.tsx
@@ -6,7 +6,7 @@ import { toast } from "sonner";
 import { api } from "@/lib/api";
 import { PlaylistArtwork, type PlaylistArtworkTrack } from "@/components/playlists/PlaylistArtwork";
 import { usePlayerActions, type Track } from "@/contexts/PlayerContext";
-import { encPath } from "@/lib/utils";
+import { encPath, shuffleArray } from "@/lib/utils";
 
 interface PlaylistTrackResponse {
   track_id?: number;
@@ -47,16 +47,6 @@ interface PlaylistListRowProps {
   }>;
 }
 
-function shuffleArray<T>(arr: T[]): T[] {
-  const copy = [...arr];
-  for (let i = copy.length - 1; i > 0; i--) {
-    const j = Math.floor(Math.random() * (i + 1));
-    const tmp = copy[i]!;
-    copy[i] = copy[j]!;
-    copy[j] = tmp;
-  }
-  return copy;
-}
 
 function toPlayerTracks(tracks: PlaylistTrackResponse[]): Track[] {
   return tracks.map((track) => ({

--- a/app/listen/src/lib/utils.ts
+++ b/app/listen/src/lib/utils.ts
@@ -6,3 +6,22 @@ export * from "../../../shared/web/utils";
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));
 }
+
+export function formatTotalDuration(seconds: number): string {
+  if (!seconds) return "";
+  const h = Math.floor(seconds / 3600);
+  const m = Math.floor((seconds % 3600) / 60);
+  if (h > 0) return `${h} hr ${m} min`;
+  return `${m} min`;
+}
+
+export function shuffleArray<T>(arr: T[]): T[] {
+  const copy = [...arr];
+  for (let i = copy.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    const tmp = copy[i]!;
+    copy[i] = copy[j]!;
+    copy[j] = tmp;
+  }
+  return copy;
+}

--- a/app/listen/src/pages/Album.tsx
+++ b/app/listen/src/pages/Album.tsx
@@ -12,7 +12,7 @@ import { usePlayerActions, type Track } from "@/contexts/PlayerContext";
 import { useSavedAlbums } from "@/contexts/SavedAlbumsContext";
 import { TrackRow, type TrackRowData } from "@/components/cards/TrackRow";
 import { fetchAlbumRadio } from "@/lib/radio";
-import { encPath, formatBadgeClass } from "@/lib/utils";
+import { encPath, formatBadgeClass, shuffleArray, formatTotalDuration } from "@/lib/utils";
 
 interface AlbumTrack {
   id: number;
@@ -64,16 +64,6 @@ interface Playlist {
   name: string;
 }
 
-function shuffleArray<T>(arr: T[]): T[] {
-  const copy = [...arr];
-  for (let i = copy.length - 1; i > 0; i--) {
-    const j = Math.floor(Math.random() * (i + 1));
-    const tmp = copy[i]!;
-    copy[i] = copy[j]!;
-    copy[j] = tmp;
-  }
-  return copy;
-}
 
 function buildPlayerTracks(data: AlbumData): Track[] {
   const cover = `/api/cover/${encPath(data.artist)}/${encPath(data.name)}`;
@@ -88,12 +78,6 @@ function buildPlayerTracks(data: AlbumData): Track[] {
   }));
 }
 
-function formatTotalDuration(seconds: number): string {
-  const h = Math.floor(seconds / 3600);
-  const m = Math.floor((seconds % 3600) / 60);
-  if (h > 0) return `${h} hr ${m} min`;
-  return `${m} min`;
-}
 
 export function Album() {
   const { artist, album } = useParams<{ artist: string; album: string }>();

--- a/app/listen/src/pages/Artist.tsx
+++ b/app/listen/src/pages/Artist.tsx
@@ -29,7 +29,7 @@ import { useApi } from "@/hooks/use-api";
 import { api } from "@/lib/api";
 import { fetchPlayableSetlist } from "@/lib/upcoming";
 import { fetchArtistRadio } from "@/lib/radio";
-import { encPath, formatCompact } from "@/lib/utils";
+import { encPath, formatCompact, shuffleArray } from "@/lib/utils";
 
 interface ArtistAlbum {
   id: number;
@@ -83,16 +83,6 @@ interface StatsListResponse<T> {
   items: T[];
 }
 
-function shuffleArray<T>(items: T[]): T[] {
-  const copy = [...items];
-  for (let i = copy.length - 1; i > 0; i--) {
-    const j = Math.floor(Math.random() * (i + 1));
-    const tmp = copy[i]!;
-    copy[i] = copy[j]!;
-    copy[j] = tmp;
-  }
-  return copy;
-}
 
 export function Artist() {
   const navigate = useNavigate();

--- a/app/listen/src/pages/CuratedPlaylist.tsx
+++ b/app/listen/src/pages/CuratedPlaylist.tsx
@@ -10,7 +10,7 @@ import { PlaylistArtwork, type PlaylistArtworkTrack } from "@/components/playlis
 import { usePlayerActions, type Track } from "@/contexts/PlayerContext";
 import { usePlaylistComposer } from "@/contexts/PlaylistComposerContext";
 import { fetchPlaylistRadio } from "@/lib/radio";
-import { encPath } from "@/lib/utils";
+import { encPath, shuffleArray, formatTotalDuration } from "@/lib/utils";
 
 interface CuratedPlaylistTrack {
   id: number;
@@ -42,23 +42,8 @@ interface CuratedPlaylistData {
   tracks: CuratedPlaylistTrack[];
 }
 
-function fmtTotalDuration(seconds: number): string {
-  const h = Math.floor(seconds / 3600);
-  const m = Math.floor((seconds % 3600) / 60);
-  if (h > 0) return `${h} hr ${m} min`;
-  return `${m} min`;
-}
 
-function shuffleArray<T>(arr: T[]): T[] {
-  const copy = [...arr];
-  for (let i = copy.length - 1; i > 0; i--) {
-    const j = Math.floor(Math.random() * (i + 1));
-    const tmp = copy[i]!;
-    copy[i] = copy[j]!;
-    copy[j] = tmp;
-  }
-  return copy;
-}
+
 
 export function CuratedPlaylist() {
   const navigate = useNavigate();
@@ -253,7 +238,7 @@ export function CuratedPlaylist() {
           </div>
           <div className="flex flex-wrap items-center gap-x-4 gap-y-1 text-xs text-muted-foreground">
             <span>{data.track_count} tracks</span>
-            {data.total_duration > 0 ? <span>{fmtTotalDuration(data.total_duration)}</span> : null}
+            {data.total_duration > 0 ? <span>{formatTotalDuration(data.total_duration)}</span> : null}
             <span className="inline-flex items-center gap-1">
               <Users size={12} />
               {data.follower_count} follower{data.follower_count !== 1 ? "s" : ""}

--- a/app/listen/src/pages/Library.tsx
+++ b/app/listen/src/pages/Library.tsx
@@ -14,7 +14,7 @@ import { AppModal, ModalBody, ModalCloseButton, ModalFooter, ModalHeader } from 
 import { type PlaylistArtworkTrack } from "@/components/playlists/PlaylistArtwork";
 import { usePlayerActions, type Track } from "@/contexts/PlayerContext";
 import { api } from "@/lib/api";
-import { encPath } from "@/lib/utils";
+import { encPath, formatTotalDuration } from "@/lib/utils";
 
 type Tab = "playlists" | "artists" | "albums" | "liked";
 
@@ -96,13 +96,6 @@ function parseTab(value: string | null): Tab {
   return "playlists";
 }
 
-function formatTotalDuration(seconds: number): string {
-  if (!seconds) return "";
-  const h = Math.floor(seconds / 3600);
-  const m = Math.floor((seconds % 3600) / 60);
-  if (h > 0) return `${h}h ${m}m`;
-  return `${m}m`;
-}
 
 function Spinner() {
   return (

--- a/app/listen/src/pages/Playlist.tsx
+++ b/app/listen/src/pages/Playlist.tsx
@@ -14,7 +14,7 @@ import { AppModal, ModalBody, ModalFooter, ModalHeader, ModalCloseButton } from 
 import { usePlayerActions, type Track } from "@/contexts/PlayerContext";
 import { usePlaylistComposer } from "@/contexts/PlaylistComposerContext";
 import { fetchPlaylistRadio } from "@/lib/radio";
-import { encPath } from "@/lib/utils";
+import { encPath, shuffleArray, formatTotalDuration } from "@/lib/utils";
 
 interface PlaylistTrack {
   id: number;
@@ -46,23 +46,8 @@ interface PlaylistData {
   tracks: PlaylistTrack[];
 }
 
-function fmtTotalDuration(seconds: number): string {
-  const h = Math.floor(seconds / 3600);
-  const m = Math.floor((seconds % 3600) / 60);
-  if (h > 0) return `${h} hr ${m} min`;
-  return `${m} min`;
-}
 
-function shuffleArray<T>(arr: T[]): T[] {
-  const copy = [...arr];
-  for (let i = copy.length - 1; i > 0; i--) {
-    const j = Math.floor(Math.random() * (i + 1));
-    const tmp = copy[i]!;
-    copy[i] = copy[j]!;
-    copy[j] = tmp;
-  }
-  return copy;
-}
+
 
 export function Playlist() {
   const navigate = useNavigate();
@@ -333,7 +318,7 @@ export function Playlist() {
             <div className="text-xs text-muted-foreground">
               {data.track_count} track{data.track_count !== 1 ? "s" : ""}
               {data.total_duration > 0 &&
-                ` · ${fmtTotalDuration(data.total_duration)}`}
+                ` · ${formatTotalDuration(data.total_duration)}`}
             </div>
           </div>
         </div>


### PR DESCRIPTION
## Summary

- **#19** Remove dead FullscreenPlayer from PlayerBar (never opened, always mounted)
- **#17** shuffleArray extracted to @/lib/utils — 5 local copies removed
- **#101** formatTotalDuration extracted to @/lib/utils — 4 local copies removed  
- **#14** Closed: usePlayer() no longer used outside PlayerContext (already resolved by PR #48)

Net result: -86 lines, +29 lines. 9 fewer function definitions in the codebase.

## Test plan
- [x] `npm run build` passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated shared utility functions for shuffle and duration formatting across the application.
  * Removed fullscreen player overlay functionality from the player bar.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->