### PR TITLE
fix: mobile Phase A pt2 — profile tab, settings links, album card touch

### DIFF
--- a/app/listen/src/components/cards/AlbumCard.tsx
+++ b/app/listen/src/components/cards/AlbumCard.tsx
@@ -88,7 +88,7 @@ export const AlbumCard = memo(function AlbumCard({ artist, album, albumId, year,
         />
         {albumId != null && (
           <button
-            className="absolute top-2 right-2 z-10 w-9 h-9 rounded-full bg-black/55 backdrop-blur-md border border-white/10 flex items-center justify-center text-white/75 hover:text-white hover:bg-black/70 transition-colors opacity-0 group-hover:opacity-100"
+            className={`absolute top-2 right-2 z-10 w-9 h-9 rounded-full bg-black/55 backdrop-blur-md border border-white/10 flex items-center justify-center text-white/75 hover:text-white hover:bg-black/70 transition-colors ${saved ? "opacity-100" : "opacity-0 group-hover:opacity-100"}`}
             onClick={async (event) => {
               event.stopPropagation();
               try {
@@ -101,9 +101,9 @@ export const AlbumCard = memo(function AlbumCard({ artist, album, albumId, year,
             <Heart size={16} className={saved ? "text-primary fill-primary" : ""} />
           </button>
         )}
-        <div className="absolute inset-0 bg-black/0 group-hover:bg-black/40 transition-colors flex items-center justify-center">
+        <div className="absolute inset-0 bg-black/0 group-hover:bg-black/40 transition-colors flex items-end justify-end p-2 md:items-center md:justify-center md:p-0">
           <button
-            className="w-10 h-10 rounded-full bg-primary flex items-center justify-center opacity-0 group-hover:opacity-100 transition-opacity translate-y-2 group-hover:translate-y-0 shadow-lg"
+            className="w-10 h-10 rounded-full bg-primary flex items-center justify-center opacity-100 md:opacity-0 md:group-hover:opacity-100 transition-opacity md:translate-y-2 md:group-hover:translate-y-0 shadow-lg"
             onClick={handlePlayOverlay}
           >
             {playing ? (

--- a/app/listen/src/components/layout/Shell.tsx
+++ b/app/listen/src/components/layout/Shell.tsx
@@ -1,7 +1,7 @@
 import { useState, useRef, useEffect } from "react";
 import { Outlet, NavLink, useLocation, useNavigate } from "react-router";
 import {
-  Home, Compass, Rss, Library, Music, Disc, Heart, Users,
+  Home, Compass, Rss, Library, Music, Disc, Heart, Users, User,
   ListMusic, PanelLeftClose, PanelLeftOpen, ChevronRight, BarChart3,
 } from "lucide-react";
 import { useIsDesktop } from "@/hooks/use-breakpoint";
@@ -182,9 +182,10 @@ function Sidebar() {
 const MOBILE_NAV = [
   { to: "/", icon: Home, label: "Home" },
   { to: "/explore", icon: Compass, label: "Explore" },
-  { to: "/stats", icon: BarChart3, label: "Stats" },
   { to: "/library", icon: Library, label: "Library" },
+  { to: "/stats", icon: BarChart3, label: "Stats" },
   { to: "/upcoming", icon: Rss, label: "Upcoming" },
+  { to: "/settings", icon: User, label: "Profile" },
 ] as const;
 
 // ── Shell ───────────────────────────────────────────────────────

--- a/app/listen/src/pages/Settings.tsx
+++ b/app/listen/src/pages/Settings.tsx
@@ -9,6 +9,9 @@ import {
   setSmartPlaylistSuggestionsPreference,
 } from "@/lib/player-playback-prefs";
 import { useState } from "react";
+import { Link } from "react-router";
+import { Upload, BarChart3, LogOut } from "lucide-react";
+import { useAuth } from "@/contexts/AuthContext";
 
 function Section({
   title,
@@ -114,6 +117,7 @@ function ToggleRow({
 }
 
 export function Settings() {
+  const { logout } = useAuth();
   const [crossfadeSeconds, setCrossfadeSeconds] = useState(getCrossfadeDurationPreference);
   const [infinitePlaybackEnabled, setInfinitePlaybackEnabled] = useState(getInfinitePlaybackPreference);
   const [smartPlaylistSuggestionsEnabled, setSmartPlaylistSuggestionsEnabled] = useState(
@@ -181,6 +185,20 @@ export function Settings() {
             setSmartPlaylistSuggestionsCadencePreference(value);
           }}
         />
+      </Section>
+
+      <Section title="Quick links">
+        <div className="flex flex-col gap-2">
+          <Link to="/upload" className="flex items-center gap-3 rounded-xl px-3 py-3 text-sm text-foreground hover:bg-white/5 transition-colors">
+            <Upload size={18} className="text-muted-foreground" /> Upload music
+          </Link>
+          <Link to="/stats" className="flex items-center gap-3 rounded-xl px-3 py-3 text-sm text-foreground hover:bg-white/5 transition-colors">
+            <BarChart3 size={18} className="text-muted-foreground" /> Listening stats
+          </Link>
+          <button onClick={logout} className="flex items-center gap-3 rounded-xl px-3 py-3 text-sm text-red-400 hover:bg-white/5 transition-colors w-full text-left">
+            <LogOut size={18} /> Sign out
+          </button>
+        </div>
       </Section>
     </div>
   );


### PR DESCRIPTION
## Summary

- **#123** Profile tab added to mobile bottom nav (6 items: Home, Explore, Library, Stats, Upcoming, Profile). Settings page now has Quick Links section with Upload, Stats, and Sign Out — all previously unreachable on mobile.
- **#126** AlbumCard play button always visible on mobile (positioned bottom-right), centered overlay on desktop hover. Heart button always visible when album is saved.

## Test plan
- [x] `npm run build` passes
- [x] 6 items fit in 375px bottom nav with justify-around

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "Profile" navigation option to mobile menu
  * Added quick links section in settings with shortcuts to upload and stats pages, plus sign-out button

* **UI/UX Improvements**
  * Enhanced album card styling for saved indicator visibility and play button positioning on mobile devices
  * Improved responsive layout for album playback controls across screen sizes

<!-- end of auto-generated comment: release notes by coderabbit.ai -->