### PR TITLE
fix: mobile foundations — MediaSession, safe areas, touch visibility

### DIFF
--- a/app/listen/src/components/cards/TrackRow.tsx
+++ b/app/listen/src/components/cards/TrackRow.tsx
@@ -111,7 +111,7 @@ export const TrackRow = memo(function TrackRow({
             ) : (
               <Play
                 size={16}
-                className={`text-white transition-opacity ${isActive ? "opacity-100" : "opacity-0 group-hover:opacity-100"}`}
+                className={`text-white transition-opacity ${isActive ? "opacity-100" : "opacity-0 md:group-hover:opacity-100"}`}
                 fill="currentColor"
               />
             )}
@@ -155,8 +155,8 @@ export const TrackRow = memo(function TrackRow({
 
       {/* Like + Actions */}
       <button
-        className={`flex-shrink-0 p-1 transition-opacity ${
-          liked ? "opacity-100" : "opacity-0 group-hover:opacity-100"
+        className={`flex-shrink-0 p-2 transition-opacity ${
+          liked ? "opacity-100" : "md:opacity-0 md:group-hover:opacity-100"
         }`}
         title={liked ? "Unlike" : "Like"}
         onClick={async (e) => {
@@ -177,8 +177,8 @@ export const TrackRow = memo(function TrackRow({
         />
       </button>
 
-      {/* Actions (on hover) */}
-      <div className="flex-shrink-0 flex gap-1 opacity-0 group-hover:opacity-100 transition-opacity">
+      {/* Actions (visible on mobile, hover-reveal on desktop) */}
+      <div className="flex-shrink-0 flex gap-1 md:opacity-0 md:group-hover:opacity-100 transition-opacity">
         {onAddToPlaylist && (
           <div className="relative" ref={playlistMenuRef}>
             <button

--- a/app/listen/src/components/layout/Shell.tsx
+++ b/app/listen/src/components/layout/Shell.tsx
@@ -255,7 +255,7 @@ export function Shell() {
 
       <div className="fixed bottom-0 left-0 right-0 z-50">
         <MiniPlayer />
-        <nav className="h-16 bg-[#0a0a0f] border-t border-white/5 flex items-center justify-around px-2">
+        <nav className="bg-[#0a0a0f] border-t border-white/5 flex items-center justify-around px-2" style={{ paddingBottom: "max(0px, env(safe-area-inset-bottom))", height: "calc(64px + env(safe-area-inset-bottom, 0px))" }}>
           {MOBILE_NAV.map(({ to, icon: Icon, label }) => (
             <NavLink
               key={to}

--- a/app/listen/src/contexts/PlayerContext.tsx
+++ b/app/listen/src/contexts/PlayerContext.tsx
@@ -29,6 +29,7 @@ import {
 import { usePlayEventTracker } from "@/contexts/use-play-event-tracker";
 import { usePlaybackIntelligence } from "@/contexts/use-playback-intelligence";
 import { usePlayerShortcuts } from "@/contexts/use-player-shortcuts";
+import { useMediaSession } from "@/contexts/use-media-session";
 import {
   getCrossfadeDurationPreference,
   getInfinitePlaybackPreference,
@@ -726,6 +727,8 @@ export function PlayerProvider({ children }: { children: ReactNode }) {
     seek,
     setVolume,
   });
+
+  useMediaSession({ currentTrack, isPlaying, currentTime, duration, pause, resume, next, prev, seek });
 
   const stateValue = useMemo<PlayerStateValue>(
     () => ({ currentTime, duration, isPlaying, isBuffering, volume }),

--- a/app/listen/src/contexts/use-media-session.ts
+++ b/app/listen/src/contexts/use-media-session.ts
@@ -1,0 +1,103 @@
+import { useEffect } from "react";
+import type { Track } from "./player-types";
+
+/**
+ * Sync the Web MediaSession API with the current player state.
+ * This enables OS-level playback controls: lockscreen, bluetooth,
+ * headphone buttons, car stereos, media keys, etc.
+ */
+export function useMediaSession({
+  currentTrack,
+  isPlaying,
+  currentTime,
+  duration,
+  pause,
+  resume,
+  next,
+  prev,
+  seek,
+}: {
+  currentTrack: Track | undefined;
+  isPlaying: boolean;
+  currentTime: number;
+  duration: number;
+  pause: () => void;
+  resume: () => void;
+  next: () => void;
+  prev: () => void;
+  seek: (time: number) => void;
+}) {
+  // Update metadata when track changes
+  useEffect(() => {
+    if (!("mediaSession" in navigator) || !currentTrack) return;
+
+    const artwork: MediaImage[] = [];
+    if (currentTrack.albumCover) {
+      artwork.push({ src: currentTrack.albumCover, sizes: "256x256", type: "image/jpeg" });
+    }
+
+    navigator.mediaSession.metadata = new MediaMetadata({
+      title: currentTrack.title || "Unknown",
+      artist: currentTrack.artist || "",
+      album: currentTrack.album || "",
+      artwork,
+    });
+  }, [currentTrack?.id, currentTrack?.title, currentTrack?.artist, currentTrack?.album, currentTrack?.albumCover]);
+
+  // Update playback state
+  useEffect(() => {
+    if (!("mediaSession" in navigator)) return;
+    navigator.mediaSession.playbackState = isPlaying ? "playing" : "paused";
+  }, [isPlaying]);
+
+  // Update position state for seek bar on lockscreen
+  useEffect(() => {
+    if (!("mediaSession" in navigator) || !duration) return;
+    try {
+      navigator.mediaSession.setPositionState({
+        duration: duration || 0,
+        playbackRate: 1,
+        position: Math.min(currentTime, duration),
+      });
+    } catch {
+      // Some browsers don't support setPositionState
+    }
+  }, [currentTime, duration]);
+
+  // Register action handlers
+  useEffect(() => {
+    if (!("mediaSession" in navigator)) return;
+
+    const actions: Array<[MediaSessionAction, MediaSessionActionHandler]> = [
+      ["play", () => resume()],
+      ["pause", () => pause()],
+      ["previoustrack", () => prev()],
+      ["nexttrack", () => next()],
+      ["seekto", (details) => {
+        if (details.seekTime != null) seek(details.seekTime);
+      }],
+      ["seekbackward", (details) => {
+        seek(Math.max(0, currentTime - (details.seekOffset || 10)));
+      }],
+      ["seekforward", (details) => {
+        seek(Math.min(duration, currentTime + (details.seekOffset || 10)));
+      }],
+    ];
+
+    for (const [action, handler] of actions) {
+      try {
+        navigator.mediaSession.setActionHandler(action, handler);
+      } catch {
+        // Action not supported in this browser
+      }
+    }
+
+    return () => {
+      for (const [action] of actions) {
+        try {
+          navigator.mediaSession.setActionHandler(action, null);
+        } catch { /* ignore */ }
+      }
+    };
+  }, [pause, resume, next, prev, seek, currentTime, duration]);
+}

--- a/app/listen/src/index.css
+++ b/app/listen/src/index.css
@@ -45,7 +45,15 @@
 
 body {
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, sans-serif;
+  overscroll-behavior: none;
+  -webkit-user-select: none;
+  user-select: none;
+  -webkit-tap-highlight-color: transparent;
 }
+
+/* Allow text selection in content areas */
+p, article, .selectable { -webkit-user-select: text; user-select: text; }
+input, textarea { -webkit-user-select: auto; user-select: auto; }
 
 * {
   border-color: var(--color-border);


### PR DESCRIPTION
## Summary

Critical mobile foundations that make the app usable on phones:

- **#54** MediaSession API — lockscreen controls, bluetooth headphone buttons, car stereos, and OS media widgets now work. Syncs metadata, playback state, position, and all action handlers.
- **#55** Safe area insets — bottom nav respects env(safe-area-inset-bottom) for iPhone home indicator. Added overscroll-behavior:none, user-select:none, and tap-highlight-color:transparent for app-like feel.
- **#57** TrackRow actions (like, queue, playlist) now visible on mobile — previously hidden behind hover-only opacity. Desktop retains hover-reveal behavior.

## Test plan
- [x] `npm run build` passes
- [x] MediaSession: tested with Chrome DevTools Application > MediaSession