### PR TITLE
fix: restore listen connect and sharing

### DIFF
--- a/app/listen/android/app/src/main/java/app/cratemusic/crate/CrateSocialSharePlugin.java
+++ b/app/listen/android/app/src/main/java/app/cratemusic/crate/CrateSocialSharePlugin.java
@@ -1,6 +1,7 @@
 package app.cratemusic.crate;
 
 import android.content.Intent;
+import android.content.ActivityNotFoundException;
 import android.content.pm.PackageManager;
 import android.net.Uri;
 import android.util.Base64;
@@ -16,10 +17,18 @@ import com.getcapacitor.annotation.CapacitorPlugin;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.io.InputStream;
+import java.io.ByteArrayOutputStream;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.util.Locale;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 
 @CapacitorPlugin(name = "CrateSocialShare")
 public class CrateSocialSharePlugin extends Plugin {
     private static final String INSTAGRAM_PACKAGE = "com.instagram.android";
+    private final ExecutorService imageExecutor = Executors.newSingleThreadExecutor();
 
     @PluginMethod
     public void canShareInstagramStory(PluginCall call) {
@@ -43,16 +52,73 @@ public class CrateSocialSharePlugin extends Plugin {
 
         try {
             StoryImage storyImage = writeStoryImage(imageDataUrl);
-            shareStoryImage(storyImage);
-            JSObject payload = new JSObject();
-            payload.put("shared", true);
-            call.resolve(payload);
+            getActivity().runOnUiThread(() -> {
+                try {
+                    shareStoryImage(storyImage, contentUrl);
+                    JSObject payload = new JSObject();
+                    payload.put("shared", true);
+                    call.resolve(payload);
+                } catch (ActivityNotFoundException error) {
+                    call.reject("Instagram Stories is not available", error);
+                } catch (Exception error) {
+                    call.reject("Failed to open Instagram Stories", error);
+                }
+            });
         } catch (Exception error) {
-            call.reject("Failed to share to Instagram Stories", error);
+            call.reject("Failed to prepare Instagram story", error);
         }
     }
 
-    private void shareStoryImage(StoryImage storyImage) {
+    @PluginMethod
+    public void loadImageDataUrl(PluginCall call) {
+        String imageUrl = call.getString("url", "");
+        if (imageUrl.isEmpty()) {
+            call.reject("Missing image URL");
+            return;
+        }
+
+        imageExecutor.execute(() -> {
+            HttpURLConnection connection = null;
+            try {
+                URL url = new URL(imageUrl);
+                connection = (HttpURLConnection) url.openConnection();
+                connection.setInstanceFollowRedirects(true);
+                connection.setConnectTimeout(5_000);
+                connection.setReadTimeout(10_000);
+                connection.setRequestProperty("Accept", "image/avif,image/webp,image/apng,image/svg+xml,image/*,*/*;q=0.8");
+                connection.setRequestProperty("User-Agent", "Crate Android");
+
+                int status = connection.getResponseCode();
+                if (status < 200 || status >= 300) {
+                    call.reject("Failed to load share artwork: HTTP " + status);
+                    return;
+                }
+
+                byte[] bytes;
+                try (InputStream input = connection.getInputStream()) {
+                    bytes = readBytes(input);
+                }
+                if (bytes.length == 0) {
+                    call.reject("Failed to load share artwork: empty response");
+                    return;
+                }
+
+                String mimeType = normalizeImageMime(connection.getContentType(), imageUrl);
+                String base64 = Base64.encodeToString(bytes, Base64.NO_WRAP);
+                JSObject payload = new JSObject();
+                payload.put("dataUrl", "data:" + mimeType + ";base64," + base64);
+                call.resolve(payload);
+            } catch (Exception error) {
+                call.reject("Failed to load share artwork", error);
+            } finally {
+                if (connection != null) {
+                    connection.disconnect();
+                }
+            }
+        });
+    }
+
+    private void shareStoryImage(StoryImage storyImage, String contentUrl) {
         getContext().grantUriPermission(
             INSTAGRAM_PACKAGE,
             storyImage.uri,
@@ -61,8 +127,12 @@ public class CrateSocialSharePlugin extends Plugin {
 
         Intent addToStoryIntent = new Intent("com.instagram.share.ADD_TO_STORY");
         addToStoryIntent.setPackage(INSTAGRAM_PACKAGE);
-        addToStoryIntent.setDataAndType(storyImage.uri, "image/*");
+        addToStoryIntent.setDataAndType(storyImage.uri, storyImage.mimeType);
         addToStoryIntent.addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION);
+        addToStoryIntent.putExtra("source_application", getContext().getPackageName());
+        if (contentUrl != null && !contentUrl.isEmpty()) {
+            addToStoryIntent.putExtra("content_url", contentUrl);
+        }
         getActivity().startActivity(addToStoryIntent);
     }
 
@@ -124,5 +194,41 @@ public class CrateSocialSharePlugin extends Plugin {
         if ("image/png".equalsIgnoreCase(mimeType)) return ".png";
         if ("image/webp".equalsIgnoreCase(mimeType)) return ".webp";
         return ".jpg";
+    }
+
+    private byte[] readBytes(InputStream input) throws IOException {
+        ByteArrayOutputStream output = new ByteArrayOutputStream();
+        byte[] buffer = new byte[16_384];
+        int read;
+        while ((read = input.read(buffer)) != -1) {
+            output.write(buffer, 0, read);
+        }
+        return output.toByteArray();
+    }
+
+    private String normalizeImageMime(String contentType, String imageUrl) {
+        if (contentType != null && !contentType.isEmpty()) {
+            String mime = contentType.split(";")[0].trim().toLowerCase(Locale.ROOT);
+            if (mime.startsWith("image/")) {
+                if ("image/jpg".equals(mime)) return "image/jpeg";
+                return mime;
+            }
+        }
+        return inferImageMimeFromUrl(imageUrl);
+    }
+
+    private String inferImageMimeFromUrl(String imageUrl) {
+        String lower = imageUrl.toLowerCase(Locale.ROOT).split("\\?")[0];
+        if (lower.endsWith(".jpg") || lower.endsWith(".jpeg")) return "image/jpeg";
+        if (lower.endsWith(".webp")) return "image/webp";
+        if (lower.endsWith(".gif")) return "image/gif";
+        if (lower.endsWith(".svg")) return "image/svg+xml";
+        return "image/png";
+    }
+
+    @Override
+    protected void handleOnDestroy() {
+        imageExecutor.shutdownNow();
+        super.handleOnDestroy();
     }
 }

--- a/app/listen/src/components/share/ShareSheet.tsx
+++ b/app/listen/src/components/share/ShareSheet.tsx
@@ -86,13 +86,12 @@ export function ShareSheetHost() {
       open
       onClose={() => setPayload(null)}
       maxWidthClassName="sm:max-w-[420px]"
-      panelClassName="listen-glass-panel overflow-hidden"
+      panelClassName="listen-glass-panel overflow-hidden rounded-[28px]"
       overlayClassName="bg-black/58"
       mobileSafeArea
     >
       <div className="relative overflow-hidden">
-        <div className="pointer-events-none absolute inset-x-0 top-0 h-36 bg-[radial-gradient(circle_at_20%_0%,rgba(34,211,238,0.28),transparent_62%)]" />
-        <div className="relative flex items-start gap-3 border-b border-white/8 px-4 py-4">
+        <div className="relative flex items-start gap-3 border-b border-white/8 bg-black/[0.08] px-4 py-4">
           <SharePreviewImage payload={payload} />
           <div className="min-w-0 flex-1 pt-0.5">
             <p className="text-[10px] font-bold uppercase tracking-[0.18em] text-primary">
@@ -194,13 +193,13 @@ function ShareAction({
       disabled={disabled}
       onClick={onClick}
       className={cn(
-        "group flex w-full items-center gap-3 rounded-2xl border border-white/10 bg-white/[0.045] px-3 py-3 text-left transition",
-        "hover:border-primary/30 hover:bg-primary/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40",
+        "group flex w-full items-center gap-3 rounded-2xl border border-white/10 bg-black/20 px-3 py-3 text-left transition",
+        "hover:border-white/20 hover:bg-white/[0.06] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40",
         disabled &&
-          "cursor-not-allowed opacity-45 hover:border-white/10 hover:bg-white/[0.045]",
+          "cursor-not-allowed opacity-45 hover:border-white/10 hover:bg-black/20",
       )}
     >
-      <span className="flex h-11 w-11 shrink-0 items-center justify-center rounded-xl border border-white/10 bg-black/30 text-primary shadow-[inset_0_1px_0_rgba(255,255,255,0.04)] backdrop-blur">
+      <span className="flex h-11 w-11 shrink-0 items-center justify-center rounded-xl border border-white/10 bg-white/[0.06] text-primary shadow-[inset_0_1px_0_rgba(255,255,255,0.05)] backdrop-blur">
         <Icon size={19} className={spinning ? "animate-spin" : ""} />
       </span>
       <span className="min-w-0 flex-1">

--- a/app/listen/src/contexts/PlayerContext.tsx
+++ b/app/listen/src/contexts/PlayerContext.tsx
@@ -86,6 +86,7 @@ import {
   CRATE_CONNECT_V2_TRANSPORT_ENABLED,
   connectPlayerStateToRemotePlaybackState,
 } from "@/lib/crate-connect";
+import { recordDevLog } from "@/lib/dev-logs";
 import {
   buildPlaybackStatePayload,
   remotePlaybackQueue,
@@ -278,6 +279,7 @@ export function PlayerProvider({ children }: { children: ReactNode }) {
   const nativeBufferingWatchdogRef = useRef<number | null>(null);
   const nativeBufferingProbeIdRef = useRef(0);
   const nativeAuthRetryKeyRef = useRef<string | null>(null);
+  const nativeBufferingRecoveryKeyRef = useRef<string | null>(null);
 
   // queue, currentIndex, currentTrack, currentTime, duration, isPlaying are
   // kept in sync with their refs by their respective commit* helpers.
@@ -653,6 +655,51 @@ export function PlayerProvider({ children }: { children: ReactNode }) {
     nativeBufferingWatchdogRef.current = null;
   }, []);
 
+  const recoverNativeBuffering = useCallback(
+    async (options: { forceRefresh: boolean; probeStatus: string }) => {
+      if (!shouldUseAndroidNativePlayer()) return false;
+
+      const queueSnapshot = queueRef.current;
+      if (queueSnapshot.length === 0) return false;
+
+      const index = clampIndex(currentIndexRef.current, queueSnapshot.length);
+      const targetTrack = queueSnapshot[index];
+      const positionMs = Math.max(0, Math.round(currentTimeRef.current * 1000));
+      const retryKey = [
+        targetTrack?.id || index,
+        Math.floor(positionMs / 10_000),
+        options.probeStatus,
+      ].join(":");
+      if (nativeBufferingRecoveryKeyRef.current === retryKey) return false;
+      nativeBufferingRecoveryKeyRef.current = retryKey;
+
+      if (options.forceRefresh && !(await refreshAuthToken())) {
+        return false;
+      }
+
+      const engineTracks = await toFreshEngineTracks(queueSnapshot);
+      await androidNativeEngine.loadQueue({
+        revision: createQueueRevision(),
+        tracks: engineTracks,
+        currentIndex: index,
+        positionMs,
+        autoplay: true,
+        repeat: repeatRef.current,
+        crossfadeMs: effectiveCrossfadeMsRef.current,
+        volume: lastNonZeroVolumeRef.current,
+      });
+      return true;
+    },
+    [
+      currentIndexRef,
+      currentTimeRef,
+      effectiveCrossfadeMsRef,
+      lastNonZeroVolumeRef,
+      queueRef,
+      repeatRef,
+    ],
+  );
+
   const probeNativeBuffering = useCallback(async () => {
     const track = currentTrackRef.current;
     const probeId = nativeBufferingProbeIdRef.current + 1;
@@ -664,7 +711,15 @@ export function PlayerProvider({ children }: { children: ReactNode }) {
       ? "network-error"
       : "no-track";
     let detail = "";
-    if (track && streamUrl) {
+    const isNativeLocalUrl =
+      streamUrl.startsWith("file:") ||
+      streamUrl.startsWith("capacitor:") ||
+      streamUrl.startsWith("content:");
+
+    if (track && streamUrl && isNativeLocalUrl) {
+      status = 206;
+      detail = "Native local media URL; skipping WebView range probe";
+    } else if (track && streamUrl) {
       const controller = new AbortController();
       const timeout = window.setTimeout(() => controller.abort(), 5000);
       try {
@@ -702,11 +757,46 @@ export function PlayerProvider({ children }: { children: ReactNode }) {
       probeStatus: status,
       detail,
     });
+    const canRecover =
+      status === 200 || status === 206 || status === 401 || isNativeLocalUrl;
+    if (canRecover) {
+      try {
+        const recovered = await recoverNativeBuffering({
+          forceRefresh: status === 401,
+          probeStatus: String(status),
+        });
+        if (recovered) {
+          recordDevLog(
+            "native-player",
+            "recovered stuck native buffering",
+            {
+              track: track?.title,
+              artist: track?.artist,
+              probeStatus: status,
+              url: redactedUrl,
+            },
+            "warn",
+          );
+          return;
+        }
+      } catch (error) {
+        persistNativePlaybackDiagnostic({
+          type: "buffering-recovery-failed",
+          track: track
+            ? { id: track.id, title: track.title, artist: track.artist }
+            : null,
+          streamUrl: redactedUrl,
+          probeStatus: status,
+          detail,
+          recoveryError: error instanceof Error ? error.message : String(error),
+        });
+      }
+    }
     toast.error("Native playback is stuck buffering", {
       description: `Stream probe: ${status}${detail ? ` · ${detail}` : ""}`,
       duration: 9000,
     });
-  }, [currentTrackRef]);
+  }, [currentTrackRef, recoverNativeBuffering]);
 
   const scheduleNativeBufferingWatchdog = useCallback(() => {
     clearNativeBufferingWatchdog();
@@ -893,6 +983,9 @@ export function PlayerProvider({ children }: { children: ReactNode }) {
       if (state.playbackState === "buffering" && !isPassiveLifecycleBuffering) {
         scheduleNativeBufferingWatchdog();
       } else {
+        if (state.playbackState !== "buffering") {
+          nativeBufferingRecoveryKeyRef.current = null;
+        }
         clearNativeBufferingWatchdog();
       }
       if (state.isPlaying) {
@@ -1205,7 +1298,7 @@ export function PlayerProvider({ children }: { children: ReactNode }) {
         "bufferingChanged",
         (event) => {
           if (disposed) return;
-          commitIsBuffering(event.isBuffering);
+          handleNativeEvent("bufferingChanged", event);
         },
       );
       removers.push(bufferingRemove);

--- a/app/listen/src/contexts/use-player-engine-sync.ts
+++ b/app/listen/src/contexts/use-player-engine-sync.ts
@@ -266,8 +266,13 @@ export function usePlayerEngineSync({
         commitIsBuffering(autoplay);
         commitIsPlaying(autoplay);
 
+        void primeOfflineRuntimeProfile().catch((error) => {
+          console.warn(
+            "[offline] failed to prime profile before native sync:",
+            error,
+          );
+        });
         void (async () => {
-          await primeOfflineRuntimeProfile();
           const engineTracks = await toFreshEngineTracks(nextQueue);
           return androidNativeEngine.loadQueue({
             revision: createQueueRevision(),

--- a/app/listen/src/contexts/use-player-queue-actions.ts
+++ b/app/listen/src/contexts/use-player-queue-actions.ts
@@ -253,8 +253,13 @@ export function usePlayerQueueActions({
           startTrackerSession(activeTrack, nextSource);
         }
         commitIsPlaying(true);
+        void primeOfflineRuntimeProfile().catch((error) => {
+          console.warn(
+            "[offline] failed to prime profile before native load:",
+            error,
+          );
+        });
         void (async () => {
-          await primeOfflineRuntimeProfile();
           const engineTracks = await toFreshEngineTracks(tracks);
           return nativeEngine.loadQueue({
             revision: createQueueRevision(),

--- a/app/listen/src/lib/crate-connect.test.ts
+++ b/app/listen/src/lib/crate-connect.test.ts
@@ -20,9 +20,17 @@ import {
   fetchConnectWsTicket,
   generatePlaybackInstanceId,
   isCrateConnectEnabled,
+  isCrateConnectFeatureFlagEnabled,
 } from "@/lib/crate-connect";
 
 describe("Crate Connect v2 client primitives", () => {
+  it("keeps the feature compiled in unless explicitly disabled", () => {
+    expect(isCrateConnectFeatureFlagEnabled(undefined)).toBe(true);
+    expect(isCrateConnectFeatureFlagEnabled("")).toBe(true);
+    expect(isCrateConnectFeatureFlagEnabled("true")).toBe(true);
+    expect(isCrateConnectFeatureFlagEnabled("false")).toBe(false);
+  });
+
   it("starts disabled until the user preference enables it", () => {
     expect(isCrateConnectEnabled()).toBe(false);
   });

--- a/app/listen/src/lib/crate-connect.ts
+++ b/app/listen/src/lib/crate-connect.ts
@@ -7,8 +7,16 @@ import type {
 
 export const CONNECT_SESSION_EVENT = "crate:connect-session-updated";
 export const CONNECT_ENABLED_EVENT = "crate:connect-enabled-changed";
-export const CRATE_CONNECT_FEATURE_ENABLED =
-  import.meta.env.VITE_CRATE_CONNECT_FEATURE_ENABLED === "true";
+
+export function isCrateConnectFeatureFlagEnabled(
+  value: string | undefined,
+): boolean {
+  return value !== "false";
+}
+
+export const CRATE_CONNECT_FEATURE_ENABLED = isCrateConnectFeatureFlagEnabled(
+  import.meta.env.VITE_CRATE_CONNECT_FEATURE_ENABLED,
+);
 export const CRATE_CONNECT_V2_TRANSPORT_ENABLED = true;
 let connectEnabled = false;
 let connectPreferencesLoaded = false;

--- a/app/listen/src/lib/social-share.ts
+++ b/app/listen/src/lib/social-share.ts
@@ -2,11 +2,15 @@ import { registerPlugin } from "@capacitor/core";
 
 import { resolveMaybeApiAssetUrl } from "@/lib/api";
 import { isNative } from "@/lib/capacitor-runtime";
+import { recordDevLog } from "@/lib/dev-logs";
 
 export const SHARE_REQUEST_EVENT = "crate:share-request";
 
 const STORY_WIDTH = 1080;
 const STORY_HEIGHT = 1920;
+const STORY_ASSET_TIMEOUT_MS = 4500;
+const STORY_FONT_TIMEOUT_MS = 1500;
+const STORY_NATIVE_SHARE_TIMEOUT_MS = 8000;
 const CRATE_LOGO_URL = "/icons/logo.svg";
 const POPPINS_600_URL = new URL(
   "../../../shared/fonts/poppins/poppins-600.woff2",
@@ -47,8 +51,13 @@ interface NativeHttpPlugin {
   }): Promise<NativeHttpResponse>;
 }
 
+interface NativeImageDataResult {
+  dataUrl?: string;
+}
+
 interface CrateSocialSharePlugin {
   canShareInstagramStory(): Promise<NativeInstagramStoryResult>;
+  loadImageDataUrl?(options: { url: string }): Promise<NativeImageDataResult>;
   shareInstagramStory(options: {
     imageDataUrl: string;
     contentUrl: string;
@@ -116,14 +125,29 @@ export async function shareInstagramStory(
     );
   }
   const imageDataUrl = await buildInstagramStoryCard(payload);
-  await nativeSocialShare.shareInstagramStory({
-    imageDataUrl,
-    contentUrl: payload.url,
-  });
+  await withTimeout(
+    nativeSocialShare.shareInstagramStory({
+      imageDataUrl,
+      contentUrl: payload.url,
+    }),
+    STORY_NATIVE_SHARE_TIMEOUT_MS,
+    "Instagram Stories did not respond",
+  );
 }
 
 async function buildInstagramStoryCard(payload: SharePayload): Promise<string> {
-  await loadInstagramStoryFonts();
+  await withTimeout(
+    loadInstagramStoryFonts(),
+    STORY_FONT_TIMEOUT_MS,
+    "Story font loading timed out",
+  ).catch((error) => {
+    recordDevLog(
+      "share",
+      "Instagram story fonts unavailable; using fallback fonts",
+      { error: formatArtworkError(error) },
+      "warn",
+    );
+  });
 
   const canvas = document.createElement("canvas");
   canvas.width = STORY_WIDTH;
@@ -131,10 +155,12 @@ async function buildInstagramStoryCard(payload: SharePayload): Promise<string> {
   const ctx = canvas.getContext("2d");
   if (!ctx) throw new Error("Canvas is not available");
 
-  const artwork = payload.imageUrl
-    ? await loadCanvasImage(payload.imageUrl)
-    : null;
-  const logo = await loadCanvasImage(CRATE_LOGO_URL).catch(() => null);
+  const [artwork, logo] = await Promise.all([
+    payload.imageUrl
+      ? loadOptionalCanvasImage(payload.imageUrl, "artwork")
+      : Promise.resolve(null),
+    loadOptionalCanvasImage(CRATE_LOGO_URL, "logo"),
+  ]);
   try {
     if (artwork) {
       drawStoryArtworkBackground(
@@ -489,6 +515,27 @@ interface CanvasArtwork {
   release: () => void;
 }
 
+async function loadOptionalCanvasImage(
+  src: string,
+  label: string,
+): Promise<CanvasArtwork | null> {
+  try {
+    return await withTimeout(
+      loadCanvasImage(src),
+      STORY_ASSET_TIMEOUT_MS,
+      `${label} loading timed out`,
+    );
+  } catch (error) {
+    recordDevLog(
+      "share",
+      `Instagram story ${label} unavailable; using fallback`,
+      { error: formatArtworkError(error), src },
+      "warn",
+    );
+    return null;
+  }
+}
+
 async function loadCanvasImage(src: string): Promise<CanvasArtwork> {
   const resolvedSrc = resolveMaybeApiAssetUrl(src) || src;
   if (isNative && isHttpUrl(resolvedSrc)) {
@@ -529,6 +576,19 @@ async function loadCanvasImage(src: string): Promise<CanvasArtwork> {
 }
 
 async function loadNativeHttpImageDataUrl(src: string): Promise<string> {
+  const pluginDataUrl = await loadNativeSharePluginImageDataUrl(src).catch(
+    (error) => {
+      recordDevLog(
+        "share",
+        "Native story artwork loader failed; falling back to CapacitorHttp",
+        { error: formatArtworkError(error), src },
+        "warn",
+      );
+      return null;
+    },
+  );
+  if (pluginDataUrl) return pluginDataUrl;
+
   let response;
   try {
     const nativeHttp = await getNativeHttpPlugin();
@@ -551,16 +611,34 @@ async function loadNativeHttpImageDataUrl(src: string): Promise<string> {
     throw new Error(`Failed to load share artwork: HTTP ${response.status}`);
   }
 
-  const base64 = typeof response.data === "string" ? response.data : "";
+  const base64 = typeof response.data === "string" ? response.data.trim() : "";
   if (!base64) {
     throw new Error("Failed to load share artwork: empty response");
   }
+  if (base64.startsWith("data:image/")) return base64;
 
   const contentType =
     getResponseHeader(response.headers, "content-type")
       ?.split(";")[0]
-      ?.trim() || inferImageMimeFromUrl(src);
+      ?.trim() ||
+    inferImageMimeFromBase64(base64) ||
+    inferImageMimeFromUrl(src);
   return `data:${contentType};base64,${base64}`;
+}
+
+async function loadNativeSharePluginImageDataUrl(
+  src: string,
+): Promise<string | null> {
+  if (!nativeSocialShare.loadImageDataUrl) return null;
+  const result = await nativeSocialShare.loadImageDataUrl({ url: src });
+  const dataUrl = result.dataUrl?.trim();
+  if (!dataUrl) {
+    throw new Error("native social image loader returned empty data");
+  }
+  if (!dataUrl.startsWith("data:image/")) {
+    throw new Error("native social image loader returned non-image data");
+  }
+  return dataUrl;
 }
 
 let nativeHttpPluginPromise: Promise<NativeHttpPlugin | null> | null = null;
@@ -569,12 +647,33 @@ function getNativeHttpPlugin(): Promise<NativeHttpPlugin | null> {
   nativeHttpPluginPromise ??= import("@capacitor/core")
     .then((module) => {
       const maybeModule = module as unknown as {
+        Capacitor?: {
+          Plugins?: {
+            CapacitorHttp?: NativeHttpPlugin;
+          };
+        };
         CapacitorHttp?: NativeHttpPlugin;
       };
-      return maybeModule.CapacitorHttp ?? null;
+      return (
+        maybeModule.CapacitorHttp ??
+        maybeModule.Capacitor?.Plugins?.CapacitorHttp ??
+        null
+      );
     })
-    .catch(() => null);
+    .catch(() => getWindowCapacitorHttpPlugin());
   return nativeHttpPluginPromise;
+}
+
+function getWindowCapacitorHttpPlugin(): NativeHttpPlugin | null {
+  if (typeof window === "undefined") return null;
+  const maybeWindow = window as unknown as {
+    Capacitor?: {
+      Plugins?: {
+        CapacitorHttp?: NativeHttpPlugin;
+      };
+    };
+  };
+  return maybeWindow.Capacitor?.Plugins?.CapacitorHttp ?? null;
 }
 
 function getResponseHeader(
@@ -599,6 +698,17 @@ function inferImageMimeFromUrl(src: string): string {
   return "image/png";
 }
 
+function inferImageMimeFromBase64(base64: string): string | null {
+  if (base64.startsWith("/9j/")) return "image/jpeg";
+  if (base64.startsWith("iVBORw0KGgo")) return "image/png";
+  if (base64.startsWith("UklGR")) return "image/webp";
+  if (base64.startsWith("R0lGOD")) return "image/gif";
+  if (base64.startsWith("PHN2Zy") || base64.startsWith("PD94bW")) {
+    return "image/svg+xml";
+  }
+  return null;
+}
+
 function safeUrlPathname(src: string): string {
   try {
     return new URL(src).pathname;
@@ -618,6 +728,20 @@ function loadImageElement(src: string): Promise<HTMLImageElement> {
     image.onload = () => resolve(image);
     image.onerror = () => reject(new Error("Failed to load share artwork"));
     image.src = src;
+  });
+}
+
+function withTimeout<T>(
+  promise: Promise<T>,
+  timeoutMs: number,
+  message: string,
+): Promise<T> {
+  let timeoutId: number | null = null;
+  const timeout = new Promise<never>((_, reject) => {
+    timeoutId = window.setTimeout(() => reject(new Error(message)), timeoutMs);
+  });
+  return Promise.race([promise, timeout]).finally(() => {
+    if (timeoutId != null) window.clearTimeout(timeoutId);
   });
 }
 


### PR DESCRIPTION
## Summary
- enable Crate Connect in Listen unless explicitly disabled at build time
- make Android native playback recover from token/buffering edge cases
- make Instagram Stories sharing load artwork through the native Android plugin and align the ShareSheet with Listen glass surfaces

## Validation
- npm run --workspace=app/listen typecheck
- npm run --workspace=app/listen test -- ShareSheet.test.tsx social-share.test.ts crate-connect.test.ts use-player-queue-actions.test.ts use-restore-on-mount.test.ts
- npm run --workspace=app/listen build:cap
- Gradle assembleDebug

## Deploy note
Hotfix path: merge first, release v1.6.4-beta, deploy as soon as images are available without waiting for the full test matrix.