### PR TITLE
fix(repair): unblock library-health repair + stop process_new_content spam

### DIFF
--- a/app/crate/api/browse_artist.py
+++ b/app/crate/api/browse_artist.py
@@ -739,9 +739,11 @@ def api_shows_list(request: Request, city: str = "", country: str = ""):
 
 def api_artist_enrich(request: Request, name: str):
     _require_auth(request)
-    from crate.db import create_task_dedup
+    from crate.content import queue_process_new_content_if_needed
 
-    task_id = create_task_dedup("process_new_content", {"artist": name})
+    # force=True because this endpoint is the "re-enrich" button; the admin
+    # explicitly asked for a fresh run even if the filesystem hash is stable.
+    task_id = queue_process_new_content_if_needed(name, force=True)
     return {"status": "queued", "task_id": task_id}
 
 

--- a/app/crate/content.py
+++ b/app/crate/content.py
@@ -1,0 +1,105 @@
+"""Content hashing + task gating for process_new_content.
+
+Single source of truth for:
+ - computing an artist directory's content hash (preferring the Rust CLI
+   `crate-cli scan --hash`, falling back to Python MD5 over filenames+sizes).
+ - deciding whether a `process_new_content` task should actually be enqueued
+   for a given artist. Call sites that used to blindly call
+   ``create_task_dedup("process_new_content", ...)`` should go through
+   :func:`queue_process_new_content_if_needed` instead, so we stop flooding
+   the queue with no-ops that the worker then discards with
+   ``skipped: content_unchanged``.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+from pathlib import Path
+
+log = logging.getLogger(__name__)
+
+
+def compute_dir_hash(directory: Path) -> str:
+    """Return a content hash for ``directory``.
+
+    Tries ``crate-cli scan --hash`` first; falls back to a pure-Python
+    MD5 over ``filename:size`` pairs for every file under the directory.
+    """
+    try:
+        from crate.crate_cli import has_subcommands, is_available, run_scan
+
+        if is_available() and has_subcommands():
+            data = run_scan(str(directory), hash=True, covers=False)
+            if data and data.get("artists"):
+                content_hash = data["artists"][0].get("content_hash")
+                if content_hash:
+                    return content_hash
+    except Exception:
+        log.debug("crate-cli scan failed for %s, falling back to md5", directory, exc_info=True)
+
+    digest = hashlib.md5(usedforsecurity=False)
+    for file_path in sorted(directory.rglob("*")):
+        if file_path.is_file():
+            digest.update(f"{file_path.relative_to(directory)}:{file_path.stat().st_size}\n".encode())
+    return digest.hexdigest()
+
+
+def should_process_artist(artist_name: str, library_path: Path | str | None = None) -> bool:
+    """Return True iff the filesystem content for ``artist_name`` differs from
+    the stored ``library_artists.content_hash``.
+
+    Returns True when:
+    - the artist has no stored hash yet (never processed),
+    - the stored hash differs from the freshly computed filesystem hash.
+
+    Returns False when:
+    - the artist directory cannot be located,
+    - the hash already matches (no new content to process).
+    """
+    from crate.db import get_library_artist
+
+    if library_path is None:
+        from crate.config import load_config
+
+        library_path = load_config()["library_path"]
+    lib = Path(library_path)
+
+    artist_row = get_library_artist(artist_name)
+    folder = (artist_row.get("folder_name") if artist_row else None) or artist_name
+    artist_dir = lib / folder
+    if not artist_dir.is_dir():
+        return False
+
+    old_hash = artist_row.get("content_hash") if artist_row else None
+    if not old_hash:
+        return True
+
+    new_hash = compute_dir_hash(artist_dir)
+    return new_hash != old_hash
+
+
+def queue_process_new_content_if_needed(
+    artist_name: str,
+    *,
+    library_path: Path | str | None = None,
+    force: bool = False,
+) -> str | None:
+    """Enqueue ``process_new_content`` for ``artist_name`` only if the
+    filesystem content has actually changed since the last time the artist
+    was fully processed.
+
+    Returns the task id (string) if a task was enqueued, ``None`` if the
+    call was suppressed because content is unchanged or the dedup window
+    already contains a pending task for the same artist.
+    """
+    from crate.db import create_task_dedup
+
+    if not artist_name:
+        return None
+
+    if not force and not should_process_artist(artist_name, library_path=library_path):
+        log.debug("Skip queuing process_new_content for %s — content unchanged", artist_name)
+        return None
+
+    return create_task_dedup("process_new_content", {"artist": artist_name})

--- a/app/crate/enrichment.py
+++ b/app/crate/enrichment.py
@@ -29,14 +29,16 @@ def enrich_artist(name: str, config: dict, force: bool = False) -> dict:
     # Skip if recently enriched (unless force)
     if not force and db_artist and db_artist.get("enriched_at"):
         from datetime import datetime, timezone
-        try:
-            enriched = datetime.fromisoformat(db_artist["enriched_at"])
+        from crate.utils import to_datetime
+        enriched = to_datetime(db_artist["enriched_at"])
+        if enriched is not None:
             age_hours = (datetime.now(timezone.utc) - enriched).total_seconds() / 3600
-            min_age = int(get_setting("enrichment_min_age_hours", "24"))
+            try:
+                min_age = int(get_setting("enrichment_min_age_hours", "24"))
+            except (TypeError, ValueError):
+                min_age = 24
             if age_hours < min_age:
                 return {"artist": name, "skipped": True, "reason": "recently_enriched"}
-        except Exception:
-            pass
 
     if force:
         for prefix in ("enrichment:", "lastfm:artist:", "fanart:artist:",

--- a/app/crate/library_sync.py
+++ b/app/crate/library_sync.py
@@ -17,7 +17,7 @@ from crate.db import (
     upsert_artist,
     upsert_track,
 )
-from crate.utils import COVER_NAMES, PHOTO_NAMES, normalize_key
+from crate.utils import COVER_NAMES, PHOTO_NAMES, normalize_key, to_datetime
 
 log = logging.getLogger(__name__)
 
@@ -284,8 +284,9 @@ class LibrarySync:
             existing = existing_tracks_by_path.get(fpath)
             if existing and existing.get("updated_at"):
                 try:
-                    stored_ts = datetime.fromisoformat(existing["updated_at"]).timestamp()
-                    if fstat.st_mtime <= stored_ts:
+                    stored_dt = to_datetime(existing["updated_at"])
+                    stored_ts = stored_dt.timestamp() if stored_dt else 0.0
+                    if stored_ts and fstat.st_mtime <= stored_ts:
                         duration = existing.get("duration") or 0.0
                         total_duration += duration
                         if not year and existing.get("year"):
@@ -315,7 +316,7 @@ class LibrarySync:
                             "path": fpath,
                         })
                         continue
-                except (ValueError, OSError):
+                except (ValueError, OSError, TypeError):
                     pass
 
             # New or changed file — read tags + mutagen info

--- a/app/crate/library_watcher.py
+++ b/app/crate/library_watcher.py
@@ -131,23 +131,8 @@ class LibraryWatcher:
             # Queue enrichment for new content (only if content actually changed)
             if is_new_file:
                 try:
-                    from crate.db import create_task_dedup, get_library_artist
-                    artist_row = get_library_artist(canonical)
-                    old_hash = artist_row.get("content_hash") if artist_row else None
-                    should_queue = True
-                    if old_hash:
-                        import hashlib
-                        h = hashlib.md5(usedforsecurity=False)
-                        for f in sorted(artist_dir.rglob("*")):
-                            if f.is_file():
-                                h.update(f"{f.relative_to(artist_dir)}:{f.stat().st_size}\n".encode())
-                        if h.hexdigest() == old_hash:
-                            should_queue = False
-                            log.debug("Watcher: skipping %s — content unchanged", canonical)
-                    if should_queue:
-                        create_task_dedup("process_new_content", {
-                            "artist": canonical,
-                        })
+                    from crate.content import queue_process_new_content_if_needed
+                    if queue_process_new_content_if_needed(canonical, library_path=self.library_path):
                         log.info("Watcher: queued process_new_content for %s", canonical)
                 except Exception:
                     log.debug("Watcher: failed to queue processing for %s", canonical)

--- a/app/crate/orchestrator.py
+++ b/app/crate/orchestrator.py
@@ -254,7 +254,10 @@ class Orchestrator:
             for t in running:
                 try:
                     from datetime import datetime, timezone
-                    updated = datetime.fromisoformat(t["updated_at"].replace("Z", "+00:00"))
+                    from crate.utils import to_datetime
+                    updated = to_datetime(t["updated_at"])
+                    if updated is None:
+                        continue
                     age_sec = (datetime.now(timezone.utc) - updated).total_seconds()
                     if age_sec > 1800:  # 30 minutes
                         log.warning("Marking zombie task %s (type=%s, age=%dm) as failed",

--- a/app/crate/repair.py
+++ b/app/crate/repair.py
@@ -9,7 +9,6 @@ from crate.db import (
     delete_album,
     delete_track,
     upsert_artist,
-    create_task_dedup,
 )
 from crate.utils import PHOTO_NAMES
 
@@ -406,7 +405,10 @@ class LibraryRepair:
             result["details"]["sync_error"] = str(exc)[:200]
             return result
 
-        create_task_dedup("process_new_content", {"artist": canonical_artist})
+        # Report the affected canonical artist so _handle_repair can queue
+        # process_new_content once per artist after the full batch, instead of
+        # re-enqueueing per-album and flooding dedup.
+        result["details"]["enrich_artist"] = canonical_artist
         log_audit("reindex_unindexed", "directory", dir_path,
                   details={"count": details.get("count", 0), "artist": canonical_artist}, task_id=task_id)
         return result

--- a/app/crate/scheduler.py
+++ b/app/crate/scheduler.py
@@ -56,13 +56,12 @@ def should_run(task_type: str, schedules: dict[str, int] | None = None) -> bool:
     last_run = get_setting(last_key)
 
     if last_run:
-        try:
-            last_time = datetime.fromisoformat(last_run)
+        from crate.utils import to_datetime
+        last_time = to_datetime(last_run)
+        if last_time is not None:
             elapsed = (datetime.now(timezone.utc) - last_time).total_seconds()
             if elapsed < interval:
                 return False
-        except Exception:
-            pass
 
     # Check if already pending/running
     pending = list_tasks(status="pending", task_type=task_type, limit=1)

--- a/app/crate/utils.py
+++ b/app/crate/utils.py
@@ -2,6 +2,7 @@
 
 import re
 import unicodedata
+from datetime import datetime, timezone
 
 PHOTO_NAMES = {"artist.jpg", "artist.png", "photo.jpg"}
 
@@ -24,3 +25,25 @@ def normalize_key(name: str) -> str:
     name = re.sub(r"\s+", " ", name)
     name = re.sub(r"-+", "-", name)
     return name
+
+
+def to_datetime(value) -> datetime | None:
+    """Normalize a DB/date-ish value to a timezone-aware datetime.
+
+    After the TIMESTAMPTZ migration, psycopg2 returns datetime objects for
+    TIMESTAMPTZ/TIMESTAMP columns. Older code that called
+    ``datetime.fromisoformat(row["updated_at"])`` now raises TypeError. Use
+    this helper instead — it accepts datetime, str or None and always returns
+    a timezone-aware datetime (or None on failure).
+    """
+    if value is None:
+        return None
+    if isinstance(value, datetime):
+        return value if value.tzinfo is not None else value.replace(tzinfo=timezone.utc)
+    if isinstance(value, str):
+        try:
+            parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+        except ValueError:
+            return None
+        return parsed if parsed.tzinfo is not None else parsed.replace(tzinfo=timezone.utc)
+    return None

--- a/app/crate/worker_handlers/acquisition.py
+++ b/app/crate/worker_handlers/acquisition.py
@@ -97,44 +97,6 @@ def _seed_uploaded_library(user_id: int | None, imported_albums: list[dict]):
                 seen_track_ids.add(track_id)
 
 
-def _compute_dir_hash(directory: Path) -> str:
-    try:
-        from crate.crate_cli import has_subcommands, is_available, run_scan
-
-        if is_available() and has_subcommands():
-            data = run_scan(str(directory), hash=True, covers=False)
-            if data and data.get("artists"):
-                content_hash = data["artists"][0].get("content_hash")
-                if content_hash:
-                    return content_hash
-    except Exception:
-        log.debug("crate-cli scan failed for %s, falling back to md5", directory, exc_info=True)
-
-    import hashlib
-
-    digest = hashlib.md5(usedforsecurity=False)
-    for file_path in sorted(directory.rglob("*")):
-        if file_path.is_file():
-            digest.update(f"{file_path.relative_to(directory)}:{file_path.stat().st_size}\n".encode())
-    return digest.hexdigest()
-
-
-def _should_process_artist(artist_name: str, config: dict) -> bool:
-    from crate.db import get_library_artist
-
-    lib = Path(config["library_path"])
-    artist_row = get_library_artist(artist_name)
-    folder = (artist_row.get("folder_name") if artist_row else None) or artist_name
-    artist_dir = lib / folder
-    if not artist_dir.is_dir():
-        return False
-    old_hash = artist_row.get("content_hash") if artist_row else None
-    if not old_hash:
-        return True
-    new_hash = _compute_dir_hash(artist_dir)
-    return new_hash != old_hash
-
-
 def _tidal_download_inner(task_id, params, config, url, quality, download_id, lib):
     from crate.db import mark_release_downloaded, update_tidal_download
     from crate.library_sync import LibrarySync
@@ -219,10 +181,12 @@ def _tidal_download_inner(task_id, params, config, url, quality, download_id, li
             except Exception:
                 log.warning("Sync failed for %s", current_artist, exc_info=True)
 
+    from crate.content import queue_process_new_content_if_needed
     for current_artist in modified_artists:
         try:
-            if _should_process_artist(current_artist, config):
-                create_task_dedup("process_new_content", {"artist": current_artist})
+            queue_process_new_content_if_needed(
+                current_artist, library_path=config.get("library_path"), force=True
+            )
         except Exception:
             log.debug("Failed to queue process_new_content for Tidal artist %s", current_artist, exc_info=True)
 
@@ -791,9 +755,12 @@ def _handle_soulseek_download(task_id: str, params: dict, config: dict) -> dict:
             },
         )
 
-    if artist and moved > 0 and _should_process_artist(artist, config):
-        create_task_dedup("process_new_content", {"artist": artist})
-        emit_task_event(task_id, "info", {"message": f"Processing new content for {artist}"})
+    if artist and moved > 0:
+        from crate.content import queue_process_new_content_if_needed
+        if queue_process_new_content_if_needed(
+            artist, library_path=config.get("library_path"), force=True
+        ):
+            emit_task_event(task_id, "info", {"message": f"Processing new content for {artist}"})
 
     return {
         "artist": artist,
@@ -943,9 +910,12 @@ def _handle_library_upload(task_id: str, params: dict, config: dict) -> dict:
 
     _seed_uploaded_library(uploader_user_id, imported_albums)
 
+    from crate.content import queue_process_new_content_if_needed
     for artist in modified_artists:
         try:
-            create_task_dedup("process_new_content", {"artist": artist})
+            queue_process_new_content_if_needed(
+                artist, library_path=config.get("library_path"), force=True
+            )
         except Exception:
             log.debug("Failed to queue process_new_content for uploaded artist %s", artist, exc_info=True)
 

--- a/app/crate/worker_handlers/enrichment.py
+++ b/app/crate/worker_handlers/enrichment.py
@@ -27,26 +27,7 @@ def _unmark_processing(artist_name: str):
     delete_cache(f"processing:{artist_name.lower()}")
 
 
-def _compute_dir_hash(directory: Path) -> str:
-    try:
-        from crate.crate_cli import has_subcommands, is_available, run_scan
-
-        if is_available() and has_subcommands():
-            data = run_scan(str(directory), hash=True, covers=False)
-            if data and data.get("artists"):
-                content_hash = data["artists"][0].get("content_hash")
-                if content_hash:
-                    return content_hash
-    except Exception:
-        log.debug("crate-cli scan failed for %s, falling back to md5", directory, exc_info=True)
-
-    import hashlib
-
-    digest = hashlib.md5(usedforsecurity=False)
-    for file_path in sorted(directory.rglob("*")):
-        if file_path.is_file():
-            digest.update(f"{file_path.relative_to(directory)}:{file_path.stat().st_size}\n".encode())
-    return digest.hexdigest()
+from crate.content import compute_dir_hash as _compute_dir_hash
 
 
 def _clean_album_lookup_name(album_name: str) -> str:

--- a/app/crate/worker_handlers/management.py
+++ b/app/crate/worker_handlers/management.py
@@ -9,7 +9,6 @@ def _escape_like(value: str) -> str:
 
 from crate.db import (
     create_task,
-    create_task_dedup,
     delete_cache,
     emit_task_event,
     get_cache,
@@ -115,11 +114,42 @@ def _handle_repair(task_id: str, params: dict, config: dict) -> dict:
                 except Exception:
                     log.debug("Failed to mark issue %s as resolved", issue_id, exc_info=True)
 
+        # Collect unique artists that need re-enrichment from repair actions
+        # (e.g. unindexed_files that just got synced). Queue one
+        # process_new_content per artist after the loop, not per action —
+        # otherwise we flood the worker with duplicates that all skip.
+        enrich_artists: set[str] = set()
+        for action in result.get("actions", []):
+            if action.get("applied"):
+                artist = (action.get("details") or {}).get("enrich_artist")
+                if artist:
+                    enrich_artists.add(artist)
+
+        enqueued_enrich = 0
+        if not dry_run and enrich_artists:
+            from crate.content import queue_process_new_content_if_needed
+
+            for artist in sorted(enrich_artists):
+                try:
+                    # force=True because the repair actions just mutated the
+                    # DB and the filesystem content_hash may still match
+                    # what's stored in library_artists.
+                    if queue_process_new_content_if_needed(
+                        artist, library_path=config.get("library_path"), force=True
+                    ):
+                        enqueued_enrich += 1
+                except Exception:
+                    log.debug("Failed to queue enrichment for %s", artist, exc_info=True)
+
         emit_task_event(
             task_id,
             "info",
             {
-                "message": f"Repair complete: {action_count} actions, {len(resolved_ids)} resolved",
+                "message": (
+                    f"Repair complete: {action_count} actions, "
+                    f"{len(resolved_ids)} resolved, "
+                    f"{enqueued_enrich} enrichments queued"
+                ),
                 "fs_changed": result.get("fs_changed"),
                 "db_changed": result.get("db_changed"),
             },
@@ -127,6 +157,7 @@ def _handle_repair(task_id: str, params: dict, config: dict) -> dict:
         if not dry_run and result.get("fs_changed"):
             start_scan()
 
+        result["enrich_queued"] = enqueued_enrich
         return result
     finally:
         if not dry_run:
@@ -189,12 +220,31 @@ def _handle_library_pipeline(task_id: str, params: dict, config: dict) -> dict:
     if repair_result.get("fs_changed"):
         start_scan()
 
+    from crate.content import queue_process_new_content_if_needed
+
+    repair_enrich_artists: set[str] = set()
+    for action in repair_result.get("actions", []):
+        if action.get("applied"):
+            artist = (action.get("details") or {}).get("enrich_artist")
+            if artist:
+                repair_enrich_artists.add(artist)
+
+    for artist in sorted(repair_enrich_artists):
+        try:
+            queue_process_new_content_if_needed(
+                artist, library_path=config.get("library_path"), force=True
+            )
+        except Exception:
+            log.debug("Failed to queue enrichment for %s", artist, exc_info=True)
+
     all_artists, _ = get_library_artists(per_page=10000)
     queued = 0
     for artist in all_artists:
         if not artist.get("content_hash"):
-            create_task_dedup("process_new_content", {"artist": artist["name"]})
-            queued += 1
+            if queue_process_new_content_if_needed(
+                artist["name"], library_path=config.get("library_path")
+            ):
+                queued += 1
     if queued:
         emit_task_event(
             task_id,


### PR DESCRIPTION
## Problem

Two interlocking backend regressions:

1. **Repair no hace nada** — después de la migración a TIMESTAMPTZ, `library_sync.py:287` lanza `TypeError` en cada sync_album porque `existing['updated_at']` ya no es un string sino un `datetime`. El `except (ValueError, OSError)` no lo captura, el error propaga hasta el try/except de `sync_artist_dirs` y se loguea como "Failed to sync album ...". Resultado: `LibraryRepair._fix_unindexed_files` corre `sync_artist`, cada álbum crashea, **no se añade ningún track**, y la issue `unindexed_files` vuelve a aparecer en el siguiente health check. Loop infinito.

2. **Spam de tareas `process_new_content`** — 125 `unindexed_files` issues × N tasks por artista. `create_task_dedup` sólo dedupa contra tareas en `pending/running`, y el fast-path `skipped: content_unchanged` termina en <500ms, así que la siguiente llamada idéntica inserta una fila nueva. Resultado observado en prod: 8 tareas para Circle Jerks en 2 segundos, todas `skipped`.

## Verification en prod

```
SELECT params_json->>'artist', result_json->>'skipped', result_json->>'reason', updated_at
FROM tasks WHERE type='process_new_content' AND status='completed'
ORDER BY updated_at DESC LIMIT 15;
```

Salida: 8 Circle Jerks + 5 Guilt Trip + Drain + Mastodon + Nia Archives, todas `skipped: true, content_unchanged`.

Reproducción directa del crash:
```
docker compose exec crate-worker python -c '...LibraryRepair(...).repair({"issues": unindexed}, dry_run=False)'
Failed to sync album Silence Is Loud
Traceback ...
TypeError: fromisoformat: argument must be str
```

## Fixes

### Bug 1 — `sync_album` TypeError

- Nuevo helper `crate.utils.to_datetime(value)` que acepta `datetime | str | None` y devuelve siempre un `datetime` tz-aware (o None).
- Aplicado en el punto del crash + hygiene en los otros callers de `datetime.fromisoformat` que estaban fail-open:
  - `orchestrator.py` — zombie task detection
  - `scheduler.py` — last-run check
  - `enrichment.py` — recency check

### Bug 2 — `process_new_content` spam

- Nuevo módulo `crate.content` con:
  - `compute_dir_hash(directory)` — reemplaza las 2 copias idénticas en `worker_handlers/{enrichment,acquisition}.py`
  - `should_process_artist(artist_name)` — hash check contra `library_artists.content_hash`
  - `queue_process_new_content_if_needed(artist_name, *, force=False)` — el gate autoritativo; los call sites ya no llaman a `create_task_dedup` directamente para este task type.

- Call sites migrados:
  - `library_watcher.py` — ya tenía hash check inline, ahora usa el helper
  - `repair.py` — `_fix_unindexed_files` ya no enqueue directamente; reporta `enrich_artist` en los details del action para que el handler haga batch.
  - `_handle_repair` y `_handle_library_pipeline` — colectan artistas únicos desde los action details y llaman `queue_process_new_content_if_needed(..., force=True)` una vez por artista. 125 unindexed_files sobre 20 artistas → 20 tareas, no 125.
  - `acquisition.py` — Tidal / Soulseek / upload paths
  - `browse_artist.api_artist_enrich` — re-enrich button del admin

- `force=True` se usa donde el admin explícitamente acaba de mutar el filesystem o la DB (repair, download, upload, re-enrich). Los paths "orgánicos" (watcher, pipeline) confían en el hash check.

## Test plan

- [ ] `python3 -c "import ast; ast.parse(...)"` — pasa
- [ ] Deploy a prod via `make deploy` (requiere que CI buildee esta rama o merge a main)
- [ ] Después del deploy, ejecutar repair desde admin: verificar que los 125 unindexed_files disminuyen a 0 en 2-3 iteraciones de health-check + repair
- [ ] Verificar que `SELECT COUNT(*) FROM tasks WHERE type='process_new_content' AND updated_at > now() - interval '10 minutes'` es <= número de artistas afectados (no 125+)
- [ ] Verificar logs del worker: no más "Failed to sync album ... TypeError: fromisoformat"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Artist re-enrichment now supports forced content reprocessing regardless of prior state

* **Bug Fixes**
  * Enhanced error handling for malformed date values and configuration parsing
  * Improved robustness in content change detection and timestamp conversion

* **Refactor**
  * Streamlined content processing workflow and centralized timestamp handling logic

<!-- end of auto-generated comment: release notes by coderabbit.ai -->