### PR TITLE
feat: Tier 2 — sleep timer + browse by mood

### DIFF
--- a/app/crate/api/browse_media.py
+++ b/app/crate/api/browse_media.py
@@ -1,6 +1,6 @@
 import logging
 
-from fastapi import APIRouter, HTTPException, Request
+from fastapi import APIRouter, HTTPException, Query, Request
 from fastapi.responses import JSONResponse, Response
 
 from crate.api._deps import library_path, safe_path
@@ -389,3 +389,71 @@ def api_download_track(request: Request, filepath: str):
         return Response(status_code=404)
 
     return FileResponse(path=str(file_path), filename=file_path.name, media_type="application/octet-stream")
+
+
+# ── Mood/Energy browse ──────────────────────────────────────────
+
+MOOD_PRESETS = {
+    "energetic": {"energy_min": 0.7, "danceability_min": 0.5},
+    "chill": {"energy_max": 0.4, "valence_min": 0.3},
+    "dark": {"valence_max": 0.3, "energy_min": 0.4},
+    "happy": {"valence_min": 0.6, "energy_min": 0.4},
+    "melancholy": {"valence_max": 0.35, "energy_max": 0.5},
+    "intense": {"energy_min": 0.8},
+    "groovy": {"danceability_min": 0.65, "energy_min": 0.45},
+    "acoustic": {"acousticness_min": 0.6},
+}
+
+
+@router.get("/api/browse/moods")
+def api_browse_moods(request: Request):
+    """Return available mood presets with track counts."""
+    _require_auth(request)
+    from crate.db import get_db_ctx
+    results = []
+    with get_db_ctx() as cur:
+        for name, filters in MOOD_PRESETS.items():
+            conditions = ["bpm IS NOT NULL"]
+            params: list = []
+            for key, val in filters.items():
+                col = key.rsplit("_", 1)[0]
+                op = ">" if key.endswith("_min") else "<"
+                conditions.append(f"{col} {op}= %s")
+                params.append(val)
+            cur.execute(
+                f"SELECT COUNT(*) AS cnt FROM library_tracks WHERE {' AND '.join(conditions)}",
+                params,
+            )
+            count = cur.fetchone()["cnt"]
+            results.append({"name": name, "track_count": count, "filters": filters})
+    return results
+
+
+@router.get("/api/browse/mood/{mood}")
+def api_browse_mood_tracks(request: Request, mood: str, limit: int = Query(50, ge=1, le=200)):
+    """Return tracks matching a mood preset."""
+    _require_auth(request)
+    preset = MOOD_PRESETS.get(mood)
+    if not preset:
+        raise HTTPException(status_code=404, detail=f"Unknown mood: {mood}")
+    from crate.db import get_db_ctx
+    conditions = ["bpm IS NOT NULL"]
+    params: list = []
+    for key, val in preset.items():
+        col = key.rsplit("_", 1)[0]
+        op = ">" if key.endswith("_min") else "<"
+        conditions.append(f"{col} {op}= %s")
+        params.append(val)
+    params.append(limit)
+    with get_db_ctx() as cur:
+        cur.execute(
+            f"""SELECT t.id, t.title, t.artist, a.name AS album, t.path, t.duration,
+                       t.bpm, t.energy, t.danceability, t.valence, t.navidrome_id
+                FROM library_tracks t
+                JOIN library_albums a ON a.id = t.album_id
+                WHERE {' AND '.join(conditions)}
+                ORDER BY RANDOM() LIMIT %s""",
+            params,
+        )
+        tracks = [dict(r) for r in cur.fetchall()]
+    return {"mood": mood, "filters": preset, "tracks": tracks, "count": len(tracks)}

--- a/app/listen/src/components/player/FullscreenPlayer.tsx
+++ b/app/listen/src/components/player/FullscreenPlayer.tsx
@@ -13,7 +13,15 @@ import {
   ListMusic,
   AlignLeft,
   Disc3,
+  Moon,
 } from "lucide-react";
+import {
+  subscribeSleepTimer,
+  startSleepTimer,
+  cancelSleepTimer,
+  formatRemaining,
+  type SleepTimerState,
+} from "@/lib/sleep-timer";
 import { usePlayer } from "@/contexts/PlayerContext";
 import { useLikedTracks } from "@/contexts/LikedTracksContext";
 import { useEscapeKey } from "@/hooks/use-escape-key";
@@ -64,6 +72,10 @@ export function FullscreenPlayer({ open, onClose }: FullscreenPlayerProps) {
   const [visible, setVisible] = useState(false);
   const [animating, setAnimating] = useState(false);
   const [swipeY, setSwipeY] = useState(0);
+  const [showSleepMenu, setShowSleepMenu] = useState(false);
+  const [sleepTimer, setSleepTimer] = useState<SleepTimerState>({ active: false, remainingSeconds: 0, mode: null });
+
+  useEffect(() => subscribeSleepTimer(setSleepTimer), []);
   const swipeStartRef = useRef<number | null>(null);
   const progressRef = useRef<HTMLDivElement>(null);
   const draggingRef = useRef(false);
@@ -244,8 +256,41 @@ export function FullscreenPlayer({ open, onClose }: FullscreenPlayerProps) {
             </button>
           ))}
         </div>
-        <div className="w-11" />
+        <button
+          onClick={() => setShowSleepMenu(!showSleepMenu)}
+          className={`w-11 h-11 flex items-center justify-center -mr-2 transition-colors ${sleepTimer.active ? "text-primary" : "text-white/40 active:text-white/60"}`}
+        >
+          <Moon size={18} />
+          {sleepTimer.active && sleepTimer.remainingSeconds > 0 && (
+            <span className="absolute text-[8px] font-mono text-primary mt-7">{formatRemaining(sleepTimer.remainingSeconds)}</span>
+          )}
+        </button>
       </div>
+
+      {/* Sleep timer menu */}
+      {showSleepMenu && (
+        <div className="mx-4 mb-2 rounded-xl bg-white/5 p-3 flex flex-wrap gap-2">
+          {(["15min", "30min", "45min", "1hr", "end_of_track"] as const).map((mode) => (
+            <button
+              key={mode}
+              onClick={() => { startSleepTimer(mode, pause); setShowSleepMenu(false); }}
+              className={`rounded-full px-3 py-1.5 text-xs font-medium transition-colors ${
+                sleepTimer.mode === mode ? "bg-primary text-white" : "bg-white/10 text-white/60 active:bg-white/15"
+              }`}
+            >
+              {mode === "end_of_track" ? "End of track" : mode.replace("min", " min").replace("hr", " hour")}
+            </button>
+          ))}
+          {sleepTimer.active && (
+            <button
+              onClick={() => { cancelSleepTimer(); setShowSleepMenu(false); }}
+              className="rounded-full px-3 py-1.5 text-xs font-medium bg-red-500/20 text-red-400 active:bg-red-500/30"
+            >
+              Cancel timer
+            </button>
+          )}
+        </div>
+      )}
 
       {/* Tab content */}
       {activeTab === "player" && (

--- a/app/listen/src/contexts/PlayerContext.tsx
+++ b/app/listen/src/contexts/PlayerContext.tsx
@@ -375,6 +375,7 @@ export function PlayerProvider({ children }: { children: ReactNode }) {
     };
     const onDurationChange = () => setDuration(audio.duration || 0);
     const onEnded = () => {
+      import("@/lib/sleep-timer").then((m) => m.onTrackEnded());
       const endedTrack = currentTrackRef.current;
       if (endedTrack) {
         flushCurrentPlayEvent("completed");

--- a/app/listen/src/lib/sleep-timer.ts
+++ b/app/listen/src/lib/sleep-timer.ts
@@ -1,0 +1,85 @@
+/**
+ * Sleep timer module — pauses playback after a countdown.
+ * Singleton state, framework-agnostic.
+ */
+
+type Listener = (state: SleepTimerState) => void;
+
+export interface SleepTimerState {
+  active: boolean;
+  remainingSeconds: number;
+  mode: SleepTimerMode | null;
+}
+
+export type SleepTimerMode = "15min" | "30min" | "45min" | "1hr" | "end_of_track";
+
+const DURATIONS: Record<Exclude<SleepTimerMode, "end_of_track">, number> = {
+  "15min": 15 * 60,
+  "30min": 30 * 60,
+  "45min": 45 * 60,
+  "1hr": 60 * 60,
+};
+
+let _state: SleepTimerState = { active: false, remainingSeconds: 0, mode: null };
+let _interval: ReturnType<typeof setInterval> | null = null;
+let _pauseFn: (() => void) | null = null;
+const _listeners = new Set<Listener>();
+
+function _notify() {
+  for (const fn of _listeners) fn({ ..._state });
+}
+
+export function subscribeSleepTimer(fn: Listener): () => void {
+  _listeners.add(fn);
+  fn({ ..._state });
+  return () => { _listeners.delete(fn); };
+}
+
+export function getSleepTimerState(): SleepTimerState {
+  return { ..._state };
+}
+
+export function startSleepTimer(mode: SleepTimerMode, pauseFn: () => void) {
+  cancelSleepTimer();
+  _pauseFn = pauseFn;
+
+  if (mode === "end_of_track") {
+    _state = { active: true, remainingSeconds: 0, mode };
+    _notify();
+    return;
+  }
+
+  const seconds = DURATIONS[mode];
+  _state = { active: true, remainingSeconds: seconds, mode };
+  _notify();
+
+  _interval = setInterval(() => {
+    _state.remainingSeconds = Math.max(0, _state.remainingSeconds - 1);
+    if (_state.remainingSeconds <= 0) {
+      _pauseFn?.();
+      cancelSleepTimer();
+    }
+    _notify();
+  }, 1000);
+}
+
+export function cancelSleepTimer() {
+  if (_interval) { clearInterval(_interval); _interval = null; }
+  _state = { active: false, remainingSeconds: 0, mode: null };
+  _pauseFn = null;
+  _notify();
+}
+
+/** Call from PlayerContext when a track ends — handles "end_of_track" mode. */
+export function onTrackEnded() {
+  if (_state.active && _state.mode === "end_of_track") {
+    _pauseFn?.();
+    cancelSleepTimer();
+  }
+}
+
+export function formatRemaining(seconds: number): string {
+  const m = Math.floor(seconds / 60);
+  const s = seconds % 60;
+  return `${m}:${String(s).padStart(2, "0")}`;
+}

--- a/app/listen/src/pages/Explore.tsx
+++ b/app/listen/src/pages/Explore.tsx
@@ -21,6 +21,7 @@ import {
 } from "@/components/explore/explore-model";
 import { useApi } from "@/hooks/use-api";
 import { ApiError, api } from "@/lib/api";
+import { encPath } from "@/lib/utils";
 import { PlaylistCard } from "@/components/playlists/PlaylistCard";
 import { usePlayerActions } from "@/contexts/PlayerContext";
 
@@ -234,12 +235,82 @@ export function Explore() {
                   </div>
                 </div>
               )}
+              {/* Moods — browse by audio analysis */}
+              <MoodBrowseSection />
             </>
           ) : (
             <p className="text-muted-foreground text-sm">No filters available.</p>
           )}
         </div>
       )}
+    </div>
+  );
+}
+
+const MOOD_COLORS: Record<string, string> = {
+  energetic: "bg-orange-500/20 text-orange-300 border-orange-500/30",
+  chill: "bg-blue-500/20 text-blue-300 border-blue-500/30",
+  dark: "bg-purple-500/20 text-purple-300 border-purple-500/30",
+  happy: "bg-yellow-500/20 text-yellow-300 border-yellow-500/30",
+  melancholy: "bg-indigo-500/20 text-indigo-300 border-indigo-500/30",
+  intense: "bg-red-500/20 text-red-300 border-red-500/30",
+  groovy: "bg-green-500/20 text-green-300 border-green-500/30",
+  acoustic: "bg-amber-500/20 text-amber-300 border-amber-500/30",
+};
+
+interface MoodPreset { name: string; track_count: number; }
+
+function MoodBrowseSection() {
+  const { data: moods } = useApi<MoodPreset[]>("/api/browse/moods");
+  const { playAll } = usePlayerActions();
+  const [loadingMood, setLoadingMood] = useState<string | null>(null);
+
+  async function playMood(mood: string) {
+    setLoadingMood(mood);
+    try {
+      const data = await api<{ tracks: Array<{ id: number; title: string; artist: string; album: string; path: string; navidrome_id?: string }> }>(`/api/browse/mood/${mood}?limit=50`);
+      if (data.tracks.length > 0) {
+        playAll(
+          data.tracks.map((t) => ({
+            id: t.path || String(t.id),
+            title: t.title,
+            artist: t.artist,
+            album: t.album,
+            path: t.path,
+            navidromeId: t.navidrome_id,
+            albumCover: `/api/cover/${encPath(t.artist)}/${encPath(t.album)}`,
+          })),
+          0,
+          { type: "playlist", name: `${mood.charAt(0).toUpperCase() + mood.slice(1)} Mix` },
+        );
+      } else {
+        toast.info("No tracks match this mood yet — analyze more of your library");
+      }
+    } catch {
+      toast.error("Failed to load mood tracks");
+    } finally {
+      setLoadingMood(null);
+    }
+  }
+
+  if (!moods || moods.length === 0) return null;
+
+  return (
+    <div className="space-y-3">
+      <ExploreSectionHeader title="Browse by Mood" subtitle="Powered by audio analysis of your library." />
+      <div className="grid grid-cols-2 sm:grid-cols-4 gap-2">
+        {moods.map((m) => (
+          <button
+            key={m.name}
+            onClick={() => playMood(m.name)}
+            disabled={loadingMood !== null}
+            className={`rounded-xl border px-4 py-3 text-left transition-colors ${MOOD_COLORS[m.name] || "bg-white/5 text-white/70 border-white/10"} active:scale-[0.98]`}
+          >
+            <span className="text-sm font-medium capitalize">{loadingMood === m.name ? "Loading..." : m.name}</span>
+            <span className="block text-[10px] opacity-60 mt-0.5">{m.track_count} tracks</span>
+          </button>
+        ))}
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary

Two high-value Tier 2 features:

### Sleep Timer (#72)
- Moon icon in FullscreenPlayer header
- Options: 15min, 30min, 45min, 1 hour, end of current track
- Visual countdown displayed below icon
- Automatic pause when timer expires
- Cancel button when active

### Browse by Mood (#70)
- Backend: 8 mood presets (energetic, chill, dark, happy, melancholy, intense, groovy, acoustic)
- Each preset maps to energy/danceability/valence/acousticness ranges
- `/api/browse/moods` returns presets with track counts
- `/api/browse/mood/{mood}` returns random matching tracks
- Explore page: colored mood cards with instant-play on tap
- **Unique differentiator**: powered by real per-track Essentia audio analysis

## Test plan
- [x] `npm run build` passes
- [x] Python syntax check passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Sleep Timer with customizable preset durations (15, 30, and 45 minutes, 1 hour, or end of track) to automatically pause playback
  * Added Browse by Mood feature to discover music by selecting preset moods with track counts and random track selection

<!-- end of auto-generated comment: release notes by coderabbit.ai -->