### PR TITLE
fix: UX — playable search tracks, MiniPlayer skip, scroll snap

### DIFF
--- a/app/listen/src/components/cards/AlbumCard.tsx
+++ b/app/listen/src/components/cards/AlbumCard.tsx
@@ -69,7 +69,7 @@ export const AlbumCard = memo(function AlbumCard({ artist, album, albumId, year,
     <div
       role="button"
       tabIndex={0}
-      className={`group text-left flex-shrink-0 ${compact ? "w-[120px]" : "w-[160px]"}`}
+      className={`group text-left flex-shrink-0 snap-start ${compact ? "w-[120px]" : "w-[160px]"}`}
       onClick={() => navigate(`/album/${encPath(artist)}/${encPath(album)}`)}
       onKeyDown={(event) => {
         if (event.key === "Enter" || event.key === " ") {

--- a/app/listen/src/components/cards/ArtistCard.tsx
+++ b/app/listen/src/components/cards/ArtistCard.tsx
@@ -43,7 +43,7 @@ export function ArtistCard({ name, photo, subtitle, compact, href, external = fa
         href={targetHref}
         target="_blank"
         rel="noopener noreferrer"
-        className={`group text-left flex-shrink-0 ${compact ? "w-[100px]" : large ? "w-[156px]" : "w-[140px]"}`}
+        className={`group text-left flex-shrink-0 snap-start ${compact ? "w-[100px]" : large ? "w-[156px]" : "w-[140px]"}`}
       >
         {content}
       </a>
@@ -52,7 +52,7 @@ export function ArtistCard({ name, photo, subtitle, compact, href, external = fa
 
   return (
     <button
-      className={`group text-left flex-shrink-0 ${compact ? "w-[100px]" : large ? "w-[156px]" : "w-[140px]"}`}
+      className={`group text-left flex-shrink-0 snap-start ${compact ? "w-[100px]" : large ? "w-[156px]" : "w-[140px]"}`}
       onClick={() => navigate(targetHref)}
     >
       {content}

--- a/app/listen/src/components/layout/TopBar.tsx
+++ b/app/listen/src/components/layout/TopBar.tsx
@@ -5,12 +5,13 @@ import { api } from "@/lib/api";
 import { useAuth } from "@/contexts/AuthContext";
 import { useDismissibleLayer } from "@/hooks/use-dismissible-layer";
 import { AppMenuButton, AppPopover, AppPopoverDivider } from "@/components/ui/AppPopover";
+import { usePlayerActions } from "@/contexts/PlayerContext";
 import { encPath } from "@/lib/utils";
 
 interface SearchResult {
   artists: { name: string }[];
   albums: { artist: string; name: string }[];
-  tracks: { title: string; artist: string; album: string }[];
+  tracks: { id?: number; title: string; artist: string; album: string; path?: string; navidrome_id?: string }[];
 }
 
 const RECENTS_KEY = "listen-search-recents";
@@ -36,6 +37,7 @@ interface FlatItem {
   sublabel?: string;
   navigateTo?: string;
   imageUrl?: string;
+  trackData?: { id: string; path?: string; title: string; artist: string; album: string; navidromeId?: string };
 }
 
 function flattenResults(data: SearchResult): FlatItem[] {
@@ -58,6 +60,7 @@ function flattenResults(data: SearchResult): FlatItem[] {
     items.push({
       type: "track", label: t.title, sublabel: `${t.artist} - ${t.album}`,
       imageUrl: t.album ? `/api/cover/${encPath(t.artist)}/${encPath(t.album)}` : undefined,
+      trackData: { id: t.path || String(t.id), path: t.path, title: t.title, artist: t.artist, album: t.album, navidromeId: t.navidrome_id },
     });
   }
   return items;
@@ -82,6 +85,7 @@ function ResultThumb({ item }: { item: FlatItem }) {
 export function TopBar() {
   const navigate = useNavigate();
   const { user, logout } = useAuth();
+  const { play } = usePlayerActions();
   const [query, setQuery] = useState("");
   const [results, setResults] = useState<FlatItem[]>([]);
   const [loading, setLoading] = useState(false);
@@ -135,15 +139,21 @@ export function TopBar() {
 
   const selectItem = useCallback(
     (item: FlatItem) => {
-      if (item.navigateTo) {
-        addRecent(item.label);
-        setRecents(getRecents());
+      addRecent(item.label);
+      setRecents(getRecents());
+      if (item.trackData) {
+        const t = item.trackData;
+        play(
+          { id: t.id, path: t.path, title: t.title, artist: t.artist, album: t.album, navidromeId: t.navidromeId, albumCover: item.imageUrl },
+          { type: "queue", name: "Search" },
+        );
+      } else if (item.navigateTo) {
         navigate(item.navigateTo);
       }
       setShowDropdown(false);
       setQuery("");
     },
-    [navigate],
+    [navigate, play],
   );
 
   const selectRecent = useCallback(

--- a/app/listen/src/components/player/MiniPlayer.tsx
+++ b/app/listen/src/components/player/MiniPlayer.tsx
@@ -1,10 +1,11 @@
 import { useState } from "react";
-import { Play, Pause, Loader2 } from "lucide-react";
-import { usePlayer } from "@/contexts/PlayerContext";
+import { Play, Pause, SkipForward, Loader2 } from "lucide-react";
+import { usePlayer, usePlayerActions } from "@/contexts/PlayerContext";
 import { FullscreenPlayer } from "@/components/player/FullscreenPlayer";
 
 export function MiniPlayer() {
-  const { currentTrack, isPlaying, isBuffering, currentTime, duration, pause, resume } = usePlayer();
+  const { currentTrack, isPlaying, isBuffering, currentTime, duration } = usePlayer();
+  const { pause, resume, next } = usePlayerActions();
   const [fsOpen, setFsOpen] = useState(false);
 
   if (!currentTrack) return null;
@@ -43,21 +44,32 @@ export function MiniPlayer() {
             <p className="text-xs text-white/50 truncate">{currentTrack.artist}</p>
           </div>
 
-          {/* Play/pause */}
+          {/* Play/pause + skip */}
           <button
             onClick={(e) => {
               e.stopPropagation();
               isPlaying ? pause() : resume();
             }}
-            className="w-8 h-8 flex items-center justify-center text-white"
+            className="w-11 h-11 flex items-center justify-center text-white"
+            aria-label={isPlaying ? "Pause" : "Play"}
           >
             {isBuffering ? (
-              <Loader2 size={18} className="animate-spin" />
+              <Loader2 size={20} className="animate-spin" />
             ) : isPlaying ? (
-              <Pause size={20} />
+              <Pause size={22} />
             ) : (
-              <Play size={20} className="ml-0.5" />
+              <Play size={22} className="ml-0.5" />
             )}
+          </button>
+          <button
+            onClick={(e) => {
+              e.stopPropagation();
+              next();
+            }}
+            className="w-11 h-11 flex items-center justify-center text-white/60"
+            aria-label="Next track"
+          >
+            <SkipForward size={20} />
           </button>
         </div>
       </div>

--- a/app/listen/src/pages/Explore.tsx
+++ b/app/listen/src/pages/Explore.tsx
@@ -135,7 +135,7 @@ function SearchResultsView({ results }: { results: SearchResults }) {
       {hasArtists && (
         <div className="space-y-3">
           <h2 className="text-lg font-bold px-1">Artists</h2>
-          <div className="flex gap-4 overflow-x-auto pb-2 [&::-webkit-scrollbar]:hidden [-ms-overflow-style:none] [scrollbar-width:none]">
+          <div className="flex gap-4 overflow-x-auto pb-2 snap-x snap-mandatory [&::-webkit-scrollbar]:hidden [-ms-overflow-style:none] [scrollbar-width:none]">
             {results.artists.map((a) => (
               <ArtistCard
                 key={a.name}
@@ -150,7 +150,7 @@ function SearchResultsView({ results }: { results: SearchResults }) {
       {hasAlbums && (
         <div className="space-y-3">
           <h2 className="text-lg font-bold px-1">Albums</h2>
-          <div className="flex gap-4 overflow-x-auto pb-2 [&::-webkit-scrollbar]:hidden [-ms-overflow-style:none] [scrollbar-width:none]">
+          <div className="flex gap-4 overflow-x-auto pb-2 snap-x snap-mandatory [&::-webkit-scrollbar]:hidden [-ms-overflow-style:none] [scrollbar-width:none]">
             {results.albums.map((a) => (
               <AlbumCard
                 key={a.id || `${a.artist}-${a.name}`}
@@ -221,7 +221,7 @@ function SectionHeader({
 
 function SectionRail({ children }: { children: React.ReactNode }) {
   return (
-    <div className="flex gap-4 overflow-x-auto pb-2 [&::-webkit-scrollbar]:hidden [-ms-overflow-style:none] [scrollbar-width:none]">
+    <div className="flex gap-4 overflow-x-auto pb-2 snap-x snap-mandatory [&::-webkit-scrollbar]:hidden [-ms-overflow-style:none] [scrollbar-width:none]">
       {children}
     </div>
   );

--- a/app/listen/src/pages/Home.tsx
+++ b/app/listen/src/pages/Home.tsx
@@ -209,7 +209,7 @@ function SectionHeader({
 
 function SectionRail({ children }: { children: React.ReactNode }) {
   return (
-    <div className="flex gap-4 overflow-x-auto pb-2 [&::-webkit-scrollbar]:hidden [-ms-overflow-style:none] [scrollbar-width:none]">
+    <div className="flex gap-4 overflow-x-auto pb-2 snap-x snap-mandatory [&::-webkit-scrollbar]:hidden [-ms-overflow-style:none] [scrollbar-width:none]">
       {children}
     </div>
   );


### PR DESCRIPTION
## Summary

- **#60** Search track results are now playable — clicking a track in the search dropdown plays it
- **#58** MiniPlayer: added skip-next button (44px touch target), enlarged play button from 32px to 44px, added aria-labels
- **#65** Horizontal scroll rails (Home, Explore) now use CSS scroll-snap for precise touch scrolling; AlbumCard and ArtistCard have snap-start alignment

## Test plan
- [x] `npm run build` passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Search results now enable direct track playback without navigation.
  * Added next track button to player controls alongside play/pause.

* **Improvements**
  * Enhanced scrolling experience with scroll snapping on cards and content rails for better navigation.
  * Improved player control styling and accessibility with enhanced button labels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->