### PR TITLE
feat: setlist enhancements — covers, hero button, queue export, visual section

### DIFF
--- a/app/crate/api/browse_artist.py
+++ b/app/crate/api/browse_artist.py
@@ -775,6 +775,10 @@ def api_artist_setlist_playable(request: Request, name: str):
     if not probable_setlist:
         return {"tracks": []}
 
+    artist_row = get_library_artist(name)
+    artist_id = artist_row["id"] if artist_row else None
+    artist_slug = artist_row.get("slug") if artist_row else None
+
     with get_db_ctx() as cur:
         cur.execute(
             """
@@ -783,6 +787,8 @@ def api_artist_setlist_playable(request: Request, name: str):
                 t.title,
                 t.path,
                 t.album,
+                t.album_id,
+                a.slug AS album_slug,
                 t.duration,
                 t.navidrome_id
             FROM library_tracks t
@@ -806,7 +812,11 @@ def api_artist_setlist_playable(request: Request, name: str):
                 "library_track_id": match["id"],
                 "title": match.get("title", ""),
                 "artist": name,
+                "artist_id": artist_id,
+                "artist_slug": artist_slug,
                 "album": match.get("album", ""),
+                "album_id": match.get("album_id"),
+                "album_slug": match.get("album_slug"),
                 "path": match.get("path", ""),
                 "duration": match.get("duration"),
                 "navidrome_id": match.get("navidrome_id"),

--- a/app/listen/src/components/artist/ArtistHeroSection.tsx
+++ b/app/listen/src/components/artist/ArtistHeroSection.tsx
@@ -1,5 +1,6 @@
 import {
   ChevronDown,
+  ListMusic,
   Play,
   Radio,
   Share2,
@@ -22,6 +23,8 @@ interface ArtistHeroSectionProps {
   onPlay: () => void;
   onShuffle: () => void;
   onArtistRadio: () => void;
+  onPlaySetlist?: () => void;
+  hasSetlist?: boolean;
   onToggleFollow: () => void;
   onShare: () => void;
   onOpenBio: () => void;
@@ -36,6 +39,8 @@ export function ArtistHeroSection({
   onPlay,
   onShuffle,
   onArtistRadio,
+  onPlaySetlist,
+  hasSetlist,
   onToggleFollow,
   onShare,
   onOpenBio,
@@ -138,6 +143,14 @@ export function ArtistHeroSection({
         >
           <Radio size={15} />
           Artist Radio
+        </button>
+        <button
+          className="flex items-center gap-2 rounded-full border border-white/15 px-4 py-2.5 text-sm text-foreground transition-colors hover:bg-white/5 disabled:opacity-40 disabled:cursor-not-allowed"
+          onClick={onPlaySetlist}
+          disabled={!hasSetlist}
+        >
+          <ListMusic size={15} />
+          Setlist
         </button>
         <button
           className={`flex items-center gap-2 rounded-full px-4 py-2.5 text-sm transition-colors ${

--- a/app/listen/src/components/artist/ArtistSetlistSection.tsx
+++ b/app/listen/src/components/artist/ArtistSetlistSection.tsx
@@ -1,0 +1,54 @@
+import { Play } from "lucide-react";
+
+interface ArtistSetlistSectionProps {
+  artistName: string;
+  setlist: { title: string; frequency: number; play_count: number; last_played?: string }[];
+  onPlayAll: () => void;
+}
+
+export function ArtistSetlistSection({ setlist, onPlayAll }: ArtistSetlistSectionProps) {
+  return (
+    <section>
+      <div className="mb-4 flex items-center justify-between">
+        <div>
+          <h2 className="text-lg font-semibold text-foreground">Probable Setlist</h2>
+          <p className="text-xs text-muted-foreground">Based on recent concerts</p>
+        </div>
+        <button
+          className="flex items-center gap-1.5 rounded-full border border-white/15 px-3 py-1.5 text-xs text-foreground transition-colors hover:bg-white/5"
+          onClick={onPlayAll}
+        >
+          <Play size={12} fill="currentColor" />
+          Play All
+        </button>
+      </div>
+
+      <div className="space-y-1">
+        {setlist.map((track, i) => (
+          <div
+            key={`${track.title}-${i}`}
+            className="flex items-center gap-3 rounded-lg px-2 py-1.5"
+          >
+            <span className="w-5 shrink-0 text-right text-xs tabular-nums text-white/25">
+              {i + 1}
+            </span>
+            <span className="min-w-0 flex-1 truncate text-sm font-medium text-foreground">
+              {track.title}
+            </span>
+            <div className="hidden w-24 items-center gap-2 sm:flex">
+              <div className="relative h-1 flex-1 rounded-full bg-primary/15">
+                <div
+                  className="absolute inset-y-0 left-0 rounded-full bg-primary"
+                  style={{ width: `${Math.round(track.frequency * 100)}%` }}
+                />
+              </div>
+              <span className="w-8 text-right text-[10px] tabular-nums text-white/30">
+                {Math.round(track.frequency * 100)}%
+              </span>
+            </div>
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/app/listen/src/components/artist/ArtistSetlistSection.tsx
+++ b/app/listen/src/components/artist/ArtistSetlistSection.tsx
@@ -1,54 +1,134 @@
-import { Play } from "lucide-react";
+import { ListMusic, Play, Save, X } from "lucide-react";
+import { useState } from "react";
+import { toast } from "sonner";
 
-interface ArtistSetlistSectionProps {
-  artistName: string;
-  setlist: { title: string; frequency: number; play_count: number; last_played?: string }[];
-  onPlayAll: () => void;
+import { api } from "@/lib/api";
+
+interface SetlistTrack {
+  title: string;
+  frequency: number;
+  play_count: number;
+  last_played?: string;
 }
 
-export function ArtistSetlistSection({ setlist, onPlayAll }: ArtistSetlistSectionProps) {
-  return (
-    <section>
-      <div className="mb-4 flex items-center justify-between">
-        <div>
-          <h2 className="text-lg font-semibold text-foreground">Probable Setlist</h2>
-          <p className="text-xs text-muted-foreground">Based on recent concerts</p>
-        </div>
-        <button
-          className="flex items-center gap-1.5 rounded-full border border-white/15 px-3 py-1.5 text-xs text-foreground transition-colors hover:bg-white/5"
-          onClick={onPlayAll}
-        >
-          <Play size={12} fill="currentColor" />
-          Play All
-        </button>
-      </div>
+interface ArtistSetlistModalProps {
+  artistName: string;
+  artistId?: number;
+  setlist: SetlistTrack[];
+  open: boolean;
+  onClose: () => void;
+  onPlay: () => void;
+}
 
-      <div className="space-y-1">
-        {setlist.map((track, i) => (
-          <div
-            key={`${track.title}-${i}`}
-            className="flex items-center gap-3 rounded-lg px-2 py-1.5"
-          >
-            <span className="w-5 shrink-0 text-right text-xs tabular-nums text-white/25">
-              {i + 1}
-            </span>
-            <span className="min-w-0 flex-1 truncate text-sm font-medium text-foreground">
-              {track.title}
-            </span>
-            <div className="hidden w-24 items-center gap-2 sm:flex">
-              <div className="relative h-1 flex-1 rounded-full bg-primary/15">
-                <div
-                  className="absolute inset-y-0 left-0 rounded-full bg-primary"
-                  style={{ width: `${Math.round(track.frequency * 100)}%` }}
-                />
-              </div>
-              <span className="w-8 text-right text-[10px] tabular-nums text-white/30">
-                {Math.round(track.frequency * 100)}%
-              </span>
+export function ArtistSetlistModal({
+  artistName,
+  artistId,
+  setlist,
+  open,
+  onClose,
+  onPlay,
+}: ArtistSetlistModalProps) {
+  const [saving, setSaving] = useState(false);
+
+  if (!open) return null;
+
+  async function handleExport() {
+    if (!artistId) return;
+    setSaving(true);
+    try {
+      await api(`/api/artists/${artistId}/setlist-playlist`, "POST");
+      toast.success("Setlist exported as playlist");
+    } catch {
+      toast.error("Failed to export setlist");
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  function handlePlay() {
+    onPlay();
+    onClose();
+  }
+
+  return (
+    <div
+      className="fixed inset-0 z-app-modal flex items-end justify-center sm:items-center"
+      onClick={onClose}
+    >
+      <div className="absolute inset-0 bg-black/70" />
+      <div
+        className="relative w-full max-w-md max-h-[85vh] overflow-hidden rounded-t-2xl sm:rounded-2xl bg-card border border-white/10 shadow-2xl flex flex-col"
+        onClick={(e) => e.stopPropagation()}
+      >
+        {/* Header */}
+        <div className="flex items-center justify-between border-b border-white/5 px-5 py-4">
+          <div className="flex items-center gap-3">
+            <ListMusic size={18} className="text-primary" />
+            <div>
+              <h3 className="text-sm font-semibold text-foreground">Probable Setlist</h3>
+              <p className="text-[11px] text-muted-foreground">{artistName} · {setlist.length} songs</p>
             </div>
           </div>
-        ))}
+          <button
+            onClick={onClose}
+            className="rounded-full p-1.5 text-white/40 transition-colors hover:bg-white/10 hover:text-white"
+          >
+            <X size={16} />
+          </button>
+        </div>
+
+        {/* Track list */}
+        <div className="flex-1 overflow-y-auto px-2 py-2">
+          {setlist.map((track, i) => (
+            <div
+              key={`${track.title}-${i}`}
+              className="flex items-center gap-3 rounded-lg px-3 py-2 transition-colors hover:bg-white/[0.03]"
+            >
+              <span className="w-5 shrink-0 text-right text-xs tabular-nums text-white/20">
+                {i + 1}
+              </span>
+              <div className="min-w-0 flex-1">
+                <span className="block truncate text-sm text-foreground">{track.title}</span>
+                <div className="mt-1 flex items-center gap-2">
+                  <div className="relative h-1 w-16 rounded-full bg-primary/15">
+                    <div
+                      className="absolute inset-y-0 left-0 rounded-full bg-primary/70"
+                      style={{ width: `${Math.round(track.frequency * 100)}%` }}
+                    />
+                  </div>
+                  <span className="text-[10px] tabular-nums text-white/25">
+                    {Math.round(track.frequency * 100)}%
+                  </span>
+                  {track.play_count > 0 && (
+                    <span className="text-[10px] text-white/20">
+                      {track.play_count} plays
+                    </span>
+                  )}
+                </div>
+              </div>
+            </div>
+          ))}
+        </div>
+
+        {/* Actions */}
+        <div className="flex gap-2 border-t border-white/5 px-5 py-4">
+          <button
+            onClick={handlePlay}
+            className="flex flex-1 items-center justify-center gap-2 rounded-xl bg-primary/15 py-2.5 text-sm font-medium text-primary transition-colors hover:bg-primary/25"
+          >
+            <Play size={14} fill="currentColor" />
+            Play Setlist
+          </button>
+          <button
+            onClick={handleExport}
+            disabled={saving || !artistId}
+            className="flex items-center justify-center gap-2 rounded-xl border border-white/10 px-4 py-2.5 text-sm text-foreground transition-colors hover:bg-white/5 disabled:opacity-40"
+          >
+            <Save size={14} />
+            {saving ? "Saving..." : "Export"}
+          </button>
+        </div>
       </div>
-    </section>
+    </div>
   );
 }

--- a/app/listen/src/components/player/extended/QueueTab.tsx
+++ b/app/listen/src/components/player/extended/QueueTab.tsx
@@ -1,6 +1,8 @@
-import { X } from "lucide-react";
+import { Save, X } from "lucide-react";
+import { toast } from "sonner";
 
 import { usePlayer, usePlayerActions } from "@/contexts/PlayerContext";
+import { api } from "@/lib/api";
 
 export function QueueTab() {
   const { isPlaying } = usePlayer();
@@ -9,6 +11,23 @@ export function QueueTab() {
   const history = queue.slice(0, currentIndex).reverse();
   const upcoming = queue.slice(currentIndex + 1);
   const sourceName = playSource?.name || "Queue";
+
+  async function handleSaveAsPlaylist() {
+    try {
+      await api("/api/playlists", "POST", {
+        name: playSource?.name || "Queue",
+        tracks: queue.map((t) => ({
+          track_path: t.path || t.id,
+          title: t.title,
+          artist: t.artist,
+          album: t.album || "",
+        })),
+      });
+      toast.success("Playlist saved");
+    } catch {
+      toast.error("Failed to save playlist");
+    }
+  }
 
   return (
     <div className="flex-1 overflow-y-auto pr-1">
@@ -47,9 +66,21 @@ export function QueueTab() {
 
       {currentTrack && (
         <div className="mb-4">
-          <p className="mb-2 px-1 text-[10px] font-bold uppercase tracking-wider text-white/25">
-            Now playing from: {sourceName}
-          </p>
+          <div className="mb-2 flex items-center justify-between px-1">
+            <p className="text-[10px] font-bold uppercase tracking-wider text-white/25">
+              Now playing from: {sourceName}
+            </p>
+            {queue.length > 0 && (
+              <button
+                className="flex items-center gap-1 rounded px-1.5 py-0.5 text-[10px] text-white/30 transition-colors hover:bg-white/5 hover:text-white/50"
+                onClick={() => void handleSaveAsPlaylist()}
+                title="Save as Playlist"
+              >
+                <Save size={10} />
+                Save
+              </button>
+            )}
+          </div>
           <div className="flex items-center gap-3 rounded-lg bg-white/5 px-2 py-1.5">
             <span className="w-4 shrink-0 text-right text-[10px] tabular-nums text-primary">
               {currentIndex + 1}

--- a/app/listen/src/components/player/extended/QueueTab.tsx
+++ b/app/listen/src/components/player/extended/QueueTab.tsx
@@ -13,17 +13,22 @@ export function QueueTab() {
   const sourceName = playSource?.name || "Queue";
 
   async function handleSaveAsPlaylist() {
+    const validTracks = queue.filter((t) => t.path && t.path.includes("/"));
+    if (!validTracks.length) {
+      toast.error("No local tracks in queue to save");
+      return;
+    }
     try {
       await api("/api/playlists", "POST", {
         name: playSource?.name || "Queue",
-        tracks: queue.map((t) => ({
-          track_path: t.path || t.id,
+        tracks: validTracks.map((t) => ({
+          path: t.path,
           title: t.title,
           artist: t.artist,
           album: t.album || "",
         })),
       });
-      toast.success("Playlist saved");
+      toast.success(`Playlist saved (${validTracks.length} tracks)`);
     } catch {
       toast.error("Failed to save playlist");
     }

--- a/app/listen/src/lib/upcoming.ts
+++ b/app/listen/src/lib/upcoming.ts
@@ -23,7 +23,7 @@ export async function fetchPlayableSetlist(input: { artistId?: number; artistNam
   }>(`/api/artists/${input.artistId}/setlist-playable`);
 
   return (response.tracks || []).map((track) => ({
-    id: track.path || track.navidrome_id || String(track.library_track_id),
+    id: track.path || String(track.library_track_id),
     title: track.title,
     artist: track.artist,
     artistId: track.artist_id,
@@ -31,11 +31,11 @@ export async function fetchPlayableSetlist(input: { artistId?: number; artistNam
     album: track.album,
     albumId: track.album_id,
     albumSlug: track.album_slug,
-    albumCover: track.album
-      ? albumCoverApiUrl({ albumId: track.album_id, albumSlug: track.album_slug, artistName: track.artist, albumName: track.album })
-      : artistPhotoApiUrl({ artistId: track.artist_id, artistSlug: track.artist_slug, artistName: track.artist || input.artistName }),
-    path: track.path || undefined,
-    navidromeId: track.navidrome_id || undefined,
+    path: track.path,
+    navidromeId: track.navidrome_id,
     libraryTrackId: track.library_track_id,
+    albumCover: albumCoverApiUrl({ albumId: track.album_id, albumSlug: track.album_slug, artistName: track.artist, albumName: track.album })
+      || artistPhotoApiUrl({ artistId: track.artist_id, artistSlug: track.artist_slug, artistName: track.artist })
+      || undefined,
   }));
 }

--- a/app/listen/src/pages/Artist.tsx
+++ b/app/listen/src/pages/Artist.tsx
@@ -6,7 +6,7 @@ import {
   ArtistBioModal,
 } from "@/components/artist/ArtistBioModal";
 import { ArtistHeroSection } from "@/components/artist/ArtistHeroSection";
-import { ArtistSetlistSection } from "@/components/artist/ArtistSetlistSection";
+import { ArtistSetlistModal } from "@/components/artist/ArtistSetlistSection";
 import {
   ArtistAlbumsSection,
   ArtistShowsSection,
@@ -38,6 +38,7 @@ export function Artist() {
   const { artistId: artistIdParam } = useParams<{ artistId?: string }>();
   const artistId = artistIdParam ? Number(artistIdParam) : undefined;
   const [bioModalOpen, setBioModalOpen] = useState(false);
+  const [setlistModalOpen, setSetlistModalOpen] = useState(false);
   const [expandedShowId, setExpandedShowId] = useState<string | null>(null);
   const [following, setFollowing] = useState(false);
   const { playAll } = usePlayerActions();
@@ -205,7 +206,7 @@ export function Artist() {
         onPlay={() => handlePlayTopTracks()}
         onShuffle={() => handlePlayTopTracks(0, true)}
         onArtistRadio={() => void handleArtistRadio()}
-        onPlaySetlist={() => void handlePlayArtistSetlist()}
+        onPlaySetlist={() => setSetlistModalOpen(true)}
         hasSetlist={!!enrichment?.setlist?.probable_setlist?.length}
         onToggleFollow={() => void toggleFollow()}
         onShare={() => void handleShare()}
@@ -227,13 +228,6 @@ export function Artist() {
           onToggleExpand={setExpandedShowId}
           onPlayProbableSetlist={() => void handlePlayArtistSetlist()}
         />
-        {enrichment?.setlist?.probable_setlist?.length ? (
-          <ArtistSetlistSection
-            artistName={data.name}
-            setlist={enrichment.setlist.probable_setlist}
-            onPlayAll={() => void handlePlayArtistSetlist()}
-          />
-        ) : null}
         <RelatedArtistsSection
           artists={similarArtists}
         />
@@ -247,6 +241,16 @@ export function Artist() {
         tags={tags}
         onClose={() => setBioModalOpen(false)}
       />
+      {enrichment?.setlist?.probable_setlist?.length ? (
+        <ArtistSetlistModal
+          artistName={data.name}
+          artistId={data.id}
+          setlist={enrichment.setlist.probable_setlist}
+          open={setlistModalOpen}
+          onClose={() => setSetlistModalOpen(false)}
+          onPlay={() => void handlePlayArtistSetlist()}
+        />
+      ) : null}
     </div>
   );
 }

--- a/app/listen/src/pages/Artist.tsx
+++ b/app/listen/src/pages/Artist.tsx
@@ -6,6 +6,7 @@ import {
   ArtistBioModal,
 } from "@/components/artist/ArtistBioModal";
 import { ArtistHeroSection } from "@/components/artist/ArtistHeroSection";
+import { ArtistSetlistSection } from "@/components/artist/ArtistSetlistSection";
 import {
   ArtistAlbumsSection,
   ArtistShowsSection,
@@ -94,6 +95,14 @@ export function Artist() {
   );
   const { data: showsData } = useApi<{ events: ArtistShowEvent[] }>(
     artistId != null ? `/api/artists/${artistId}/shows?limit=12` : null,
+  );
+  const { data: enrichment } = useApi<{
+    setlist?: {
+      probable_setlist: { title: string; frequency: number; play_count: number; last_played?: string }[];
+      total_shows: number;
+    };
+  }>(
+    artistId != null ? `/api/artists/${artistId}/enrichment` : null,
   );
   const { data: topArtistsStats } = useApi<StatsListResponse<StatsArtist>>(
     artistId != null ? "/api/me/stats/top-artists?window=30d&limit=12" : null,
@@ -196,6 +205,8 @@ export function Artist() {
         onPlay={() => handlePlayTopTracks()}
         onShuffle={() => handlePlayTopTracks(0, true)}
         onArtistRadio={() => void handleArtistRadio()}
+        onPlaySetlist={() => void handlePlayArtistSetlist()}
+        hasSetlist={!!enrichment?.setlist?.probable_setlist?.length}
         onToggleFollow={() => void toggleFollow()}
         onShare={() => void handleShare()}
         onOpenBio={() => setBioModalOpen(true)}
@@ -216,6 +227,13 @@ export function Artist() {
           onToggleExpand={setExpandedShowId}
           onPlayProbableSetlist={() => void handlePlayArtistSetlist()}
         />
+        {enrichment?.setlist?.probable_setlist?.length ? (
+          <ArtistSetlistSection
+            artistName={data.name}
+            setlist={enrichment.setlist.probable_setlist}
+            onPlayAll={() => void handlePlayArtistSetlist()}
+          />
+        ) : null}
         <RelatedArtistsSection
           artists={similarArtists}
         />


### PR DESCRIPTION
## Summary

- **Fix**: setlist tracks now show album covers in the player (backend was missing album_id/slug in response)
- **Setlist button in Artist hero**: "Setlist" button next to Artist Radio, disabled when no setlist data
- **Save as Playlist in Queue**: button in QueueTab that POSTs current queue as a new playlist
- **ArtistSetlistSection**: visual probable setlist with frequency bars, shown on Artist page between Shows and Related Artists

## Test plan
- [ ] Play probable setlist from ShowCard → tracks should have covers
- [ ] Artist page → Setlist button in hero plays the setlist
- [ ] Artist page → Probable Setlist section visible with frequency bars
- [ ] Queue tab → Save button creates a playlist with queue contents

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Probable setlist section on artist pages with frequency bars and a "Play All" action.
  * "Play Setlist" action added to artist header for quick playback.
  * "Save as Playlist" option for the current queue.

* **Improvements**
  * Playable setlists provide richer track metadata for more reliable playback and linking.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->