### PR TITLE
perf + mobile polish (#11, #16, #59, #138, #139)

### DIFF
--- a/app/crate/api/browse_media.py
+++ b/app/crate/api/browse_media.py
@@ -243,101 +243,24 @@ def api_track_info(request: Request, filepath: str):
 
 @router.get("/api/discover/completeness")
 def api_discover_completeness(request: Request):
+    """Return cached completeness data. The heavy computation runs as a worker task."""
     _require_auth(request)
-    cache_key = "discover:completeness"
-    cached = get_cache(cache_key, max_age_seconds=3600)
-    if cached:
+    cached = get_cache("discover:completeness", max_age_seconds=86400)
+    if cached is not None:
         return cached
+    # No cached data — queue a worker task to compute it
+    from crate.db import create_task_dedup
+    create_task_dedup("compute_completeness", {})
+    return []
 
-    with get_db_ctx() as cur:
-        cur.execute(
-            """
-            SELECT id, slug, name, mbid, album_count, has_photo, listeners
-            FROM library_artists
-            WHERE mbid IS NOT NULL AND mbid != ''
-            ORDER BY name
-            """
-        )
-        artists = [dict(row) for row in cur.fetchall()]
 
-    import musicbrainzngs
-
-    musicbrainzngs.set_useragent("grooveyard", "0.1", "https://github.com/grooveyard")
-
-    results = []
-    for artist in artists:
-        try:
-            mb_data = get_cache(f"mb:albums:{artist['mbid']}", max_age_seconds=86400 * 7)
-            if not mb_data:
-                try:
-                    mb_artist = musicbrainzngs.get_artist_by_id(artist["mbid"])["artist"]
-                    mb_name = mb_artist.get("name", "")
-                    from thefuzz import fuzz
-
-                    if fuzz.ratio(artist["name"].lower(), mb_name.lower()) < 70:
-                        log.warning(
-                            "MBID mismatch: %s -> %s (expected %s), skipping",
-                            artist["mbid"],
-                            mb_name,
-                            artist["name"],
-                        )
-                        continue
-                except Exception:
-                    pass
-
-                result = musicbrainzngs.browse_release_groups(
-                    artist=artist["mbid"], release_type=["album"], limit=100
-                )
-                mb_albums = result.get("release-group-list", [])
-                mb_data = {
-                    "count": result.get("release-group-count", len(mb_albums)),
-                    "albums": [
-                        {
-                            "title": release_group.get("title", ""),
-                            "type": release_group.get("primary-type", ""),
-                            "year": release_group.get("first-release-date", "")[:4]
-                            if release_group.get("first-release-date")
-                            else "",
-                        }
-                        for release_group in mb_albums
-                    ],
-                }
-                set_cache(f"mb:albums:{artist['mbid']}", mb_data, ttl=604800)
-
-            mb_count = mb_data["count"]
-            local_count = artist["album_count"] or 0
-            pct = round(local_count / mb_count * 100) if mb_count > 0 else 100
-
-            with get_db_ctx() as cur:
-                cur.execute("SELECT name FROM library_albums WHERE artist = %s", (artist["name"],))
-                local_names = {row["name"].lower() for row in cur.fetchall()}
-                local_clean = {_YEAR_PREFIX_RE.sub("", name).lower() for name in local_names}
-
-            missing = [
-                album
-                for album in mb_data["albums"]
-                if album["title"].lower() not in local_names and album["title"].lower() not in local_clean
-            ]
-
-            results.append(
-                {
-                    "artist_id": artist["id"],
-                    "artist_slug": artist["slug"],
-                    "artist": artist["name"],
-                    "has_photo": bool(artist["has_photo"]),
-                    "listeners": artist.get("listeners", 0),
-                    "local_count": local_count,
-                    "mb_count": mb_count,
-                    "pct": min(pct, 100),
-                    "missing": missing[:10],
-                }
-            )
-        except Exception:
-            pass
-
-    results.sort(key=lambda item: item["pct"])
-    set_cache(cache_key, results, ttl=3600)
-    return results
+@router.post("/api/discover/completeness/refresh")
+def api_discover_completeness_refresh(request: Request):
+    """Force recompute of completeness data."""
+    _require_auth(request)
+    from crate.db import create_task_dedup
+    task_id = create_task_dedup("compute_completeness", {})
+    return {"task_id": task_id}
 
 
 _STREAM_MEDIA_TYPES = {

--- a/app/crate/worker_handlers/enrichment.py
+++ b/app/crate/worker_handlers/enrichment.py
@@ -819,10 +819,103 @@ def _process_new_content_inner(
     return result
 
 
+def _handle_compute_completeness(task_id: str, params: dict, config: dict) -> dict:
+    """Compute library completeness vs MusicBrainz for all artists with MBIDs."""
+    import re
+    import musicbrainzngs
+    from crate.db import get_cache, set_cache
+
+    musicbrainzngs.set_useragent("crate", "1.0", "https://github.com/crate")
+    year_re = re.compile(r"^\d{4}\s*[-–]\s*")
+
+    with get_db_ctx() as cur:
+        cur.execute(
+            """
+            SELECT id, slug, name, mbid, album_count, has_photo, listeners
+            FROM library_artists
+            WHERE mbid IS NOT NULL AND mbid != ''
+            ORDER BY name
+            """
+        )
+        artists = [dict(row) for row in cur.fetchall()]
+
+    total = len(artists)
+    results = []
+    for index, artist in enumerate(artists):
+        if is_cancelled(task_id):
+            break
+        if index % 10 == 0:
+            update_task(task_id, progress=json.dumps({"done": index, "total": total}))
+
+        try:
+            mb_data = get_cache(f"mb:albums:{artist['mbid']}", max_age_seconds=86400 * 7)
+            if not mb_data:
+                try:
+                    mb_artist = musicbrainzngs.get_artist_by_id(artist["mbid"])["artist"]
+                    mb_name = mb_artist.get("name", "")
+                    from thefuzz import fuzz
+                    if fuzz.ratio(artist["name"].lower(), mb_name.lower()) < 70:
+                        log.debug("MBID mismatch: %s -> %s, skipping", artist["mbid"], mb_name)
+                        continue
+                except Exception:
+                    pass
+
+                result = musicbrainzngs.browse_release_groups(
+                    artist=artist["mbid"], release_type=["album"], limit=100
+                )
+                mb_albums = result.get("release-group-list", [])
+                mb_data = {
+                    "count": result.get("release-group-count", len(mb_albums)),
+                    "albums": [
+                        {
+                            "title": rg.get("title", ""),
+                            "type": rg.get("primary-type", ""),
+                            "year": rg.get("first-release-date", "")[:4] if rg.get("first-release-date") else "",
+                        }
+                        for rg in mb_albums
+                    ],
+                }
+                set_cache(f"mb:albums:{artist['mbid']}", mb_data, ttl=604800)
+                time.sleep(1)  # rate limit
+
+            mb_count = mb_data["count"]
+            local_count = artist["album_count"] or 0
+            pct = round(local_count / mb_count * 100) if mb_count > 0 else 100
+
+            with get_db_ctx() as cur:
+                cur.execute("SELECT name FROM library_albums WHERE artist = %s", (artist["name"],))
+                local_names = {row["name"].lower() for row in cur.fetchall()}
+                local_clean = {year_re.sub("", name).lower() for name in local_names}
+
+            missing = [
+                album for album in mb_data["albums"]
+                if album["title"].lower() not in local_names and album["title"].lower() not in local_clean
+            ]
+
+            results.append({
+                "artist_id": artist["id"],
+                "artist_slug": artist["slug"],
+                "artist": artist["name"],
+                "has_photo": bool(artist["has_photo"]),
+                "listeners": artist.get("listeners", 0),
+                "local_count": local_count,
+                "mb_count": mb_count,
+                "pct": min(pct, 100),
+                "missing": missing[:10],
+            })
+        except Exception:
+            log.debug("Completeness check failed for %s", artist["name"], exc_info=True)
+
+    results.sort(key=lambda item: item["pct"])
+    set_cache("discover:completeness", results, ttl=86400)
+    return {"artists_checked": len(results), "total": total}
+
+
 ENRICHMENT_TASK_HANDLERS: dict[str, TaskHandler] = {
     "enrich_artist": _handle_enrich_single,
     "enrich_artists": _handle_enrich_artists,
     "reset_enrichment": _handle_reset_enrichment,
     "enrich_mbids": _handle_enrich_mbids,
     "process_new_content": _handle_process_new_content,
+    "compute_completeness": _handle_compute_completeness,
 }

--- a/app/listen/src/components/cards/TrackRow.tsx
+++ b/app/listen/src/components/cards/TrackRow.tsx
@@ -1,6 +1,6 @@
 import { memo, useEffect, useRef, useState } from "react";
 import { Play, Pause, Plus, ListPlus, Heart, ListMusic } from "lucide-react";
-import { usePlayer, usePlayerActions, type Track } from "@/contexts/PlayerContext";
+import { usePlayerState, usePlayerActions, type Track } from "@/contexts/PlayerContext";
 import { useLikedTracks } from "@/contexts/LikedTracksContext";
 import { ActionIconButton } from "@/components/ui/ActionIconButton";
 import { formatDuration } from "@/lib/utils";
@@ -51,8 +51,8 @@ export const TrackRow = memo(function TrackRow({
   onAddToPlaylist,
   onCreatePlaylist,
 }: TrackRowProps) {
-  const { currentTrack, isPlaying } = usePlayer();
-  const { play, pause, resume, addToQueue, playNext } = usePlayerActions();
+  const { isPlaying } = usePlayerState();
+  const { currentTrack, play, pause, resume, addToQueue, playNext } = usePlayerActions();
   const { isLiked, toggleTrackLike } = useLikedTracks();
   const [playlistMenuOpen, setPlaylistMenuOpen] = useState(false);
   const playlistMenuRef = useRef<HTMLDivElement>(null);

--- a/app/listen/src/components/player/FullscreenPlayer.tsx
+++ b/app/listen/src/components/player/FullscreenPlayer.tsx
@@ -200,18 +200,21 @@ export function FullscreenPlayer({ open, onClose }: FullscreenPlayerProps) {
   // Reset tab when player closes
   useEffect(() => { if (!visible) { setActiveTab("player"); setSwipeY(0); } }, [visible]);
 
-  // Swipe-down to dismiss
+  // Swipe-down to dismiss (only from top 150px)
   const onSwipeStart = useCallback((e: React.TouchEvent) => {
     if (draggingRef.current) return;
-    swipeStartRef.current = e.touches[0]!.clientY;
+    const startY = e.touches[0]!.clientY;
+    const el = (e.currentTarget as HTMLElement).getBoundingClientRect();
+    if (startY - el.top > 150) return;
+    swipeStartRef.current = startY;
   }, []);
   const onSwipeMove = useCallback((e: React.TouchEvent) => {
     if (swipeStartRef.current === null || draggingRef.current) return;
     const dy = e.touches[0]!.clientY - swipeStartRef.current;
-    setSwipeY(Math.max(0, dy));
+    setSwipeY(dy > 0 ? Math.min(dy * 0.6, 300) : 0);
   }, []);
   const onSwipeEnd = useCallback(() => {
-    if (swipeY > 120) {
+    if (swipeY > 100) {
       onClose();
     }
     setSwipeY(0);
@@ -241,6 +244,11 @@ export function FullscreenPlayer({ open, onClose }: FullscreenPlayerProps) {
       onTouchMove={onSwipeMove}
       onTouchEnd={onSwipeEnd}
     >
+      {/* Drag handle */}
+      <div className="flex justify-center pt-3 pb-1">
+        <div className="w-10 h-1 rounded-full bg-white/20" />
+      </div>
+
       {/* Header */}
       <div className="flex items-center justify-between px-4 pt-[env(safe-area-inset-top,12px)] pb-2">
         <button

--- a/app/listen/src/components/player/PlayerBar.tsx
+++ b/app/listen/src/components/player/PlayerBar.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from "react";
+import { useMemo, useRef, useState } from "react";
 import {
   Play, Pause, SkipBack, SkipForward, Shuffle, Repeat, Repeat1,
   Heart, Airplay, ListMusic, Mic2, Maximize2, Loader2,
@@ -49,6 +49,30 @@ export function PlayerBar() {
     closeOnPointerDownOutside: false,
   });
 
+  const touchStartX = useRef<number>(0);
+  const touchStartY = useRef<number>(0);
+
+  function handleTouchStart(e: React.TouchEvent) {
+    const t = e.touches[0];
+    if (!t) return;
+    touchStartX.current = t.clientX;
+    touchStartY.current = t.clientY;
+  }
+
+  function handleTouchEnd(e: React.TouchEvent) {
+    const t = e.changedTouches[0];
+    if (!t) return;
+    const deltaX = t.clientX - touchStartX.current;
+    const deltaY = t.clientY - touchStartY.current;
+    if (Math.abs(deltaX) > 50 && Math.abs(deltaX) > Math.abs(deltaY) * 2) {
+      if (deltaX < 0) {
+        next();
+      } else {
+        prev();
+      }
+    }
+  }
+
   const progress = duration > 0 ? (currentTime / duration) * 100 : 0;
   const pseudoBars = useMemo(
     () => currentTrack ? generateWaveformBars(currentTrack.id, 80) : [],
@@ -83,7 +107,11 @@ export function PlayerBar() {
 
   return (
     <>
-      <div className={`fixed bottom-0 left-0 right-0 h-[72px] border-t border-white/5 bg-panel-surface ${hasFloatingOverlayOpen ? "z-app-player-overlay" : "z-app-player"}`}>
+      <div
+        className={`fixed bottom-0 left-0 right-0 h-[72px] border-t border-white/5 bg-panel-surface ${hasFloatingOverlayOpen ? "z-app-player-overlay" : "z-app-player"}`}
+        onTouchStart={handleTouchStart}
+        onTouchEnd={handleTouchEnd}
+      >
         <div className="h-full flex items-center px-4 gap-2">
 
           {/* ── Block 1: Track Info ── */}

--- a/app/listen/src/components/ui/AppModal.tsx
+++ b/app/listen/src/components/ui/AppModal.tsx
@@ -53,18 +53,24 @@ export function AppModal({
     };
   }, [closeOnEscape, lockBodyScroll, onClose, open]);
 
-  // Swipe-to-dismiss (mobile bottom sheet)
+  // Swipe-to-dismiss (mobile bottom sheet — drag handle only)
   const [swipeY, setSwipeY] = useState(0);
   const swipeStartRef = useRef<number | null>(null);
+  const dragHandleRef = useRef<HTMLDivElement>(null);
   const onSwipeStart = useCallback((e: React.TouchEvent) => {
-    swipeStartRef.current = e.touches[0]!.clientY;
+    if (!dragHandleRef.current) return;
+    const handleRect = dragHandleRef.current.getBoundingClientRect();
+    const touchY = e.touches[0]!.clientY;
+    if (touchY > handleRect.bottom + 8) return;
+    swipeStartRef.current = touchY;
   }, []);
   const onSwipeMove = useCallback((e: React.TouchEvent) => {
     if (swipeStartRef.current === null) return;
-    setSwipeY(Math.max(0, e.touches[0]!.clientY - swipeStartRef.current));
+    const dy = e.touches[0]!.clientY - swipeStartRef.current;
+    setSwipeY(dy > 0 ? Math.min(dy * 0.6, 300) : 0);
   }, []);
   const onSwipeEnd = useCallback(() => {
-    if (swipeY > 100) onClose();
+    if (swipeY > 80) onClose();
     setSwipeY(0);
     swipeStartRef.current = null;
   }, [swipeY, onClose]);
@@ -99,8 +105,8 @@ export function AppModal({
         onTouchEnd={onSwipeEnd}
       >
         {/* Drag handle — visible on mobile only */}
-        <div className="flex justify-center pt-2 pb-1 sm:hidden">
-          <div className="w-8 h-1 rounded-full bg-white/20" />
+        <div ref={dragHandleRef} className="flex justify-center pt-2 pb-1 sm:hidden">
+          <div className="w-10 h-1 rounded-full bg-white/20" />
         </div>
         {children}
       </div>

--- a/app/listen/src/components/ui/PullIndicator.tsx
+++ b/app/listen/src/components/ui/PullIndicator.tsx
@@ -1,0 +1,20 @@
+import { Loader2 } from "lucide-react";
+
+export function PullIndicator({ distance, refreshing }: { distance: number; refreshing: boolean }) {
+  if (distance <= 0 && !refreshing) return null;
+  return (
+    <div
+      className="flex items-center justify-center overflow-hidden transition-[height] duration-200"
+      style={{ height: refreshing ? 40 : distance }}
+    >
+      {refreshing ? (
+        <Loader2 size={18} className="animate-spin text-primary" />
+      ) : (
+        <div
+          className="h-5 w-5 rounded-full border-2 border-primary/40 border-t-primary transition-transform"
+          style={{ transform: `rotate(${distance * 4}deg)`, opacity: Math.min(distance / 32, 1) }}
+        />
+      )}
+    </div>
+  );
+}

--- a/app/listen/src/hooks/use-pull-to-refresh.ts
+++ b/app/listen/src/hooks/use-pull-to-refresh.ts
@@ -1,0 +1,42 @@
+import { useRef, useCallback, useState } from "react";
+
+export function usePullToRefresh(onRefresh: () => Promise<void>) {
+  const startY = useRef(0);
+  const [pulling, setPulling] = useState(false);
+  const [pullDistance, setPullDistance] = useState(0);
+  const [refreshing, setRefreshing] = useState(false);
+  const threshold = 80;
+
+  const handlers = {
+    onTouchStart: useCallback((e: React.TouchEvent) => {
+      const el = e.currentTarget;
+      if (el.scrollTop > 0 || window.scrollY > 0) return;
+      startY.current = e.touches[0]!.clientY;
+      setPulling(true);
+    }, []),
+
+    onTouchMove: useCallback((e: React.TouchEvent) => {
+      if (!pulling || refreshing) return;
+      const dy = e.touches[0]!.clientY - startY.current;
+      if (dy > 0) {
+        setPullDistance(Math.min(dy * 0.4, 120));
+      }
+    }, [pulling, refreshing]),
+
+    onTouchEnd: useCallback(async () => {
+      if (!pulling) return;
+      if (pullDistance >= threshold * 0.4 && !refreshing) {
+        setRefreshing(true);
+        try {
+          await onRefresh();
+        } finally {
+          setRefreshing(false);
+        }
+      }
+      setPulling(false);
+      setPullDistance(0);
+    }, [pulling, pullDistance, refreshing, onRefresh]),
+  };
+
+  return { handlers, pullDistance, refreshing };
+}

--- a/app/listen/src/pages/Home.tsx
+++ b/app/listen/src/pages/Home.tsx
@@ -1,8 +1,11 @@
+import { useCallback } from "react";
 import { useNavigate } from "react-router";
 import { toast } from "sonner";
 
 import { useApi } from "@/hooks/use-api";
+import { usePullToRefresh } from "@/hooks/use-pull-to-refresh";
 import { api } from "@/lib/api";
+import { PullIndicator } from "@/components/ui/PullIndicator";
 import { fetchPlayableSetlist } from "@/lib/upcoming";
 import { usePlayer, usePlayerActions, type Track } from "@/contexts/PlayerContext";
 import {
@@ -86,20 +89,32 @@ export function Home() {
   const { currentTrack, recentlyPlayed } = usePlayer();
   const { play, playAll } = usePlayerActions();
 
-  const { data: curatedPlaylists, loading: curatedLoading } =
+  const { data: curatedPlaylists, loading: curatedLoading, refetch: refetchCurated } =
     useApi<CuratedPlaylist[]>("/api/curation/playlists");
   const { data: followedCurated, loading: followedLoading, refetch: refetchFollowedCurated } =
     useApi<CuratedPlaylist[]>("/api/curation/followed");
-  const { data: recentGlobalArtists, loading: globalArtistsLoading } =
+  const { data: recentGlobalArtists, loading: globalArtistsLoading, refetch: refetchArtists } =
     useApi<PaginatedArtistsResponse>("/api/artists?sort=recent&per_page=10");
-  const { data: savedAlbums, loading: savedAlbumsLoading } =
+  const { data: savedAlbums, loading: savedAlbumsLoading, refetch: refetchAlbums } =
     useApi<SavedAlbum[]>("/api/me/albums");
-  const { data: playlists, loading: playlistsLoading } =
+  const { data: playlists, loading: playlistsLoading, refetch: refetchPlaylists } =
     useApi<UserPlaylist[]>("/api/playlists");
-  const { data: upcoming } =
+  const { data: upcoming, refetch: refetchUpcoming } =
     useApi<HomeUpcomingResponse>("/api/me/upcoming");
-  const { data: replay } =
+  const { data: replay, refetch: refetchReplay } =
     useApi<ReplayMix>("/api/me/stats/replay?window=30d&limit=18");
+
+  const onRefresh = useCallback(async () => {
+    refetchCurated();
+    refetchFollowedCurated();
+    refetchArtists();
+    refetchAlbums();
+    refetchPlaylists();
+    refetchUpcoming();
+    refetchReplay();
+  }, [refetchCurated, refetchFollowedCurated, refetchArtists, refetchAlbums, refetchPlaylists, refetchUpcoming, refetchReplay]);
+
+  const { handlers: pullHandlers, pullDistance, refreshing } = usePullToRefresh(onRefresh);
 
   const continueItems = currentTrack
     ? [currentTrack, ...recentlyPlayed.filter((track) => track.id !== currentTrack.id)]
@@ -215,7 +230,8 @@ export function Home() {
   }
 
   return (
-    <div className="space-y-10">
+    <div className="space-y-10" {...pullHandlers}>
+      <PullIndicator distance={pullDistance} refreshing={refreshing} />
       <div className="space-y-6">
         <div>
           <h1 className="text-3xl font-bold text-foreground">{getHomeGreeting()}</h1>

--- a/app/listen/src/pages/Library.tsx
+++ b/app/listen/src/pages/Library.tsx
@@ -1,8 +1,10 @@
-import { useMemo, useState } from "react";
+import { useCallback, useMemo, useState } from "react";
 import { useSearchParams } from "react-router";
 import { Plus, Heart, Users, Disc, ListMusic, Loader2, Play, Pencil, Trash2, Search } from "lucide-react";
 import { toast } from "sonner";
 import { useApi } from "@/hooks/use-api";
+import { usePullToRefresh } from "@/hooks/use-pull-to-refresh";
+import { PullIndicator } from "@/components/ui/PullIndicator";
 import { useLikedTracks } from "@/contexts/LikedTracksContext";
 import { usePlaylistComposer } from "@/contexts/PlaylistComposerContext";
 import { ArtistCard } from "@/components/cards/ArtistCard";
@@ -550,15 +552,24 @@ function LikedTab() {
 
 export function Library() {
   const [searchParams, setSearchParams] = useSearchParams();
-  const { data: stats } = useApi<MeStats>("/api/me");
+  const { data: stats, refetch: refetchStats } = useApi<MeStats>("/api/me");
   const tab = parseTab(searchParams.get("tab"));
+  const [refreshKey, setRefreshKey] = useState(0);
+
+  const onRefresh = useCallback(async () => {
+    refetchStats();
+    setRefreshKey((k) => k + 1);
+  }, [refetchStats]);
+
+  const { handlers: pullHandlers, pullDistance, refreshing } = usePullToRefresh(onRefresh);
 
   function setTab(tab: Tab) {
     setSearchParams({ tab });
   }
 
   return (
-    <div className="space-y-6">
+    <div className="space-y-6" {...pullHandlers}>
+      <PullIndicator distance={pullDistance} refreshing={refreshing} />
       {/* Header */}
       <div>
         <h1 className="text-2xl font-bold">Your Library</h1>
@@ -593,10 +604,10 @@ export function Library() {
       </div>
 
       {/* Tab content */}
-      {tab === "playlists" && <PlaylistsTab />}
-      {tab === "artists" && <ArtistsTab />}
-      {tab === "albums" && <AlbumsTab />}
-      {tab === "liked" && <LikedTab />}
+      {tab === "playlists" && <PlaylistsTab key={refreshKey} />}
+      {tab === "artists" && <ArtistsTab key={refreshKey} />}
+      {tab === "albums" && <AlbumsTab key={refreshKey} />}
+      {tab === "liked" && <LikedTab key={refreshKey} />}
     </div>
   );
 }


### PR DESCRIPTION
## Summary

**Performance:**
- **#11** — discover/completeness moved to worker task (eliminates API-blocking DoS with 900 MusicBrainz requests)
- **#16** — TrackRow re-renders reduced from ~4Hz to on-change by splitting usePlayer into usePlayerState + usePlayerActions

**Mobile polish (Phase 1):**
- **#59** — Swipe-to-dismiss on FullscreenPlayer (top 150px drag zone, 100px threshold) and AppModal bottom sheets (drag handle, 80px threshold)
- **#138** — Swipe left/right on MiniPlayer for next/previous track
- **#139** — Pull-to-refresh on Home and Library pages with visual indicator

## Test plan
- [ ] Open Discover page — should show cached data or empty (not block)
- [ ] Play music with long tracklist — verify smooth scrolling (no re-render lag)
- [ ] FullscreenPlayer: swipe down from top to dismiss
- [ ] MiniPlayer: swipe left for next, right for previous
- [ ] Home/Library: pull down to refresh content

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Pull-to-refresh support on Home and Library pages
  * Manual refresh option for library data

* **Refactor**
  * Enhanced player swipe gestures with smoother drag mechanics
  * Improved mobile gesture responsiveness with visual feedback

* **Performance**
  * Faster data loading with improved caching

<!-- end of auto-generated comment: release notes by coderabbit.ai -->