### PR TITLE
fix: mobile Phase B — modal swipe-to-dismiss, touch targets

### DIFF
--- a/app/listen/src/components/playlists/PlaylistListRow.tsx
+++ b/app/listen/src/components/playlists/PlaylistListRow.tsx
@@ -181,7 +181,7 @@ export function PlaylistListRow({
             event.stopPropagation();
             void loadAndPlay("play");
           }}
-          className="flex h-8 w-8 items-center justify-center rounded-full text-white/45 transition-colors hover:bg-white/10 hover:text-white"
+          className="flex h-10 w-10 items-center justify-center rounded-full text-white/45 transition-colors hover:bg-white/10 hover:text-white"
           title="Play"
         >
           {playingMode === "play" ? <Loader2 size={15} className="animate-spin" /> : <Play size={15} fill="currentColor" className="ml-0.5" />}
@@ -191,7 +191,7 @@ export function PlaylistListRow({
             event.stopPropagation();
             void loadAndPlay("shuffle");
           }}
-          className="flex h-8 w-8 items-center justify-center rounded-full text-white/45 transition-colors hover:bg-white/10 hover:text-white"
+          className="flex h-10 w-10 items-center justify-center rounded-full text-white/45 transition-colors hover:bg-white/10 hover:text-white"
           title="Shuffle"
         >
           {playingMode === "shuffle" ? <Loader2 size={15} className="animate-spin" /> : <Shuffle size={15} />}
@@ -199,7 +199,7 @@ export function PlaylistListRow({
         {followState ? (
           <button
             onClick={handleToggleFollow}
-            className={`flex h-8 w-8 items-center justify-center rounded-full transition-colors ${
+            className={`flex h-10 w-10 items-center justify-center rounded-full transition-colors ${
               followState.isFollowed
                 ? "text-primary hover:bg-primary/10"
                 : "text-white/45 hover:bg-white/10 hover:text-white"
@@ -225,7 +225,7 @@ export function PlaylistListRow({
                 event.stopPropagation();
                 await action.onClick();
               }}
-              className={`flex h-8 w-8 items-center justify-center rounded-full transition-colors ${toneClass}`}
+              className={`flex h-10 w-10 items-center justify-center rounded-full transition-colors ${toneClass}`}
               title={action.title}
             >
               {action.loading ? <Loader2 size={15} className="animate-spin" /> : <Icon size={15} />}
@@ -234,7 +234,7 @@ export function PlaylistListRow({
         })}
         <button
           onClick={handleShare}
-          className="flex h-8 w-8 items-center justify-center rounded-full text-white/45 transition-colors hover:bg-white/10 hover:text-white"
+          className="flex h-10 w-10 items-center justify-center rounded-full text-white/45 transition-colors hover:bg-white/10 hover:text-white"
           title="Share"
         >
           {sharing ? <Loader2 size={15} className="animate-spin" /> : <Share2 size={15} />}

--- a/app/listen/src/components/ui/AppModal.tsx
+++ b/app/listen/src/components/ui/AppModal.tsx
@@ -1,4 +1,4 @@
-import { useEffect, type HTMLAttributes, type ReactNode } from "react";
+import { useCallback, useEffect, useRef, useState, type HTMLAttributes, type ReactNode } from "react";
 import { X } from "lucide-react";
 
 interface AppModalProps {
@@ -55,6 +55,22 @@ export function AppModal({
     };
   }, [closeOnEscape, lockBodyScroll, onClose, open]);
 
+  // Swipe-to-dismiss (mobile bottom sheet)
+  const [swipeY, setSwipeY] = useState(0);
+  const swipeStartRef = useRef<number | null>(null);
+  const onSwipeStart = useCallback((e: React.TouchEvent) => {
+    swipeStartRef.current = e.touches[0]!.clientY;
+  }, []);
+  const onSwipeMove = useCallback((e: React.TouchEvent) => {
+    if (swipeStartRef.current === null) return;
+    setSwipeY(Math.max(0, e.touches[0]!.clientY - swipeStartRef.current));
+  }, []);
+  const onSwipeEnd = useCallback(() => {
+    if (swipeY > 100) onClose();
+    setSwipeY(0);
+    swipeStartRef.current = null;
+  }, [swipeY, onClose]);
+
   if (!open) return null;
 
   return (
@@ -75,8 +91,19 @@ export function AppModal({
           maxWidthClassName,
           panelClassName,
         )}
+        style={{
+          transform: swipeY > 0 ? `translateY(${swipeY}px)` : undefined,
+          transition: swipeY > 0 ? "none" : undefined,
+        }}
         onClick={(event) => event.stopPropagation()}
+        onTouchStart={onSwipeStart}
+        onTouchMove={onSwipeMove}
+        onTouchEnd={onSwipeEnd}
       >
+        {/* Drag handle — visible on mobile only */}
+        <div className="flex justify-center pt-2 pb-1 sm:hidden">
+          <div className="w-8 h-1 rounded-full bg-white/20" />
+        </div>
         {children}
       </div>
     </div>

--- a/app/listen/src/components/upcoming/UpcomingRows.tsx
+++ b/app/listen/src/components/upcoming/UpcomingRows.tsx
@@ -150,7 +150,7 @@ function RowActionButton({
       onClick={onClick}
       disabled={disabled}
       className={cn(
-        "flex h-8 w-8 items-center justify-center rounded-full transition-colors",
+        "flex h-10 w-10 items-center justify-center rounded-full transition-colors",
         rowActionClassName(active ? "primary" : "default", disabled),
       )}
       title={title}
@@ -182,7 +182,7 @@ function RowActionLink({
       rel="noopener noreferrer"
       onClick={onClick}
       className={cn(
-        "flex h-8 w-8 items-center justify-center rounded-full transition-colors",
+        "flex h-10 w-10 items-center justify-center rounded-full transition-colors",
         rowActionClassName(active ? "primary" : "default", disabled || !href),
       )}
       title={title}


### PR DESCRIPTION
## Summary

- **#130** AppModal: drag handle pill on mobile, swipe-down gesture to dismiss (100px threshold), visual feedback during drag
- **#132** UpcomingRows + PlaylistListRow: all action buttons increased from 32px to 40px for better touch accessibility

Remaining Phase B: #131 (keyboard overlap in PlaylistCreateModal)

## Test plan
- [x] `npm run build` passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added mobile swipe-to-dismiss gesture for modals with visual drag handle indicator.

* **Style**
  * Increased action button sizes across playlist and upcoming rows for improved touch usability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->