### PR TITLE
[codex] Fix missing track indexing in nested album folders

### DIFF
--- a/app/crate/library_sync.py
+++ b/app/crate/library_sync.py
@@ -5,7 +5,7 @@ from pathlib import Path
 
 import mutagen
 
-from crate.audio import get_audio_files, read_tags
+from crate.audio import read_tags
 from crate.db import (
     delete_album,
     delete_artist,
@@ -116,6 +116,26 @@ class LibrarySync:
         artist_name = self._canonical_artist_name(artist_dir, folder_name)
         return self.sync_artist_dirs(artist_name, [artist_dir])
 
+    def _iter_album_audio_files(self, album_dir: Path) -> list[Path]:
+        return sorted(
+            file_path
+            for file_path in album_dir.rglob("*")
+            if file_path.is_file()
+            and not any(part.startswith(".") for part in file_path.relative_to(album_dir).parts)
+            and file_path.suffix.lower() in self.extensions
+        )
+
+    def _album_tree_mtime(self, album_dir: Path) -> float:
+        latest_mtime = album_dir.stat().st_mtime
+        for path in album_dir.rglob("*"):
+            if any(part.startswith(".") for part in path.relative_to(album_dir).parts):
+                continue
+            try:
+                latest_mtime = max(latest_mtime, path.stat().st_mtime)
+            except OSError:
+                continue
+        return latest_mtime
+
     def sync_artist_dirs(self, artist_name: str, artist_dirs: list[Path]) -> int:
         """Sync one or more folders that all belong to the same canonical artist."""
         primary_dir = artist_dirs[0]
@@ -160,9 +180,15 @@ class LibrarySync:
                 synced_paths.add(album_path)
 
                 existing_album = next((a for a in existing_albums if a["path"] == album_path), None)
-                dir_mtime = album_dir.stat().st_mtime
+                tree_mtime = self._album_tree_mtime(album_dir)
+                actual_track_count = len(self._iter_album_audio_files(album_dir))
 
-                if existing_album and existing_album.get("dir_mtime") and existing_album["dir_mtime"] >= dir_mtime:
+                if (
+                    existing_album
+                    and existing_album.get("dir_mtime")
+                    and existing_album["dir_mtime"] >= tree_mtime
+                    and existing_album.get("track_count", 0) == actual_track_count
+                ):
                     total_tracks += existing_album.get("track_count", 0)
                     continue
 
@@ -217,7 +243,7 @@ class LibrarySync:
             upsert_artist({"name": artist_name, "album_count": 0, "track_count": 0,
                            "total_size": 0, "formats": [], "dir_mtime": album_dir.parent.stat().st_mtime})
 
-        audio_files = get_audio_files(album_dir, list(self.extensions))
+        audio_files = self._iter_album_audio_files(album_dir)
 
         # Get existing tracks for this album to reuse data for unchanged files
         existing_album_row = None
@@ -361,7 +387,7 @@ class LibrarySync:
             "has_cover": has_cover,
             "musicbrainz_albumid": mb_albumid,
             "tag_album": tag_album,
-            "dir_mtime": album_dir.stat().st_mtime,
+            "dir_mtime": self._album_tree_mtime(album_dir),
         })
 
         # Upsert tracks

--- a/app/tests/test_library_sync.py
+++ b/app/tests/test_library_sync.py
@@ -158,6 +158,87 @@ class TestSyncAlbum:
                 assert "flac" in result["formats"]
                 assert mock_upsert_track.call_count == 2
 
+    def test_sync_album_reads_nested_disc_tracks(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            lib = Path(tmpdir)
+            album_dir = lib / "Artist" / "Album Deluxe"
+            disc1 = album_dir / "Disc 1"
+            disc2 = album_dir / "Disc 2"
+            disc1.mkdir(parents=True)
+            disc2.mkdir(parents=True)
+            (disc1 / "01.flac").write_bytes(b"\x00" * 1024)
+            (disc1 / "02.flac").write_bytes(b"\x00" * 1024)
+            (disc2 / "03.flac").write_bytes(b"\x00" * 2048)
+
+            config = {
+                "library_path": str(lib),
+                "audio_extensions": [".flac"],
+            }
+
+            mock_mf = MagicMock()
+            mock_mf.info.length = 240.0
+            mock_mf.info.bitrate = 320000
+
+            with patch("crate.library_sync.get_library_artist", return_value={"name": "Artist"}), \
+                 patch("crate.library_sync.upsert_artist"), \
+                 patch("crate.library_sync.upsert_album", return_value=1), \
+                 patch("crate.library_sync.upsert_track") as mock_upsert_track, \
+                 patch("crate.library_sync.get_db_ctx") as mock_ctx, \
+                 patch("crate.library_sync.mutagen.File", return_value=mock_mf), \
+                 patch("crate.library_sync.read_tags", return_value={"artist": "Artist", "album": "Album Deluxe", "title": "Track"}):
+                mock_cur = MagicMock()
+                mock_cur.fetchone.return_value = None
+                mock_cur.fetchall.return_value = []
+                mock_ctx.return_value.__enter__ = MagicMock(return_value=mock_cur)
+                mock_ctx.return_value.__exit__ = MagicMock(return_value=False)
+
+                from crate.library_sync import LibrarySync
+                sync = LibrarySync(config)
+                result = sync.sync_album(album_dir, "Artist")
+
+                assert result["track_count"] == 3
+                assert result["total_size"] == 4096
+                assert mock_upsert_track.call_count == 3
+
+    def test_sync_artist_resyncs_album_when_track_count_is_stale(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            lib = Path(tmpdir)
+            artist_dir = lib / "Artist"
+            album_dir = artist_dir / "2001" / "Album Deluxe"
+            disc1 = album_dir / "Disc 1"
+            disc2 = album_dir / "Disc 2"
+            disc1.mkdir(parents=True)
+            disc2.mkdir(parents=True)
+            (disc1 / "01.flac").write_bytes(b"\x00" * 1024)
+            (disc1 / "02.flac").write_bytes(b"\x00" * 1024)
+            (disc2 / "03.flac").write_bytes(b"\x00" * 2048)
+
+            config = {
+                "library_path": str(lib),
+                "audio_extensions": [".flac"],
+            }
+
+            stale_album = {
+                "id": 11,
+                "path": str(album_dir),
+                "track_count": 1,
+                "dir_mtime": album_dir.stat().st_mtime,
+                "total_size": 1024,
+                "format": "flac",
+            }
+
+            from crate.library_sync import LibrarySync
+
+            with patch("crate.library_sync.get_library_artist", return_value={"name": "Artist"}), \
+                 patch("crate.library_sync.get_library_albums", return_value=[stale_album]), \
+                 patch("crate.library_sync.upsert_artist"), \
+                 patch.object(LibrarySync, "sync_album", return_value={"track_count": 3}) as mock_sync_album:
+                sync = LibrarySync(config)
+                count = sync.sync_artist(artist_dir)
+
+                assert count == 3
+                mock_sync_album.assert_called_once()
+
 
 class TestRemoveStale:
     def test_remove_stale_artists(self):


### PR DESCRIPTION
## Summary

Fixes `LibrarySync` so albums with nested disc/bonus subfolders are fully indexed instead of silently stopping at the top-level files only.

## Root cause

Two things combined to make these albums stay permanently incomplete:

1. [app/crate/library_sync.py](/Users/diego/Code/Ninja/musicdock/app/crate/library_sync.py) used a non-recursive album file scan, so files inside structures like `Album/Disc 1/*.flac` and `Album/Disc 2/*.flac` were never sent to `upsert_track()`.
2. `sync_artist_dirs()` could skip an existing album based only on the root album directory mtime, even when the indexed `track_count` no longer matched the actual number of audio files in the album tree.

That meant repair/full sync could report success while leaving a large tail of unindexed files behind.

## Changes

- Added recursive album-tree scanning in `LibrarySync` via `_iter_album_audio_files()`.
- Added `_album_tree_mtime()` so album freshness is based on the whole tree, not only the root folder.
- Tightened the fast-path skip in `sync_artist_dirs()` so an album is only skipped when both:
  - the stored tree mtime is still current
  - the stored `track_count` matches the actual number of audio files found on disk

## Validation

- `PYTHONPYCACHEPREFIX=/tmp/pycache python3 -m py_compile app/crate/library_sync.py`
- `docker compose -f docker-compose.dev.yaml exec worker pytest tests/test_library_sync.py -q` → `9 passed`

## Tests added

In [app/tests/test_library_sync.py](/Users/diego/Code/Ninja/musicdock/app/tests/test_library_sync.py):
- `test_sync_album_reads_nested_disc_tracks`
- `test_sync_artist_resyncs_album_when_track_count_is_stale`

Closes #150

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved album change detection to more accurately identify when synchronization is needed.
  * Enhanced support for albums organized in nested subdirectories (e.g., disc folders).

* **Tests**
  * Added test coverage for nested album directory structures.
  * Added test coverage for album resynchronization detection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->