### PR TITLE
fix: polish — batch artist check, modal ARIA, dedup consolidation

### DIFF
--- a/app/crate/api/browse_artist.py
+++ b/app/crate/api/browse_artist.py
@@ -252,6 +252,22 @@ def api_artists(
     return {"items": items, "total": total, "page": page, "per_page": per_page}
 
 
+@router.post("/api/artists/check-library")
+def api_check_artists_in_library(request: Request, body: dict):
+    """Check which artists from a list exist in the local library. Returns a dict of name → boolean."""
+    _require_auth(request)
+    names = body.get("names", [])
+    if not names or not isinstance(names, list):
+        return {}
+    from crate.db import get_db_ctx
+    with get_db_ctx() as cur:
+        placeholders = ",".join(["%s"] * len(names))
+        cur.execute(f"SELECT name FROM library_artists WHERE LOWER(name) IN ({placeholders})",
+                    [n.lower() for n in names])
+        found = {r["name"].lower() for r in cur.fetchall()}
+    return {name: name.lower() in found for name in names}
+
+
 @router.get("/api/artist/{name}/background")
 def api_artist_background(request: Request, name: str, random_pick: bool = Query(False, alias="random")):
     """Return artist background image."""

--- a/app/listen/src/components/ui/AppModal.tsx
+++ b/app/listen/src/components/ui/AppModal.tsx
@@ -59,6 +59,8 @@ export function AppModal({
 
   return (
     <div
+      role="dialog"
+      aria-modal="true"
       className={joinClasses(
         "fixed inset-0 z-[95] bg-black/72 backdrop-blur-md flex items-end sm:items-center justify-center p-0 sm:p-6",
         overlayClassName,

--- a/app/listen/src/contexts/use-playback-intelligence.ts
+++ b/app/listen/src/contexts/use-playback-intelligence.ts
@@ -35,9 +35,6 @@ function collectUniqueTracks(candidates: Track[], queue: Track[], recent: Track[
   return uniqueTracks;
 }
 
-function isLikelyContinuousAlbumBlock(currentTrack: Track | undefined, nextTrack: Track | undefined): boolean {
-  return areTracksFromSameAlbum(currentTrack, nextTrack);
-}
 
 interface UsePlaybackIntelligenceOptions {
   queue: Track[];
@@ -252,7 +249,7 @@ export function usePlaybackIntelligence({
       playlistSuggestionSignatureRef.current = null;
       return;
     }
-    if (isLikelyContinuousAlbumBlock(currentTrack, nextTrack)) {
+    if (areTracksFromSameAlbum(currentTrack, nextTrack)) {
       playlistSuggestionSignatureRef.current = null;
       return;
     }

--- a/app/listen/src/pages/Artist.tsx
+++ b/app/listen/src/pages/Artist.tsx
@@ -252,30 +252,17 @@ export function Artist() {
     }
 
     let cancelled = false;
-    const artistsToCheck = similarArtists.slice(0, 18);
+    const names = similarArtists.slice(0, 18).map((a) => a.name);
 
-    Promise.all(
-      artistsToCheck.map(async (artist) => {
-        try {
-          const response = await api<{ items?: { name: string }[] }>(
-            `/api/artists?q=${encodeURIComponent(artist.name)}&per_page=10&view=list`,
-          );
-          const exists = Boolean(
-            response.items?.some((item) => item.name.toLowerCase() === artist.name.toLowerCase()),
-          );
-          return [artist.name, exists] as const;
-        } catch {
-          return [artist.name, false] as const;
-        }
-      }),
-    ).then((entries) => {
-      if (cancelled) return;
-      setLocalSimilarArtists(Object.fromEntries(entries));
-    });
+    api<Record<string, boolean>>("/api/artists/check-library", "POST", { names })
+      .then((result) => {
+        if (!cancelled) setLocalSimilarArtists(result);
+      })
+      .catch(() => {
+        if (!cancelled) setLocalSimilarArtists({});
+      });
 
-    return () => {
-      cancelled = true;
-    };
+    return () => { cancelled = true; };
   }, [similarArtists]);
 
   if (loading) {


### PR DESCRIPTION
## Summary

- **#96** New `POST /api/artists/check-library` batch endpoint — Artist page now makes 1 request instead of 18 parallel requests for similar artist existence check
- **#106** AppModal: added `role="dialog"` and `aria-modal="true"` for screen reader accessibility
- **#52** Removed `isLikelyContinuousAlbumBlock` wrapper, uses `areTracksFromSameAlbum` directly
- **#107/#35** Verified: Shell already uses custom events for sidebar sync (no polling)

## Test plan
- [x] `npm run build` passes
- [x] Python syntax check passes