### PR TITLE
feat(listen): improve mobile overlay menu behavior

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ coverage.out
 lcov.info
 **/lcov.info
 desktop-artifacts/
+artifacts/
 
 # Python
 __pycache__/

--- a/Makefile
+++ b/Makefile
@@ -635,6 +635,8 @@ trust-local-ca: ## Trust Caddy's local CA for HTTPS (run after first 'make dev',
 CAP_DIR := app/listen
 CAP_IOS_TARGET ?= $(shell cd $(CAP_DIR) && npx cap run ios --list 2>/dev/null | grep "iPhone.*Pro " | head -1 | awk '{print $$NF}')
 CAP_DEBUG_SERVER_URL ?= https://listen.lespedants.org
+CAP_ANDROID_OUTPUT_DIR ?= artifacts/capacitor/android
+CAP_ANDROID_GRADLE_VARIANT ?= debug
 
 # Android Studio JBR + SDK paths (required for Gradle/emulator)
 export JAVA_HOME ?= $(HOME)/Applications/Android Studio.app/Contents/jbr/Contents/Home
@@ -672,6 +674,27 @@ cap-ios-list: ## List available iOS Simulator targets
 .PHONY: cap-android-list
 cap-android-list: ## List available Android Emulator targets
 	@cd $(CAP_DIR) && npx cap run android --list
+
+.PHONY: cap-android-artifacts
+cap-android-artifacts: ## Build Android APK and copy output to a local artifacts folder
+	@cd $(CAP_DIR) && VITE_API_URL="$(CAP_DEBUG_SERVER_URL)" npm run build:cap
+	@cd $(CAP_DIR)/android && variant="$(CAP_ANDROID_GRADLE_VARIANT)"; \
+	task="assemble$$(printf '%s' "$$variant" | awk '{print toupper(substr($$0,1,1)) substr($$0,2)}')"; \
+	./gradlew "$$task"
+	@mkdir -p "$(CAP_ANDROID_OUTPUT_DIR)"
+	@out="$$(ls -1t $(CAP_DIR)/android/app/build/outputs/apk/$(CAP_ANDROID_GRADLE_VARIANT)/app-$(CAP_ANDROID_GRADLE_VARIANT).apk 2>/dev/null || true)"; \
+	if [ -z "$$out" ]; then \
+		out="$$(ls -1t $(CAP_DIR)/android/app/build/outputs/apk/$(CAP_ANDROID_GRADLE_VARIANT)/*.apk 2>/dev/null | head -n 1 || true)"; \
+	fi; \
+	if [ -z "$$out" ]; then \
+		echo "$(RED)No APK found under $(CAP_DIR)/android/app/build/outputs/apk/$(CAP_ANDROID_GRADLE_VARIANT)$(NC)"; \
+		exit 1; \
+	fi; \
+	ts="$$(date +%Y%m%d-%H%M%S)"; \
+	sha="$$(git rev-parse --short HEAD 2>/dev/null || echo local)"; \
+	dst="$(CAP_ANDROID_OUTPUT_DIR)/crate-listen-$(CAP_ANDROID_GRADLE_VARIANT)-$${ts}-$${sha}.apk"; \
+	cp "$$out" "$$dst"; \
+	echo "$(GREEN)Artifact copied to:$$dst$(NC)"
 
 # ===========================================================================
 # TAURI (desktop native builds)

--- a/app/crate/api/browse_album.py
+++ b/app/crate/api/browse_album.py
@@ -733,6 +733,21 @@ def api_album_by_entity_uid(request: Request, album_entity_uid: str):
     summary="Get detailed album information",
 )
 def api_album_by_id(request: Request, album_id: int):
+    if album_id < 0:
+        release = get_release_by_virtual_album_id(album_id)
+        if not release:
+            return JSONResponse({"error": "Not found"}, status_code=404)
+
+        artist = get_library_artist_by_slug(release.get("artist_slug") or "")
+        if not artist:
+            artist = {
+                "id": release.get("artist_id"),
+                "entity_uid": None,
+                "slug": release.get("artist_slug"),
+                "name": release.get("artist_name", ""),
+            }
+        return _pre_release_album_payload(request, artist, release)
+
     album = get_library_album_by_id(album_id)
     if not album:
         return JSONResponse({"error": "Not found"}, status_code=404)

--- a/app/listen/src/components/actions/ItemActionMenu.test.tsx
+++ b/app/listen/src/components/actions/ItemActionMenu.test.tsx
@@ -1,5 +1,5 @@
 import { createRef } from "react";
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, expect, it, vi } from "vitest";
 
@@ -37,10 +37,9 @@ describe("ItemActionMenu mobile sheet", () => {
     );
 
     const dialog = screen.getByRole("dialog");
-    expect(dialog).toHaveStyle({ zIndex: "1700" });
+    expect(dialog.className).toContain("z-app-modal");
     expect(dialog.querySelector(".listen-glass-panel")).toHaveStyle({
-      bottom:
-        "calc(var(--listen-mobile-bottom-chrome-height, 4.75rem) + 0.75rem)",
+      bottom: "0px",
     });
 
     await user.click(screen.getByRole("button", { name: /Share track/i }));
@@ -83,5 +82,51 @@ describe("ItemActionMenu mobile sheet", () => {
 
     expect(onClose).toHaveBeenCalledTimes(1);
     expect(onOuterClick).not.toHaveBeenCalled();
+  });
+
+  it("dismisses the mobile sheet when dragged past half its height", () => {
+    vi.useFakeTimers();
+    const onClose = vi.fn();
+    const menuRef = createRef<HTMLDivElement>();
+    const actions: ItemActionMenuEntry[] = [
+      {
+        key: "share",
+        label: "Share track",
+        onSelect: vi.fn(),
+      },
+    ];
+
+    render(
+      <ItemActionMenu
+        actions={actions}
+        open
+        position={null}
+        menuRef={menuRef}
+        onClose={onClose}
+      />,
+    );
+
+    const dialog = screen.getByRole("dialog");
+    const panel = dialog.querySelector(".listen-glass-panel") as HTMLElement;
+    const handle = panel.querySelector(".touch-pan-y") as HTMLElement;
+    vi.spyOn(panel, "getBoundingClientRect").mockReturnValue({
+      bottom: 240,
+      height: 200,
+      left: 0,
+      right: 320,
+      top: 40,
+      width: 320,
+      x: 0,
+      y: 40,
+      toJSON: () => {},
+    });
+
+    fireEvent.touchStart(handle, { touches: [{ clientY: 0 }] });
+    fireEvent.touchMove(handle, { touches: [{ clientY: 140 }] });
+    fireEvent.touchEnd(handle);
+    vi.advanceTimersByTime(180);
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+    vi.useRealTimers();
   });
 });

--- a/app/listen/src/components/actions/ItemActionMenu.test.tsx
+++ b/app/listen/src/components/actions/ItemActionMenu.test.tsx
@@ -39,12 +39,48 @@ describe("ItemActionMenu mobile sheet", () => {
     const dialog = screen.getByRole("dialog");
     expect(dialog).toHaveStyle({ zIndex: "1700" });
     expect(dialog.querySelector(".listen-glass-panel")).toHaveStyle({
-      bottom: "calc(var(--listen-mobile-bottom-chrome-height) + 0.75rem)",
+      bottom:
+        "calc(var(--listen-mobile-bottom-chrome-height, 4.75rem) + 0.75rem)",
     });
 
     await user.click(screen.getByRole("button", { name: /Share track/i }));
 
     expect(onSelect).toHaveBeenCalledTimes(1);
+    expect(onClose).toHaveBeenCalledTimes(1);
+    expect(onOuterClick).not.toHaveBeenCalled();
+  });
+
+  it("closes on overlay tap and swallows the underlying click", async () => {
+    const user = userEvent.setup();
+    const onClose = vi.fn();
+    const onSelect = vi.fn();
+    const onOuterClick = vi.fn();
+    const menuRef = createRef<HTMLDivElement>();
+    const actions: ItemActionMenuEntry[] = [
+      {
+        key: "share",
+        label: "Share track",
+        onSelect,
+      },
+    ];
+
+    render(
+      <div className="min-h-screen" onClick={onOuterClick}>
+        <ItemActionMenu
+          actions={actions}
+          open
+          position={null}
+          menuRef={menuRef}
+          onClose={onClose}
+        />
+      </div>,
+    );
+
+    const overlay = screen.getByRole("dialog");
+    await user.click(overlay);
+
+    await new Promise((resolve) => setTimeout(resolve, 180));
+
     expect(onClose).toHaveBeenCalledTimes(1);
     expect(onOuterClick).not.toHaveBeenCalled();
   });

--- a/app/listen/src/components/actions/ItemActionMenu.tsx
+++ b/app/listen/src/components/actions/ItemActionMenu.tsx
@@ -22,6 +22,7 @@ import {
 } from "@crate/ui/primitives/AppPopover";
 import { ActionIconButton } from "@crate/ui/primitives/ActionIconButton";
 import { MobileActionSheet } from "@/components/actions/MobileActionSheet";
+import { useHoverCapability } from "@/hooks/use-hover-capability";
 import { cn } from "@/lib/utils";
 
 export type ItemActionMenuEntry =
@@ -64,6 +65,7 @@ export function useItemActionMenu(
   options: UseItemActionMenuOptions = {},
 ) {
   const isDesktop = useIsDesktop();
+  const canHover = useHoverCapability();
   const { disabled = false, onOpenChange } = options;
   const triggerRef = useRef<HTMLButtonElement | null>(null);
   const menuRef = useRef<HTMLDivElement | null>(null);
@@ -83,6 +85,7 @@ export function useItemActionMenu(
       actions.some((entry) => entry.type == null || entry.type === "action"),
     [actions],
   );
+  const shouldUseDesktopMenu = isDesktop && canHover;
 
   const close = () => {
     setOpen(false);
@@ -131,7 +134,7 @@ export function useItemActionMenu(
   const handleLongPressPointerDown = (
     event: ReactPointerEvent<HTMLElement>,
   ) => {
-    if (isDesktop || !hasActions || disabled) return;
+    if (shouldUseDesktopMenu || !hasActions || disabled) return;
     if (event.pointerType === "mouse") return;
     longPressTriggeredRef.current = false;
     clearLongPress();
@@ -167,14 +170,15 @@ export function useItemActionMenu(
   };
 
   useDismissibleLayer({
-    active: open,
+    active: shouldUseDesktopMenu && open,
     refs: [menuRef, triggerRef],
     onDismiss: close,
   });
 
   // Measure + clamp into viewport before the browser paints to avoid flash.
   useLayoutEffect(() => {
-    if (!open || !isDesktop || !rawPosition || !menuRef.current) return;
+    if (!open || !shouldUseDesktopMenu || !rawPosition || !menuRef.current)
+      return;
     const rect = menuRef.current.getBoundingClientRect();
     const padding = 12;
     const maxX = Math.max(padding, window.innerWidth - rect.width - padding);
@@ -184,7 +188,7 @@ export function useItemActionMenu(
       y: Math.min(rawPosition.y, maxY),
     });
     setMeasured(true);
-  }, [isDesktop, open, rawPosition]);
+  }, [shouldUseDesktopMenu, open, rawPosition]);
 
   return {
     hasActions,
@@ -198,6 +202,7 @@ export function useItemActionMenu(
     openFromTrigger,
     handleContextMenu,
     handleKeyboardTrigger,
+    shouldUseDesktopMenu,
     longPressHandlers: {
       onPointerDown: handleLongPressPointerDown,
       onPointerUp: handleLongPressPointerUp,
@@ -217,6 +222,8 @@ export function ItemActionMenu({
   onClose,
 }: ItemActionMenuProps) {
   const isDesktop = useIsDesktop();
+  const canHover = useHoverCapability();
+  const shouldUseDesktopMenu = isDesktop && canHover;
   const hasHeader = Boolean(header);
   const actionEntries = actions.filter(
     (entry) => entry.type == null || entry.type === "action",
@@ -291,7 +298,7 @@ export function ItemActionMenu({
 
   if (!open) return null;
 
-  if (!isDesktop) {
+  if (!shouldUseDesktopMenu) {
     return (
       <MobileActionSheet open={open} panelRef={menuRef} onClose={onClose}>
         <div className="max-h-[calc(100%-5rem)] overflow-y-auto px-3 pb-3 pt-1">

--- a/app/listen/src/components/actions/ItemActionMenu.tsx
+++ b/app/listen/src/components/actions/ItemActionMenu.tsx
@@ -1,5 +1,7 @@
 import {
   type KeyboardEvent as ReactKeyboardEvent,
+  type ReactNode,
+  useEffect,
   useLayoutEffect,
   useMemo,
   useRef,
@@ -45,6 +47,7 @@ export type ItemActionMenuEntry =
 
 interface ItemActionMenuProps {
   actions: ItemActionMenuEntry[];
+  header?: ReactNode;
   open: boolean;
   position: { x: number; y: number } | null;
   menuRef: RefObject<HTMLDivElement | null>;
@@ -53,6 +56,7 @@ interface ItemActionMenuProps {
 
 interface UseItemActionMenuOptions {
   disabled?: boolean;
+  onOpenChange?: (open: boolean) => void;
 }
 
 export function useItemActionMenu(
@@ -60,7 +64,7 @@ export function useItemActionMenu(
   options: UseItemActionMenuOptions = {},
 ) {
   const isDesktop = useIsDesktop();
-  const { disabled = false } = options;
+  const { disabled = false, onOpenChange } = options;
   const triggerRef = useRef<HTMLButtonElement | null>(null);
   const menuRef = useRef<HTMLDivElement | null>(null);
   const longPressTimerRef = useRef<number | null>(null);
@@ -86,6 +90,10 @@ export function useItemActionMenu(
     setPosition(null);
     setMeasured(false);
   };
+
+  useEffect(() => {
+    onOpenChange?.(open);
+  }, [onOpenChange, open]);
 
   const openAtPoint = (x: number, y: number) => {
     if (!hasActions || disabled) return;
@@ -202,12 +210,14 @@ export function useItemActionMenu(
 
 export function ItemActionMenu({
   actions,
+  header,
   open,
   position,
   menuRef,
   onClose,
 }: ItemActionMenuProps) {
   const isDesktop = useIsDesktop();
+  const hasHeader = Boolean(header);
   const actionEntries = actions.filter(
     (entry) => entry.type == null || entry.type === "action",
   );
@@ -229,6 +239,7 @@ export function ItemActionMenu({
 
   const content = (
     <>
+      {hasHeader ? header : null}
       {actions.map((entry) => {
         if (entry.type === "divider") {
           return <AppPopoverDivider key={entry.key} />;
@@ -282,8 +293,10 @@ export function ItemActionMenu({
 
   if (!isDesktop) {
     return (
-      <MobileActionSheet panelRef={menuRef} onClose={onClose}>
-        <div className="space-y-1 px-3 pb-3 pt-1">{content}</div>
+      <MobileActionSheet open={open} panelRef={menuRef} onClose={onClose}>
+        <div className="max-h-[calc(100%-5rem)] overflow-y-auto px-3 pb-3 pt-1">
+          {content}
+        </div>
       </MobileActionSheet>
     );
   }
@@ -291,7 +304,8 @@ export function ItemActionMenu({
   return createPortal(
     <AppPopover
       ref={menuRef}
-      className="fixed z-app-popover w-60 origin-top-left p-1 animate-pop-in"
+      layer="context"
+      className="fixed w-60 origin-top-left p-1 animate-pop-in"
       style={{
         left: position?.x ?? 12,
         top: position?.y ?? 12,

--- a/app/listen/src/components/actions/ItemActionMenu.tsx
+++ b/app/listen/src/components/actions/ItemActionMenu.tsx
@@ -23,6 +23,8 @@ import {
 import { ActionIconButton } from "@crate/ui/primitives/ActionIconButton";
 import { MobileActionSheet } from "@/components/actions/MobileActionSheet";
 import { useHoverCapability } from "@/hooks/use-hover-capability";
+import { isCapacitorRuntime } from "@/lib/platform";
+import { isTouchDominantPointer } from "@/lib/input-capabilities";
 import { cn } from "@/lib/utils";
 
 export type ItemActionMenuEntry =
@@ -60,6 +62,17 @@ interface UseItemActionMenuOptions {
   onOpenChange?: (open: boolean) => void;
 }
 
+function shouldRenderDesktopMenu(
+  isDesktop: boolean,
+  canHover: boolean,
+): boolean {
+  if (!isDesktop || !canHover) return false;
+  if (isCapacitorRuntime) return false;
+  if (typeof window === "undefined") return false;
+  if (isTouchDominantPointer()) return false;
+  return true;
+}
+
 export function useItemActionMenu(
   actions: ItemActionMenuEntry[],
   options: UseItemActionMenuOptions = {},
@@ -85,7 +98,7 @@ export function useItemActionMenu(
       actions.some((entry) => entry.type == null || entry.type === "action"),
     [actions],
   );
-  const shouldUseDesktopMenu = isDesktop && canHover;
+  const shouldUseDesktopMenu = shouldRenderDesktopMenu(isDesktop, canHover);
 
   const close = () => {
     setOpen(false);
@@ -223,7 +236,7 @@ export function ItemActionMenu({
 }: ItemActionMenuProps) {
   const isDesktop = useIsDesktop();
   const canHover = useHoverCapability();
-  const shouldUseDesktopMenu = isDesktop && canHover;
+  const shouldUseDesktopMenu = shouldRenderDesktopMenu(isDesktop, canHover);
   const hasHeader = Boolean(header);
   const actionEntries = actions.filter(
     (entry) => entry.type == null || entry.type === "action",

--- a/app/listen/src/components/actions/MobileActionSheet.tsx
+++ b/app/listen/src/components/actions/MobileActionSheet.tsx
@@ -1,5 +1,15 @@
+import {
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+  type MouseEvent as ReactMouseEvent,
+  type ReactNode,
+  type RefObject,
+  type TouchEvent as ReactTouchEvent,
+  type PointerEvent as ReactPointerEvent,
+} from "react";
 import { createPortal } from "react-dom";
-import type { ReactNode, RefObject } from "react";
 
 import { cn } from "@/lib/utils";
 
@@ -7,6 +17,7 @@ interface MobileActionSheetProps {
   children: ReactNode;
   panelRef?: RefObject<HTMLDivElement | null>;
   onClose: () => void;
+  open: boolean;
   className?: string;
 }
 
@@ -14,44 +25,180 @@ export function MobileActionSheet({
   children,
   panelRef,
   onClose,
+  open,
   className,
 }: MobileActionSheetProps) {
+  const [shouldRender, setShouldRender] = useState(open);
+  const [isClosing, setIsClosing] = useState(false);
+  const [swipeY, setSwipeY] = useState(0);
+  const swipeStartRef = useRef<number | null>(null);
+  const dragHandleRef = useRef<HTMLDivElement>(null);
+  const closeScheduledRef = useRef(false);
+  const isMountedRef = useRef(true);
+
+  useEffect(() => {
+    isMountedRef.current = true;
+    return () => {
+      isMountedRef.current = false;
+    };
+  }, []);
+
+  useEffect(() => {
+    if (open) {
+      setShouldRender(true);
+      setIsClosing(false);
+      setSwipeY(0);
+      closeScheduledRef.current = false;
+      return;
+    }
+
+    setIsClosing(true);
+    const timer = window.setTimeout(() => {
+      setShouldRender(false);
+    }, 180);
+
+    return () => window.clearTimeout(timer);
+  }, [open]);
+
+  const requestClose = useCallback(() => {
+    if (isClosing || closeScheduledRef.current) return;
+    closeScheduledRef.current = true;
+    setIsClosing(true);
+    setSwipeY(0);
+    window.setTimeout(() => {
+      if (isMountedRef.current) {
+        onClose();
+      }
+    }, 140);
+  }, [isClosing, onClose]);
+
+  const handleOverlayTouchStart = useCallback(
+    (event: ReactTouchEvent<HTMLDivElement>) => {
+      event.preventDefault();
+      event.stopPropagation();
+      requestClose();
+    },
+    [requestClose],
+  );
+
+  const handleOverlayClick = useCallback(
+    (event: ReactMouseEvent<HTMLDivElement>) => {
+      event.preventDefault();
+      event.stopPropagation();
+      requestClose();
+    },
+    [requestClose],
+  );
+
+  const handlePanelTouchStart = useCallback(
+    (event: ReactTouchEvent<HTMLDivElement>) => {
+      event.stopPropagation();
+      const firstTouch = event.touches[0];
+      if (firstTouch == null) return;
+      swipeStartRef.current = firstTouch.clientY;
+      setSwipeY(0);
+    },
+    [],
+  );
+
+  const onSwipeMove = useCallback((event: ReactTouchEvent<HTMLDivElement>) => {
+    if (swipeStartRef.current === null) return;
+    const dy = event.touches[0]!.clientY - swipeStartRef.current;
+    setSwipeY(dy > 0 ? Math.min(dy * 0.6, 240) : 0);
+  }, []);
+
+  const onSwipeEnd = useCallback(() => {
+    if (swipeY > 80) {
+      requestClose();
+      return;
+    }
+    setSwipeY(0);
+    swipeStartRef.current = null;
+  }, [requestClose, swipeY]);
+
+  const handlePointerDown = useCallback(
+    (event: ReactPointerEvent<HTMLDivElement>) => {
+      event.preventDefault();
+      event.stopPropagation();
+      requestClose();
+    },
+    [requestClose],
+  );
+
+  const handleContentTouchStart = useCallback(
+    (event: ReactTouchEvent<HTMLDivElement>) => {
+      if (!event.target) return;
+      if (!dragHandleRef.current) return;
+      const isHandle = dragHandleRef.current.contains(
+        event.target as Node | null,
+      );
+      if (!isHandle) {
+        event.stopPropagation();
+      }
+    },
+    [],
+  );
+
+  const handleContentTouchCancel = useCallback(() => {
+    setSwipeY(0);
+    swipeStartRef.current = null;
+  }, []);
+
+  if (!shouldRender) return null;
+
   return createPortal(
     <div
       role="dialog"
       aria-modal="true"
-      className="fixed inset-0 flex items-end justify-center bg-black/58 p-0 backdrop-blur-md animate-fade-in"
+      className={cn(
+        "fixed inset-0 flex items-end justify-center bg-black/58 p-0 backdrop-blur-md z-app-modal",
+        isClosing ? "animate-fade-out" : "animate-fade-in",
+      )}
       style={{ zIndex: 1700 }}
-      onClick={(event) => {
-        event.stopPropagation();
-        onClose();
-      }}
-      onPointerDown={(event) => {
-        event.stopPropagation();
-      }}
-      onTouchStart={(event) => {
-        event.stopPropagation();
+      onClick={handleOverlayClick}
+      onPointerDown={handlePointerDown}
+      onTouchStart={handleOverlayTouchStart}
+      onTouchEnd={() => {
+        setSwipeY(0);
+        swipeStartRef.current = null;
       }}
     >
       <div
         ref={panelRef}
         className={cn(
-          "listen-glass-panel fixed inset-x-3 overflow-hidden rounded-3xl animate-sheet-up",
+          "listen-glass-panel fixed inset-x-0 overflow-hidden rounded-t-3xl border border-white/10 shadow-2xl",
+          isClosing ? "animate-sheet-down" : "animate-sheet-up",
           className,
         )}
         style={{
           bottom: "calc(var(--listen-mobile-bottom-chrome-height) + 0.75rem)",
           maxHeight:
             "max(14rem, calc(var(--listen-viewport-height) - var(--listen-safe-top) - var(--listen-mobile-bottom-chrome-height) - 1.75rem))",
+          transform: `translateY(${swipeY}px)`,
+          transition: swipeY > 0 ? "none" : undefined,
         }}
         onClick={(event) => event.stopPropagation()}
         onPointerDown={(event) => event.stopPropagation()}
-        onTouchStart={(event) => event.stopPropagation()}
       >
-        <div className="flex justify-center px-4 pb-2 pt-3">
-          <div className="h-1 w-10 rounded-full bg-white/22" />
+        <div
+          ref={dragHandleRef}
+          className="touch-pan-y pt-3 pb-2"
+          onTouchStart={handlePanelTouchStart}
+          onTouchMove={onSwipeMove}
+          onTouchEnd={onSwipeEnd}
+          onTouchCancel={handleContentTouchCancel}
+        >
+          <div className="mx-auto h-1.25 w-14 rounded-full bg-white/22 transition-opacity duration-150 group-hover:opacity-90" />
         </div>
-        <div className="max-h-[inherit] overflow-y-auto">{children}</div>
+        <div
+          className="max-h-[inherit] overflow-y-auto"
+          onTouchStart={handleContentTouchStart}
+          onTouchMove={onSwipeMove}
+          onTouchEnd={onSwipeEnd}
+          onTouchCancel={handleContentTouchCancel}
+        >
+          {children}
+        </div>
       </div>
     </div>,
     document.body,

--- a/app/listen/src/components/actions/MobileActionSheet.tsx
+++ b/app/listen/src/components/actions/MobileActionSheet.tsx
@@ -30,7 +30,9 @@ export function MobileActionSheet({
 }: MobileActionSheetProps) {
   const [shouldRender, setShouldRender] = useState(open);
   const [isClosing, setIsClosing] = useState(false);
+  const [isDragging, setIsDragging] = useState(false);
   const [swipeY, setSwipeY] = useState(0);
+  const swipeYRef = useRef(0);
   const swipeStartRef = useRef<number | null>(null);
   const dragHandleRef = useRef<HTMLDivElement>(null);
   const closeScheduledRef = useRef(false);
@@ -58,7 +60,9 @@ export function MobileActionSheet({
     if (open) {
       setShouldRender(true);
       setIsClosing(false);
+      setIsDragging(false);
       setSwipeY(0);
+      swipeYRef.current = 0;
       closeScheduledRef.current = false;
       return;
     }
@@ -71,18 +75,45 @@ export function MobileActionSheet({
     return () => window.clearTimeout(timer);
   }, [open]);
 
+  const setDragOffset = useCallback((offset: number) => {
+    swipeYRef.current = offset;
+    setSwipeY(offset);
+  }, []);
+
+  const getPanelHeight = useCallback(() => {
+    const height = panelRef?.current?.getBoundingClientRect().height ?? 0;
+    return height > 0 ? height : 240;
+  }, [panelRef]);
+
   const requestClose = useCallback(() => {
     if (isClosing || closeScheduledRef.current) return;
     closeScheduledRef.current = true;
     setIsClosing(true);
-    setSwipeY(0);
+    setIsDragging(false);
+    setDragOffset(0);
+    shouldSuppressNextClickRef.current = true;
     window.setTimeout(() => {
       if (isMountedRef.current) {
         closeScheduledRef.current = false;
         onClose();
       }
     }, 140);
-  }, [isClosing, onClose]);
+  }, [isClosing, onClose, setDragOffset]);
+
+  const requestDragClose = useCallback(() => {
+    if (isClosing || closeScheduledRef.current) return;
+    closeScheduledRef.current = true;
+    setIsDragging(false);
+    setIsClosing(true);
+    setDragOffset(getPanelHeight() + 24);
+    shouldSuppressNextClickRef.current = true;
+    window.setTimeout(() => {
+      if (isMountedRef.current) {
+        closeScheduledRef.current = false;
+        onClose();
+      }
+    }, 180);
+  }, [getPanelHeight, isClosing, onClose, setDragOffset]);
 
   const suppressAndRequestClose = useCallback(() => {
     shouldSuppressNextClickRef.current = true;
@@ -123,25 +154,34 @@ export function MobileActionSheet({
       const firstTouch = event.touches[0];
       if (firstTouch == null) return;
       swipeStartRef.current = firstTouch.clientY;
-      setSwipeY(0);
+      setIsDragging(true);
+      setDragOffset(0);
     },
-    [],
+    [setDragOffset],
   );
 
-  const onSwipeMove = useCallback((event: ReactTouchEvent<HTMLDivElement>) => {
-    if (swipeStartRef.current === null) return;
-    const dy = event.touches[0]!.clientY - swipeStartRef.current;
-    setSwipeY(dy > 0 ? Math.min(dy * 0.6, 240) : 0);
-  }, []);
+  const onSwipeMove = useCallback(
+    (event: ReactTouchEvent<HTMLDivElement>) => {
+      if (swipeStartRef.current === null) return;
+      event.preventDefault();
+      event.stopPropagation();
+      const dy = event.touches[0]!.clientY - swipeStartRef.current;
+      setDragOffset(dy > 0 ? Math.min(dy, getPanelHeight() + 24) : 0);
+    },
+    [getPanelHeight, setDragOffset],
+  );
 
   const onSwipeEnd = useCallback(() => {
-    if (swipeY > 80) {
-      requestClose();
+    if (swipeStartRef.current === null) return;
+    const shouldDismiss = swipeYRef.current >= getPanelHeight() / 2;
+    swipeStartRef.current = null;
+    if (shouldDismiss) {
+      requestDragClose();
       return;
     }
-    setSwipeY(0);
-    swipeStartRef.current = null;
-  }, [requestClose, swipeY]);
+    setIsDragging(false);
+    setDragOffset(0);
+  }, [getPanelHeight, requestDragClose, setDragOffset]);
 
   const handlePointerDown = useCallback(
     (event: ReactPointerEvent<HTMLDivElement>) => {
@@ -168,9 +208,10 @@ export function MobileActionSheet({
   );
 
   const handleContentTouchCancel = useCallback(() => {
-    setSwipeY(0);
+    setIsDragging(false);
+    setDragOffset(0);
     swipeStartRef.current = null;
-  }, []);
+  }, [setDragOffset]);
 
   if (!shouldRender) return null;
 
@@ -182,12 +223,13 @@ export function MobileActionSheet({
         "fixed inset-0 flex items-end justify-center bg-black/58 p-0 backdrop-blur-md z-app-modal",
         isClosing ? "animate-fade-out" : "animate-fade-in",
       )}
-      style={{ zIndex: 1700 }}
       onClickCapture={handleOverlayClick}
       onPointerDownCapture={handlePointerDown}
       onTouchStartCapture={handleOverlayTouchStart}
-      onTouchEnd={() => {
-        setSwipeY(0);
+      onTouchEnd={(event) => {
+        if (isPanelTarget(event.target)) return;
+        setIsDragging(false);
+        setDragOffset(0);
         swipeStartRef.current = null;
       }}
     >
@@ -195,19 +237,22 @@ export function MobileActionSheet({
         ref={panelRef}
         className={cn(
           "listen-glass-panel fixed inset-x-0 overflow-hidden rounded-t-3xl border border-white/10 shadow-2xl",
-          isClosing ? "animate-sheet-down" : "animate-sheet-up",
+          isClosing && swipeY === 0 ? "animate-sheet-down" : "animate-sheet-up",
           className,
         )}
         style={{
           top: "auto",
           left: 0,
           right: 0,
-          bottom:
-            "calc(var(--listen-mobile-bottom-chrome-height, 4.75rem) + 0.75rem)",
+          bottom: "0px",
           maxHeight:
-            "min(86vh, max(14rem, calc(var(--listen-viewport-height, 100dvh) - var(--listen-safe-top, env(safe-area-inset-top, 0px)) - var(--listen-mobile-bottom-chrome-height, 4.75rem) - 1.75rem)) )",
+            "min(88vh, max(14rem, calc(var(--listen-viewport-height, 100dvh) - var(--listen-safe-top, env(safe-area-inset-top, 0px)) - 0.75rem)))",
+          paddingBottom:
+            "var(--listen-safe-bottom, env(safe-area-inset-bottom, 0px))",
           transform: swipeY ? `translateY(${swipeY}px)` : undefined,
-          transition: swipeY > 0 ? "none" : undefined,
+          transition: isDragging
+            ? "none"
+            : "transform 220ms cubic-bezier(0.22, 1, 0.36, 1)",
         }}
         onClick={(event) => event.stopPropagation()}
         onPointerDown={(event) => event.stopPropagation()}

--- a/app/listen/src/components/actions/MobileActionSheet.tsx
+++ b/app/listen/src/components/actions/MobileActionSheet.tsx
@@ -34,7 +34,18 @@ export function MobileActionSheet({
   const swipeStartRef = useRef<number | null>(null);
   const dragHandleRef = useRef<HTMLDivElement>(null);
   const closeScheduledRef = useRef(false);
+  const isDismissedRef = useRef(false);
+  const shouldSuppressNextClickRef = useRef(false);
   const isMountedRef = useRef(true);
+
+  const isPanelTarget = useCallback(
+    (target: EventTarget | null) => {
+      if (target == null) return false;
+      const node = target as Node;
+      return panelRef?.current ? panelRef.current.contains(node) : false;
+    },
+    [panelRef],
+  );
 
   useEffect(() => {
     isMountedRef.current = true;
@@ -67,27 +78,43 @@ export function MobileActionSheet({
     setSwipeY(0);
     window.setTimeout(() => {
       if (isMountedRef.current) {
+        closeScheduledRef.current = false;
         onClose();
       }
     }, 140);
   }, [isClosing, onClose]);
 
+  const suppressAndRequestClose = useCallback(() => {
+    shouldSuppressNextClickRef.current = true;
+    isDismissedRef.current = true;
+    requestClose();
+  }, [requestClose]);
+
   const handleOverlayTouchStart = useCallback(
     (event: ReactTouchEvent<HTMLDivElement>) => {
+      if (isPanelTarget(event.target)) return;
       event.preventDefault();
       event.stopPropagation();
-      requestClose();
+      suppressAndRequestClose();
     },
-    [requestClose],
+    [suppressAndRequestClose],
   );
 
   const handleOverlayClick = useCallback(
     (event: ReactMouseEvent<HTMLDivElement>) => {
+      if (isPanelTarget(event.target)) return;
+      if (isDismissedRef.current || shouldSuppressNextClickRef.current) {
+        isDismissedRef.current = false;
+        shouldSuppressNextClickRef.current = false;
+        event.preventDefault();
+        event.stopPropagation();
+        return;
+      }
       event.preventDefault();
       event.stopPropagation();
-      requestClose();
+      suppressAndRequestClose();
     },
-    [requestClose],
+    [suppressAndRequestClose],
   );
 
   const handlePanelTouchStart = useCallback(
@@ -118,11 +145,12 @@ export function MobileActionSheet({
 
   const handlePointerDown = useCallback(
     (event: ReactPointerEvent<HTMLDivElement>) => {
+      if (isPanelTarget(event.target)) return;
       event.preventDefault();
       event.stopPropagation();
-      requestClose();
+      suppressAndRequestClose();
     },
-    [requestClose],
+    [isPanelTarget, suppressAndRequestClose],
   );
 
   const handleContentTouchStart = useCallback(
@@ -155,9 +183,9 @@ export function MobileActionSheet({
         isClosing ? "animate-fade-out" : "animate-fade-in",
       )}
       style={{ zIndex: 1700 }}
-      onClick={handleOverlayClick}
-      onPointerDown={handlePointerDown}
-      onTouchStart={handleOverlayTouchStart}
+      onClickCapture={handleOverlayClick}
+      onPointerDownCapture={handlePointerDown}
+      onTouchStartCapture={handleOverlayTouchStart}
       onTouchEnd={() => {
         setSwipeY(0);
         swipeStartRef.current = null;
@@ -171,10 +199,14 @@ export function MobileActionSheet({
           className,
         )}
         style={{
-          bottom: "calc(var(--listen-mobile-bottom-chrome-height) + 0.75rem)",
+          top: "auto",
+          left: 0,
+          right: 0,
+          bottom:
+            "calc(var(--listen-mobile-bottom-chrome-height, 4.75rem) + 0.75rem)",
           maxHeight:
-            "max(14rem, calc(var(--listen-viewport-height) - var(--listen-safe-top) - var(--listen-mobile-bottom-chrome-height) - 1.75rem))",
-          transform: `translateY(${swipeY}px)`,
+            "min(86vh, max(14rem, calc(var(--listen-viewport-height, 100dvh) - var(--listen-safe-top, env(safe-area-inset-top, 0px)) - var(--listen-mobile-bottom-chrome-height, 4.75rem) - 1.75rem)) )",
+          transform: swipeY ? `translateY(${swipeY}px)` : undefined,
           transition: swipeY > 0 ? "none" : undefined,
         }}
         onClick={(event) => event.stopPropagation()}

--- a/app/listen/src/components/actions/TrackActionMenuHeader.tsx
+++ b/app/listen/src/components/actions/TrackActionMenuHeader.tsx
@@ -1,0 +1,45 @@
+import { Disc3 } from "lucide-react";
+
+interface TrackActionMenuHeaderProps {
+  album?: string;
+  artist: string;
+  coverUrl?: string;
+  title: string;
+}
+
+export function TrackActionMenuHeader({
+  album,
+  artist,
+  coverUrl,
+  title,
+}: TrackActionMenuHeaderProps) {
+  return (
+    <div className="mb-2 border-b border-white/10 pb-3 pl-3 pr-2">
+      <div className="flex items-center gap-3">
+        <div className="relative h-11 w-11 shrink-0 overflow-hidden rounded-md bg-white/10">
+          {coverUrl ? (
+            <img
+              src={coverUrl}
+              alt={album ? `${title} cover` : title}
+              loading="lazy"
+              className="h-full w-full object-cover"
+            />
+          ) : (
+            <div className="flex h-full w-full items-center justify-center">
+              <Disc3 size={18} className="text-white/55" />
+            </div>
+          )}
+        </div>
+        <div className="min-w-0">
+          <p className="truncate text-sm font-semibold leading-tight">
+            {title}
+          </p>
+          <p className="truncate text-xs text-muted-foreground">{artist}</p>
+          {album ? (
+            <p className="truncate text-[11px] text-white/55">{album}</p>
+          ) : null}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/listen/src/components/artist/ArtistBioModal.tsx
+++ b/app/listen/src/components/artist/ArtistBioModal.tsx
@@ -110,7 +110,7 @@ export function ArtistBioModal({
       onClose={onClose}
       maxWidthClassName="sm:max-w-2xl"
       overlayClassName="bg-black/58"
-      panelClassName="listen-glass-panel fixed inset-x-3 bottom-[calc(var(--listen-mobile-bottom-chrome-height)+0.75rem)] flex min-h-0 max-h-[calc(var(--listen-viewport-height)-var(--listen-safe-top)-var(--listen-mobile-bottom-chrome-height)-1.75rem)] w-full max-w-2xl flex-col overflow-hidden rounded-3xl border-0"
+      panelClassName="listen-glass-panel flex min-h-0 w-full max-w-2xl flex-col overflow-hidden border-0 sm:max-h-[92vh]"
       mobileSafeArea
     >
       <ModalHeader className="bg-transparent">

--- a/app/listen/src/components/artist/ArtistBioModal.tsx
+++ b/app/listen/src/components/artist/ArtistBioModal.tsx
@@ -109,7 +109,9 @@ export function ArtistBioModal({
       open={open}
       onClose={onClose}
       maxWidthClassName="sm:max-w-2xl"
-      panelClassName="listen-glass-panel"
+      overlayClassName="bg-black/58"
+      panelClassName="listen-glass-panel fixed inset-x-3 bottom-[calc(var(--listen-mobile-bottom-chrome-height)+0.75rem)] flex min-h-0 max-h-[calc(var(--listen-viewport-height)-var(--listen-safe-top)-var(--listen-mobile-bottom-chrome-height)-1.75rem)] w-full max-w-2xl flex-col overflow-hidden rounded-3xl border-0"
+      mobileSafeArea
     >
       <ModalHeader className="bg-transparent">
         <div className="flex items-start justify-between gap-4 px-5 py-5 sm:px-6">
@@ -165,7 +167,7 @@ export function ArtistBioModal({
         </div>
       </ModalHeader>
 
-      <ModalBody className="max-h-[calc(92vh-124px)] space-y-6 px-5 py-5 sm:px-6">
+      <ModalBody className="flex-1 space-y-6 overflow-y-auto px-5 py-5 sm:px-6">
         {/* Stats */}
         {(listeners > 0 || spotifyFollowers > 0) && (
           <div className="grid grid-cols-2 sm:grid-cols-4 gap-4">

--- a/app/listen/src/components/artist/ArtistHeroSection.tsx
+++ b/app/listen/src/components/artist/ArtistHeroSection.tsx
@@ -292,6 +292,14 @@ export function ArtistHeroSection({
           >
             {following ? <UserCheck size={16} /> : <UserPlus size={16} />}
           </button>
+          {isDesktop ? null : (
+            <BandcampSupportButton
+              entityType="artist"
+              entityUid={artist.entity_uid}
+              iconOnly
+              className="shrink-0"
+            />
+          )}
           <div className="relative" ref={menuRef}>
             <button
               className="flex h-10 w-10 items-center justify-center rounded-full border border-white/15 text-muted-foreground transition-colors hover:bg-white/5 hover:text-foreground"
@@ -305,8 +313,9 @@ export function ArtistHeroSection({
                 {menuContent}
               </AppPopover>
             ) : null}
-            {menuOpen && !isDesktop ? (
+            {!isDesktop ? (
               <MobileActionSheet
+                open={menuOpen}
                 panelRef={mobileMenuRef}
                 onClose={() => setMenuOpen(false)}
               >
@@ -314,11 +323,14 @@ export function ArtistHeroSection({
               </MobileActionSheet>
             ) : null}
           </div>
-          <BandcampSupportButton
-            entityType="artist"
-            entityUid={artist.entity_uid}
-            className="ml-auto shrink-0"
-          />
+          {isDesktop ? (
+            <BandcampSupportButton
+              entityType="artist"
+              entityUid={artist.entity_uid}
+              className="ml-auto shrink-0"
+              iconOnly={false}
+            />
+          ) : null}
         </div>
       </div>
     </>

--- a/app/listen/src/components/artist/ArtistHeroSection.tsx
+++ b/app/listen/src/components/artist/ArtistHeroSection.tsx
@@ -250,31 +250,31 @@ export function ArtistHeroSection({
       </div>
 
       <div className="px-4 py-4 sm:px-6">
-        <div className="mx-auto flex w-full max-w-[1480px] flex-wrap items-center gap-2">
+        <div className="mx-auto flex w-full max-w-[1480px] flex-nowrap items-center gap-2 overflow-x-auto [scrollbar-width:none] max-[430px]:gap-1.5 [&::-webkit-scrollbar]:hidden">
           <button
-            className="flex items-center gap-2 rounded-full bg-primary px-5 py-2.5 text-sm font-medium text-primary-foreground transition-colors hover:bg-primary/90"
+            className="flex h-10 shrink-0 items-center justify-center gap-2 rounded-full bg-primary px-5 text-sm font-medium text-primary-foreground transition-colors hover:bg-primary/90 max-[430px]:w-10 max-[430px]:px-0"
             onClick={onPlay}
             aria-label="Play"
           >
             <Play size={16} fill="currentColor" />
-            Play
+            <span className="max-[430px]:sr-only">Play</span>
           </button>
           <button
-            className="flex h-10 w-10 items-center justify-center rounded-full border border-white/15 text-foreground transition-colors hover:bg-white/5"
+            className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full border border-white/15 text-foreground transition-colors hover:bg-white/5"
             onClick={onShuffle}
             aria-label="Shuffle"
           >
             <Shuffle size={16} />
           </button>
           <button
-            className="flex h-10 w-10 items-center justify-center rounded-full border border-white/15 text-foreground transition-colors hover:bg-white/5"
+            className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full border border-white/15 text-foreground transition-colors hover:bg-white/5"
             onClick={onArtistRadio}
             aria-label="Artist Radio"
           >
             <Radio size={16} />
           </button>
           <button
-            className="flex h-10 w-10 items-center justify-center rounded-full border border-white/15 text-foreground transition-colors hover:bg-white/5 disabled:opacity-40 disabled:cursor-not-allowed"
+            className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full border border-white/15 text-foreground transition-colors hover:bg-white/5 disabled:cursor-not-allowed disabled:opacity-40"
             onClick={onPlaySetlist}
             disabled={!hasSetlist}
             aria-label="Setlist"
@@ -282,7 +282,7 @@ export function ArtistHeroSection({
             <ListMusic size={16} />
           </button>
           <button
-            className={`flex h-10 w-10 items-center justify-center rounded-full transition-colors ${
+            className={`flex h-10 w-10 shrink-0 items-center justify-center rounded-full transition-colors ${
               following
                 ? "border border-primary/30 bg-primary/15 text-primary"
                 : "border border-white/15 text-foreground hover:bg-white/5"
@@ -300,9 +300,9 @@ export function ArtistHeroSection({
               className="shrink-0"
             />
           )}
-          <div className="relative" ref={menuRef}>
+          <div className="relative shrink-0" ref={menuRef}>
             <button
-              className="flex h-10 w-10 items-center justify-center rounded-full border border-white/15 text-muted-foreground transition-colors hover:bg-white/5 hover:text-foreground"
+              className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full border border-white/15 text-muted-foreground transition-colors hover:bg-white/5 hover:text-foreground"
               onClick={() => setMenuOpen((current) => !current)}
               aria-label="More"
             >

--- a/app/listen/src/components/artist/ArtistModals.test.tsx
+++ b/app/listen/src/components/artist/ArtistModals.test.tsx
@@ -1,0 +1,79 @@
+import { MemoryRouter } from "react-router";
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { ArtistBioModal } from "./ArtistBioModal";
+import { ArtistSetlistModal } from "./ArtistSetlistSection";
+
+vi.mock("@/lib/api", () => ({
+  api: vi.fn(() => Promise.resolve({})),
+}));
+
+describe("artist mobile modals", () => {
+  it("renders probable setlist as a native bottom sheet instead of a floating panel", () => {
+    render(
+      <ArtistSetlistModal
+        artistName="Kneecap"
+        artistId={7}
+        open
+        onClose={() => {}}
+        onPlay={() => {}}
+        setlist={[
+          {
+            title: "Smugglers & Scholars",
+            frequency: 0.8,
+            play_count: 12,
+          },
+        ]}
+      />,
+    );
+
+    const panel = screen
+      .getByText("Probable Setlist")
+      .closest(".listen-glass-panel");
+    expect(panel).toBeInTheDocument();
+    expect(panel).not.toHaveClass("fixed");
+    expect(panel?.className).not.toContain(
+      "listen-mobile-bottom-chrome-height",
+    );
+  });
+
+  it("renders artist bio as a native bottom sheet instead of a floating panel", () => {
+    render(
+      <MemoryRouter>
+        <ArtistBioModal
+          open
+          onClose={() => {}}
+          photoUrl="/artist.jpg"
+          tags={["hip-hop"]}
+          artist={{
+            id: 7,
+            name: "Kneecap",
+            albums: [],
+            total_tracks: 0,
+            total_size_mb: 0,
+            primary_format: null,
+            genres: ["hip-hop"],
+            issue_count: 0,
+          }}
+          artistInfo={{
+            bio: "Belfast trio.",
+            tags: ["hip-hop"],
+            similar: [],
+            listeners: 1000,
+            playcount: 2000,
+            image_url: null,
+            url: "",
+          }}
+        />
+      </MemoryRouter>,
+    );
+
+    const panel = screen.getByText("Kneecap").closest(".listen-glass-panel");
+    expect(panel).toBeInTheDocument();
+    expect(panel).not.toHaveClass("fixed");
+    expect(panel?.className).not.toContain(
+      "listen-mobile-bottom-chrome-height",
+    );
+  });
+});

--- a/app/listen/src/components/artist/ArtistSetlistSection.tsx
+++ b/app/listen/src/components/artist/ArtistSetlistSection.tsx
@@ -2,6 +2,7 @@ import { ListMusic, Play, Save, X } from "lucide-react";
 import { useState } from "react";
 import { toast } from "sonner";
 
+import { AppModal } from "@crate/ui/primitives/AppModal";
 import { api } from "@/lib/api";
 
 interface SetlistTrack {
@@ -51,15 +52,15 @@ export function ArtistSetlistModal({
   }
 
   return (
-    <div
-      className="fixed inset-0 z-app-modal flex items-end justify-center sm:items-center"
-      onClick={onClose}
+    <AppModal
+      open={open}
+      onClose={onClose}
+      maxWidthClassName="max-w-md"
+      mobileSafeArea
+      overlayClassName="bg-black/58"
+      panelClassName="listen-glass-panel fixed inset-x-3 bottom-[calc(var(--listen-mobile-bottom-chrome-height)+0.75rem)] flex min-h-0 max-h-[calc(var(--listen-viewport-height)-var(--listen-safe-top)-var(--listen-mobile-bottom-chrome-height)-1.75rem)] flex-col overflow-hidden rounded-3xl border-0 pb-4 animate-sheet-up"
     >
-      <div className="absolute inset-0 bg-black/68" />
-      <div
-        className="listen-glass-panel relative flex max-h-[85vh] w-full max-w-md flex-col overflow-hidden rounded-t-2xl sm:rounded-2xl"
-        onClick={(e) => e.stopPropagation()}
-      >
+      <div className="flex min-h-0 flex-1 flex-col">
         {/* Header */}
         <div className="flex items-center justify-between border-b border-white/5 px-5 py-4">
           <div className="flex items-center gap-3">
@@ -135,6 +136,6 @@ export function ArtistSetlistModal({
           </button>
         </div>
       </div>
-    </div>
+    </AppModal>
   );
 }

--- a/app/listen/src/components/artist/ArtistSetlistSection.tsx
+++ b/app/listen/src/components/artist/ArtistSetlistSection.tsx
@@ -58,7 +58,7 @@ export function ArtistSetlistModal({
       maxWidthClassName="max-w-md"
       mobileSafeArea
       overlayClassName="bg-black/58"
-      panelClassName="listen-glass-panel fixed inset-x-3 bottom-[calc(var(--listen-mobile-bottom-chrome-height)+0.75rem)] flex min-h-0 max-h-[calc(var(--listen-viewport-height)-var(--listen-safe-top)-var(--listen-mobile-bottom-chrome-height)-1.75rem)] flex-col overflow-hidden rounded-3xl border-0 pb-4 animate-sheet-up"
+      panelClassName="listen-glass-panel flex min-h-0 flex-col overflow-hidden border-0 pb-4 sm:max-h-[92vh]"
     >
       <div className="flex min-h-0 flex-1 flex-col">
         {/* Header */}

--- a/app/listen/src/components/bandcamp/BandcampSupportButton.tsx
+++ b/app/listen/src/components/bandcamp/BandcampSupportButton.tsx
@@ -23,6 +23,7 @@ interface BandcampSupportButtonProps {
   entityUid?: string | null;
   fallbackArtistEntityUid?: string | null;
   className?: string;
+  iconOnly?: boolean;
 }
 
 interface ResolvedBandcampLink {
@@ -54,6 +55,7 @@ export function BandcampSupportButton({
   entityUid,
   fallbackArtistEntityUid,
   className = "",
+  iconOnly = false,
 }: BandcampSupportButtonProps) {
   const [resolved, setResolved] = useState<ResolvedBandcampLink | null>(null);
   const [busy, setBusy] = useState(false);
@@ -163,15 +165,26 @@ export function BandcampSupportButton({
     <button
       onClick={handleClick}
       disabled={busy}
-      className={`inline-flex h-10 items-center gap-2 rounded-full border border-[#1da0c3]/30 bg-[#1da0c3]/10 px-4 text-sm font-medium text-[#7ee7ff] transition-colors hover:bg-[#1da0c3]/15 disabled:opacity-50 ${className}`}
+      className={`inline-flex h-10 items-center ${
+        iconOnly ? "w-10 justify-center px-0" : "gap-2 px-4"
+      } rounded-full border border-[#1da0c3]/30 bg-[#1da0c3]/10 text-sm font-medium text-[#7ee7ff] transition-colors hover:bg-[#1da0c3]/15 disabled:opacity-50 ${className}`}
+      aria-label={ownedAlbum && !canImport ? ownedLabel : label}
     >
       {busy ? (
         <Loader2 size={15} className="animate-spin" />
       ) : (
         <BandcampLogo size={15} />
       )}
-      <span className="hidden sm:inline">{label}</span>
-      <span className="sm:hidden">Bandcamp</span>
+      {iconOnly ? (
+        <span className="sr-only">
+          {ownedAlbum && !canImport ? ownedLabel : label}
+        </span>
+      ) : (
+        <>
+          <span className="hidden sm:inline">{label}</span>
+          <span className="sm:hidden">Bandcamp</span>
+        </>
+      )}
     </button>
   );
 }

--- a/app/listen/src/components/bandcamp/BandcampSupportButton.tsx
+++ b/app/listen/src/components/bandcamp/BandcampSupportButton.tsx
@@ -130,11 +130,20 @@ export function BandcampSupportButton({
   if (ownedAlbum && !canImport) {
     return (
       <span
-        className={`inline-flex h-10 items-center gap-2 rounded-full border border-[#1da0c3]/25 bg-[#1da0c3]/10 px-4 text-sm font-medium text-[#7ee7ff]/90 ${className}`}
+        className={`inline-flex h-10 items-center rounded-full border border-[#1da0c3]/25 bg-[#1da0c3]/10 text-sm font-medium text-[#7ee7ff]/90 ${
+          iconOnly ? "w-10 justify-center px-0" : "gap-2 px-4"
+        } ${className}`}
+        aria-label={ownedLabel}
       >
         <BandcampLogo size={15} />
-        <span className="hidden sm:inline">{ownedLabel}</span>
-        <span className="sm:hidden">Owned</span>
+        {iconOnly ? (
+          <span className="sr-only">{ownedLabel}</span>
+        ) : (
+          <>
+            <span className="hidden sm:inline">{ownedLabel}</span>
+            <span className="sm:hidden">Owned</span>
+          </>
+        )}
       </span>
     );
   }

--- a/app/listen/src/components/cards/TrackRow.tsx
+++ b/app/listen/src/components/cards/TrackRow.tsx
@@ -6,6 +6,7 @@ import {
   ItemActionMenuButton,
   useItemActionMenu,
 } from "@/components/actions/ItemActionMenu";
+import { TrackActionMenuHeader } from "@/components/actions/TrackActionMenuHeader";
 import { useTrackActionEntries } from "@/components/actions/track-actions";
 import { buildTrackMenuPlayerTrack } from "@/components/actions/shared";
 import { OfflineBadge } from "@/components/offline/OfflineBadge";
@@ -427,6 +428,14 @@ export const TrackRow = memo(function TrackRow({
       {!disabled ? (
         <ItemActionMenu
           actions={actions}
+          header={
+            <TrackActionMenuHeader
+              coverUrl={cover}
+              title={track.title}
+              artist={track.artist}
+              album={track.album}
+            />
+          }
           open={actionMenu.open}
           position={actionMenu.position}
           menuRef={actionMenu.menuRef}

--- a/app/listen/src/components/home/HomePlaybackSections.tsx
+++ b/app/listen/src/components/home/HomePlaybackSections.tsx
@@ -6,6 +6,7 @@ import {
   ItemActionMenuButton,
   useItemActionMenu,
 } from "@/components/actions/ItemActionMenu";
+import { TrackActionMenuHeader } from "@/components/actions/TrackActionMenuHeader";
 import { trackToMenuData } from "@/components/actions/shared";
 import { useTrackActionEntries } from "@/components/actions/track-actions";
 import { TrackCoverThumb } from "@/components/cards/TrackCoverThumb";
@@ -79,6 +80,14 @@ function HomeTrackRowAction({
       />
       <ItemActionMenu
         actions={actions}
+        header={
+          <TrackActionMenuHeader
+            coverUrl={track.albumCover}
+            title={track.title}
+            artist={track.artist}
+            album={track.album}
+          />
+        }
         open={actionMenu.open}
         position={actionMenu.position}
         menuRef={actionMenu.menuRef}
@@ -165,6 +174,14 @@ function HomeReplayRowAction({
       />
       <ItemActionMenu
         actions={actions}
+        header={
+          <TrackActionMenuHeader
+            coverUrl={cover}
+            title={item.title}
+            artist={item.artist}
+            album={item.album}
+          />
+        }
         open={actionMenu.open}
         position={actionMenu.position}
         menuRef={actionMenu.menuRef}
@@ -240,6 +257,14 @@ function HomeQueueCardAction({
       </div>
       <ItemActionMenu
         actions={actions}
+        header={
+          <TrackActionMenuHeader
+            coverUrl={track.albumCover}
+            title={track.title}
+            artist={track.artist}
+            album={track.album}
+          />
+        }
         open={actionMenu.open}
         position={actionMenu.position}
         menuRef={actionMenu.menuRef}

--- a/app/listen/src/components/home/HomeUpcomingSections.tsx
+++ b/app/listen/src/components/home/HomeUpcomingSections.tsx
@@ -72,12 +72,23 @@ export function HomeUpcomingSection({
       { size: 800 },
     );
   const releasePath =
-    !isShow && (nextUpcoming.album_id || nextUpcoming.album_slug)
+    !isShow &&
+    (nextUpcoming.album_id ||
+      nextUpcoming.release_id ||
+      nextUpcoming.album_slug)
       ? albumPagePath({
-          albumId: nextUpcoming.album_id,
-          albumSlug: nextUpcoming.album_slug,
+          albumId: nextUpcoming.album_id
+            ? nextUpcoming.album_id
+            : nextUpcoming.release_id
+              ? -nextUpcoming.release_id
+              : undefined,
+          albumSlug: nextUpcoming.album_id
+            ? nextUpcoming.album_slug
+            : undefined,
           albumName: nextUpcoming.title,
-          artistSlug: nextUpcoming.artist_slug,
+          artistSlug: nextUpcoming.album_id
+            ? nextUpcoming.artist_slug
+            : undefined,
           artistName: nextUpcoming.artist,
         })
       : null;

--- a/app/listen/src/components/home/home-model.ts
+++ b/app/listen/src/components/home/home-model.ts
@@ -91,6 +91,7 @@ export interface HomeUpcomingItem {
   artist_slug?: string;
   album_id?: number;
   album_slug?: string;
+  release_id?: number;
   title: string;
   subtitle: string;
   cover_url?: string | null;

--- a/app/listen/src/components/layout/topbar/TopBarSearch.test.tsx
+++ b/app/listen/src/components/layout/topbar/TopBarSearch.test.tsx
@@ -8,6 +8,16 @@ vi.mock("@/lib/api", () => ({
   getAuthToken: vi.fn(() => null),
 }));
 
+const navigateMock = vi.fn();
+vi.mock("react-router", async () => {
+  const actual =
+    await vi.importActual<typeof import("react-router")>("react-router");
+  return {
+    ...actual,
+    useNavigate: () => navigateMock,
+  };
+});
+
 import { api } from "@/lib/api";
 import { TopBarSearch } from "@/components/layout/topbar/TopBarSearch";
 import { renderWithListenProviders } from "@/test/render-with-listen-providers";
@@ -176,5 +186,40 @@ describe("TopBarSearch", () => {
     await waitFor(() => {
       expect(document.activeElement).toBe(input);
     });
+  });
+
+  it("navigates directly when a recent entry has a destination", async () => {
+    const user = userEvent.setup();
+    localStorage.setItem(
+      "listen-search-recents",
+      JSON.stringify([
+        { label: "High Vis", type: "artist", navigateTo: "/artists/high-vis" },
+      ]),
+    );
+    renderWithListenProviders(<TopBarSearch />);
+
+    const searchButton = screen.getByRole("button", { name: "Search" });
+    await user.click(searchButton);
+
+    await user.click(await screen.findByText("High Vis"));
+
+    expect(navigateMock).toHaveBeenCalledWith("/artists/high-vis");
+  });
+
+  it("keeps query search behaviour for legacy plain recent entries", async () => {
+    const user = userEvent.setup();
+    localStorage.setItem("listen-search-recents", JSON.stringify(["Converge"]));
+    renderWithListenProviders(<TopBarSearch />);
+
+    const searchButton = screen.getByRole("button", { name: "Search" });
+    await user.click(searchButton);
+
+    await user.click(await screen.findByText("Converge"));
+
+    const input = screen.getByPlaceholderText(
+      "Search artists, albums, tracks...",
+    );
+    expect(input).toHaveValue("Converge");
+    expect(navigateMock).not.toHaveBeenCalled();
   });
 });

--- a/app/listen/src/components/layout/topbar/TopBarSearch.tsx
+++ b/app/listen/src/components/layout/topbar/TopBarSearch.tsx
@@ -21,6 +21,7 @@ import {
   flattenTopBarSearchResults,
   getTopBarSearchRecents,
   type SearchResult,
+  type TopBarSearchRecentEntry,
   type TopBarSearchItem,
 } from "./topbar-search-model";
 
@@ -72,7 +73,9 @@ export function TopBarSearch() {
   const [loading, setLoading] = useState(false);
   const [showDropdown, setShowDropdown] = useState(false);
   const [activeIdx, setActiveIdx] = useState(-1);
-  const [recents, setRecents] = useState<string[]>(getTopBarSearchRecents);
+  const [recents, setRecents] = useState<TopBarSearchRecentEntry[]>(
+    getTopBarSearchRecents,
+  );
   const [expanded, setExpanded] = useState(false);
 
   const containerRef = useRef<HTMLDivElement>(null);
@@ -246,7 +249,7 @@ export function TopBarSearch() {
 
   const selectItem = useCallback(
     (item: TopBarSearchItem) => {
-      addTopBarSearchRecent(item.label);
+      addTopBarSearchRecent(item);
       setRecents(getTopBarSearchRecents());
       if (item.trackData) {
         play(
@@ -264,17 +267,31 @@ export function TopBarSearch() {
   );
 
   const selectRecent = useCallback(
-    (term: string) => {
+    (recent: TopBarSearchRecentEntry) => {
+      addTopBarSearchRecent(recent);
+      setRecents(getTopBarSearchRecents());
+
+      if (recent.navigateTo) {
+        navigate(recent.navigateTo);
+        setShowDropdown(false);
+        setExpanded(false);
+        setQuery("");
+        setResults([]);
+        return;
+      }
+
       setExpanded(true);
-      setQuery(term);
+      setQuery(recent.label);
       setShowDropdown(true);
       focusInputSoon();
     },
-    [focusInputSoon],
+    [focusInputSoon, navigate],
   );
 
   function handleKeyDown(e: React.KeyboardEvent<HTMLInputElement>) {
-    const items = query.trim() ? results : recents.map((label) => ({ label }));
+    const items = query.trim()
+      ? results
+      : recents.map((recent) => ({ type: recent.type, label: recent.label }));
     if (e.key === "ArrowDown") {
       e.preventDefault();
       setActiveIdx((prev) => Math.min(prev + 1, items.length - 1));
@@ -358,17 +375,17 @@ export function TopBarSearch() {
                 <p className="px-3 py-1.5 text-[10px] font-bold uppercase tracking-wider text-white/40">
                   Recent
                 </p>
-                {recents.map((term, index) => (
+                {recents.map((recent, index) => (
                   <button
-                    key={term}
-                    onClick={() => selectRecent(term)}
+                    key={`${recent.type ?? "query"}:${recent.label}:${index}`}
+                    onClick={() => selectRecent(recent)}
                     className={`flex w-full items-center gap-3 px-3 py-2 text-left transition-colors ${
                       index === activeIdx ? "bg-white/10" : "hover:bg-white/5"
                     }`}
                   >
                     <Search size={12} className="shrink-0 text-white/20" />
                     <span className="truncate text-[13px] text-white/60">
-                      {term}
+                      {recent.label}
                     </span>
                   </button>
                 ))}

--- a/app/listen/src/components/layout/topbar/topbar-search-model.ts
+++ b/app/listen/src/components/layout/topbar/topbar-search-model.ts
@@ -45,23 +45,92 @@ export interface TopBarSearchItem {
   trackData?: Track;
 }
 
+export interface TopBarSearchRecentEntry {
+  label: string;
+  type?: TopBarSearchItem["type"];
+  navigateTo?: string;
+}
+
 const RECENTS_KEY = "listen-search-recents";
 const MAX_RECENTS = 5;
 
-export function getTopBarSearchRecents(): string[] {
+function isTopBarSearchRecentEntry(
+  value: unknown,
+): value is TopBarSearchRecentEntry {
+  return (
+    Boolean(value) &&
+    typeof value === "object" &&
+    "label" in (value as object) &&
+    typeof (value as { label?: unknown }).label === "string" &&
+    ("type" in (value as object)
+      ? ["artist", "album", "track"].includes(
+          String((value as { type?: unknown }).type),
+        )
+      : true) &&
+    ("navigateTo" in (value as object)
+      ? typeof (value as { navigateTo?: unknown }).navigateTo === "string"
+      : true)
+  );
+}
+
+export function getTopBarSearchRecents(): TopBarSearchRecentEntry[] {
   try {
-    return JSON.parse(localStorage.getItem(RECENTS_KEY) || "[]");
+    const stored = JSON.parse(localStorage.getItem(RECENTS_KEY) || "[]");
+    if (!Array.isArray(stored)) {
+      return [];
+    }
+    return stored
+      .map((entry) =>
+        typeof entry === "string"
+          ? { label: entry }
+          : isTopBarSearchRecentEntry(entry)
+            ? entry
+            : null,
+      )
+      .filter((entry): entry is TopBarSearchRecentEntry => entry !== null);
   } catch {
     return [];
   }
 }
 
-export function addTopBarSearchRecent(term: string) {
-  const recents = getTopBarSearchRecents().filter((recent) => recent !== term);
-  recents.unshift(term);
+function dedupeRecentEntries(entries: TopBarSearchRecentEntry[]) {
+  const seen = new Set<string>();
+  return entries.filter((entry) => {
+    const key = `${entry.type ?? "query"}:${entry.navigateTo ?? entry.label}`;
+    if (seen.has(key)) {
+      return false;
+    }
+    seen.add(key);
+    return true;
+  });
+}
+
+export function addTopBarSearchRecent(
+  entry: string | TopBarSearchItem | TopBarSearchRecentEntry,
+) {
+  const recent: TopBarSearchRecentEntry =
+    typeof entry === "string"
+      ? { label: entry }
+      : {
+          label: entry.label,
+          type: entry.type,
+          navigateTo: entry.navigateTo,
+        };
+
+  const recents = getTopBarSearchRecents().filter(
+    (recentItem) =>
+      !(
+        recentItem.type === recent.type &&
+        (recentItem.navigateTo ?? recentItem.label) ===
+          (recent.navigateTo ?? recent.label)
+      ),
+  );
+
+  recents.unshift(recent);
+  const deduped = dedupeRecentEntries(recents);
   localStorage.setItem(
     RECENTS_KEY,
-    JSON.stringify(recents.slice(0, MAX_RECENTS)),
+    JSON.stringify(deduped.slice(0, MAX_RECENTS)),
   );
 }
 

--- a/app/listen/src/components/player/ContinuePlaybackPrompt.tsx
+++ b/app/listen/src/components/player/ContinuePlaybackPrompt.tsx
@@ -145,7 +145,7 @@ export function ContinuePlaybackPrompt() {
   };
 
   return (
-    <div className="listen-glass-panel fixed inset-x-3 bottom-[calc(env(safe-area-inset-bottom)+7.25rem)] z-[1700] mx-auto max-w-xl rounded-xl p-3 sm:bottom-24">
+    <div className="listen-glass-panel fixed inset-x-3 bottom-[calc(env(safe-area-inset-bottom)+7.25rem)] z-app-modal mx-auto max-w-xl rounded-xl p-3 sm:bottom-24">
       <div className="flex items-start gap-3">
         <div className="mt-0.5 rounded-lg border border-cyan-400/25 bg-cyan-400/10 p-2 text-cyan-200">
           <MonitorSpeaker size={18} />

--- a/app/listen/src/components/player/EqualizerPopover.tsx
+++ b/app/listen/src/components/player/EqualizerPopover.tsx
@@ -1,5 +1,6 @@
-import { useEffect, useRef } from "react";
+import { useRef } from "react";
 
+import { useDismissibleLayer } from "@crate/ui/lib/use-dismissible-layer";
 import { EqualizerPanel } from "@/components/player/EqualizerPanel";
 
 interface EqualizerPopoverProps {
@@ -15,36 +16,11 @@ interface EqualizerPopoverProps {
 export function EqualizerPopover({ open, onClose }: EqualizerPopoverProps) {
   const panelRef = useRef<HTMLDivElement>(null);
 
-  // Esc closes, click-outside closes.
-  useEffect(() => {
-    if (!open) return;
-
-    const onKey = (event: KeyboardEvent) => {
-      if (event.key === "Escape") onClose();
-    };
-    const onPointerDown = (event: PointerEvent) => {
-      if (
-        panelRef.current &&
-        !panelRef.current.contains(event.target as Node)
-      ) {
-        onClose();
-      }
-    };
-
-    window.addEventListener("keydown", onKey);
-    // Defer the pointerdown listener to the next tick so the same click
-    // that opened the popover doesn't immediately close it.
-    const timer = window.setTimeout(
-      () => window.addEventListener("pointerdown", onPointerDown, true),
-      0,
-    );
-
-    return () => {
-      window.removeEventListener("keydown", onKey);
-      window.removeEventListener("pointerdown", onPointerDown, true);
-      window.clearTimeout(timer);
-    };
-  }, [open, onClose]);
+  useDismissibleLayer({
+    active: open,
+    refs: [panelRef],
+    onDismiss: onClose,
+  });
 
   if (!open) return null;
 

--- a/app/listen/src/components/player/FullscreenPlayer.tsx
+++ b/app/listen/src/components/player/FullscreenPlayer.tsx
@@ -7,6 +7,7 @@ import {
 } from "@/components/actions/ItemActionMenu";
 import { trackToMenuData } from "@/components/actions/shared";
 import { useTrackActionEntries } from "@/components/actions/track-actions";
+import { TrackActionMenuHeader } from "@/components/actions/TrackActionMenuHeader";
 import { PlayerTrackIdentity } from "@/components/player/PlayerTrackIdentity";
 import { SpinningDisc } from "@/components/player/SpinningDisc";
 import { getPlaySourceLabel } from "@/components/player/player-source";
@@ -158,6 +159,14 @@ function FullscreenQueueRow({
       />
       <ItemActionMenu
         actions={actions}
+        header={
+          <TrackActionMenuHeader
+            coverUrl={track.albumCover}
+            title={track.title}
+            artist={track.artist}
+            album={track.album}
+          />
+        }
         open={actionMenu.open}
         position={actionMenu.position}
         menuRef={actionMenu.menuRef}

--- a/app/listen/src/components/player/QueuePanel.tsx
+++ b/app/listen/src/components/player/QueuePanel.tsx
@@ -7,6 +7,7 @@ import {
   type ItemActionMenuEntry,
   useItemActionMenu,
 } from "@/components/actions/ItemActionMenu";
+import { TrackActionMenuHeader } from "@/components/actions/TrackActionMenuHeader";
 import { trackToMenuData } from "@/components/actions/shared";
 import { useTrackActionEntries } from "@/components/actions/track-actions";
 import type { Track } from "@/contexts/PlayerContext";
@@ -120,6 +121,14 @@ function QueuePanelRow({
       />
       <ItemActionMenu
         actions={actions}
+        header={
+          <TrackActionMenuHeader
+            coverUrl={track.albumCover}
+            title={track.title}
+            artist={track.artist}
+            album={track.album}
+          />
+        }
         open={actionMenu.open}
         position={actionMenu.position}
         menuRef={actionMenu.menuRef}

--- a/app/listen/src/components/player/bar/PlayerTrackMenu.tsx
+++ b/app/listen/src/components/player/bar/PlayerTrackMenu.tsx
@@ -5,6 +5,7 @@ import {
   ItemActionMenuButton,
   useItemActionMenu,
 } from "@/components/actions/ItemActionMenu";
+import { TrackActionMenuHeader } from "@/components/actions/TrackActionMenuHeader";
 import { trackToMenuData } from "@/components/actions/shared";
 import { useTrackActionEntries } from "@/components/actions/track-actions";
 import type { Track } from "@/contexts/PlayerContext";
@@ -19,6 +20,7 @@ interface PlayerTrackMenuProps {
 
 export function PlayerTrackMenu({
   currentTrack,
+  onOverlayChange,
   className,
 }: PlayerTrackMenuProps) {
   const menuTrack = useMemo(
@@ -29,7 +31,9 @@ export function PlayerTrackMenu({
     track: menuTrack,
     albumCover: currentTrack.albumCover,
   });
-  const actionMenu = useItemActionMenu(actions);
+  const actionMenu = useItemActionMenu(actions, {
+    onOpenChange: onOverlayChange,
+  });
 
   return (
     <>
@@ -41,6 +45,14 @@ export function PlayerTrackMenu({
       />
       <ItemActionMenu
         actions={actions}
+        header={
+          <TrackActionMenuHeader
+            coverUrl={currentTrack.albumCover}
+            title={currentTrack.title}
+            artist={currentTrack.artist}
+            album={currentTrack.album}
+          />
+        }
         open={actionMenu.open}
         position={actionMenu.position}
         menuRef={actionMenu.menuRef}

--- a/app/listen/src/components/player/extended/QueueTab.tsx
+++ b/app/listen/src/components/player/extended/QueueTab.tsx
@@ -8,6 +8,7 @@ import {
   type ItemActionMenuEntry,
   useItemActionMenu,
 } from "@/components/actions/ItemActionMenu";
+import { TrackActionMenuHeader } from "@/components/actions/TrackActionMenuHeader";
 import { trackToMenuData } from "@/components/actions/shared";
 import { useTrackActionEntries } from "@/components/actions/track-actions";
 import { getPlaySourceLabel } from "@/components/player/player-source";
@@ -110,6 +111,14 @@ function QueueTabRow({
       />
       <ItemActionMenu
         actions={actions}
+        header={
+          <TrackActionMenuHeader
+            coverUrl={track.albumCover}
+            title={track.title}
+            artist={track.artist}
+            album={track.album}
+          />
+        }
         open={actionMenu.open}
         position={actionMenu.position}
         menuRef={actionMenu.menuRef}

--- a/app/listen/src/components/upcoming/UpcomingEventRow.tsx
+++ b/app/listen/src/components/upcoming/UpcomingEventRow.tsx
@@ -37,13 +37,19 @@ export function UpcomingEventRow({
       { size: 800 },
     ) ||
     undefined;
+  const useVirtualAlbumRoute =
+    !item.album_id && item.release_id != null && item.release_id > 0;
+  const virtualAlbumId = useVirtualAlbumRoute ? item.release_id : null;
   const albumPath =
-    canOpenUpcomingRelease(item) && (item.album_id || item.album_slug)
+    canOpenUpcomingRelease(item) &&
+    (item.album_id || item.album_slug || item.release_id)
       ? albumPagePath({
-          albumId: item.album_id,
-          albumSlug: item.album_slug,
+          albumId:
+            item.album_id ??
+            (virtualAlbumId != null ? -virtualAlbumId : undefined),
+          albumSlug: useVirtualAlbumRoute ? undefined : item.album_slug,
           albumName: item.title,
-          artistSlug: item.artist_slug,
+          artistSlug: useVirtualAlbumRoute ? undefined : item.artist_slug,
           artistName: item.artist,
         })
       : null;

--- a/app/listen/src/components/upcoming/upcoming-model.test.ts
+++ b/app/listen/src/components/upcoming/upcoming-model.test.ts
@@ -72,6 +72,20 @@ describe("upcoming model", () => {
         is_upcoming: false,
       }),
     ).toBe(true);
+
+    expect(
+      canOpenUpcomingRelease({
+        type: "release",
+        date: "2026-07-17",
+        artist: "SOFTPLAY",
+        title: "Ghostly",
+        subtitle: "EP",
+        cover_url: null,
+        status: "detected",
+        is_upcoming: true,
+        release_id: 12,
+      }),
+    ).toBe(true);
   });
 
   it("labels release rows by current availability state", () => {

--- a/app/listen/src/components/upcoming/upcoming-model.ts
+++ b/app/listen/src/components/upcoming/upcoming-model.ts
@@ -103,7 +103,7 @@ export function itemKey(item: UpcomingItem, index: number): string {
 export function canOpenUpcomingRelease(item: UpcomingItem) {
   if (item.type !== "release") return false;
   if (item.album_id != null) return true;
-  return Boolean(item.is_upcoming && item.release_id && item.artist_slug);
+  return Boolean(item.is_upcoming && item.release_id != null);
 }
 
 export function upcomingReleaseBadgeLabel(item: UpcomingItem) {

--- a/app/listen/src/lib/input-capabilities.ts
+++ b/app/listen/src/lib/input-capabilities.ts
@@ -10,6 +10,22 @@ export function canUseHoverPointer(): boolean {
   return window.matchMedia(HOVER_POINTER_MEDIA_QUERY).matches;
 }
 
+export function isTouchDominantPointer(): boolean {
+  if (
+    typeof window === "undefined" ||
+    typeof window.matchMedia !== "function"
+  ) {
+    return false;
+  }
+  if (navigator.maxTouchPoints > 0) {
+    return true;
+  }
+  return (
+    window.matchMedia("(pointer: coarse)").matches ||
+    window.matchMedia("(hover: none)").matches
+  );
+}
+
 export function subscribeHoverPointer(
   callback: (canHover: boolean) => void,
 ): () => void {

--- a/app/listen/src/pages/Album.tsx
+++ b/app/listen/src/pages/Album.tsx
@@ -998,18 +998,18 @@ export function Album() {
 
       {/* Action Row */}
       <div className="px-4 py-4 sm:px-6">
-        <div className="mx-auto flex w-full max-w-[1480px] flex-wrap items-center gap-2">
+        <div className="mx-auto flex w-full max-w-[1480px] flex-nowrap items-center gap-2 overflow-x-auto [scrollbar-width:none] max-[430px]:gap-1.5 [&::-webkit-scrollbar]:hidden">
           <button
-            className="flex items-center gap-2 px-5 py-2.5 rounded-full bg-primary text-primary-foreground font-medium text-sm hover:bg-primary/90 transition-colors disabled:cursor-not-allowed disabled:opacity-45"
+            className="flex h-10 shrink-0 items-center justify-center gap-2 rounded-full bg-primary px-5 text-sm font-medium text-primary-foreground transition-colors hover:bg-primary/90 disabled:cursor-not-allowed disabled:opacity-45 max-[430px]:w-10 max-[430px]:px-0"
             onClick={() => handlePlay()}
             disabled={playerTracks.length === 0}
             aria-label="Play"
           >
             <Play size={16} fill="currentColor" />
-            Play
+            <span className="max-[430px]:sr-only">Play</span>
           </button>
           <button
-            className="flex h-10 w-10 items-center justify-center rounded-full border border-white/15 text-foreground transition-colors hover:bg-white/5 disabled:cursor-not-allowed disabled:opacity-45"
+            className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full border border-white/15 text-foreground transition-colors hover:bg-white/5 disabled:cursor-not-allowed disabled:opacity-45"
             onClick={handleShuffle}
             disabled={playerTracks.length === 0}
             aria-label="Shuffle"
@@ -1018,7 +1018,7 @@ export function Album() {
           </button>
           {!isPreRelease ? (
             <button
-              className="flex h-10 w-10 items-center justify-center rounded-full border border-white/15 text-foreground transition-colors hover:bg-white/5"
+              className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full border border-white/15 text-foreground transition-colors hover:bg-white/5"
               onClick={handleAlbumRadio}
               aria-label="Album Radio"
             >
@@ -1027,7 +1027,7 @@ export function Album() {
           ) : null}
           {canPersistAlbum ? (
             <button
-              className={`flex h-10 w-10 items-center justify-center rounded-full transition-colors ${
+              className={`flex h-10 w-10 shrink-0 items-center justify-center rounded-full transition-colors ${
                 offlineState === "ready"
                   ? "border border-cyan-400/25 bg-cyan-400/10 text-cyan-200"
                   : offlineBusy
@@ -1058,7 +1058,7 @@ export function Album() {
           ) : null}
           {canPersistAlbum ? (
             <button
-              className={`flex h-10 w-10 items-center justify-center rounded-full transition-colors ${
+              className={`flex h-10 w-10 shrink-0 items-center justify-center rounded-full transition-colors ${
                 saved
                   ? "border border-primary/30 bg-primary/15 text-primary"
                   : "border border-white/15 text-foreground hover:bg-white/5"
@@ -1078,9 +1078,9 @@ export function Album() {
             className={isDesktop ? "ml-auto shrink-0" : "shrink-0"}
             iconOnly={!isDesktop}
           />
-          <div className="relative" ref={menuRef}>
+          <div className="relative shrink-0" ref={menuRef}>
             <button
-              className="flex h-10 w-10 items-center justify-center rounded-full border border-white/15 text-muted-foreground transition-colors hover:bg-white/5 hover:text-foreground"
+              className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full border border-white/15 text-muted-foreground transition-colors hover:bg-white/5 hover:text-foreground"
               onClick={() => setMenuOpen((open) => !open)}
               aria-label="More"
             >

--- a/app/listen/src/pages/Album.tsx
+++ b/app/listen/src/pages/Album.tsx
@@ -1071,6 +1071,13 @@ export function Album() {
               <Heart size={16} className={saved ? "fill-current" : ""} />
             </button>
           ) : null}
+          <BandcampSupportButton
+            entityType="album"
+            entityUid={data.entity_uid}
+            fallbackArtistEntityUid={data.artist_entity_uid}
+            className={isDesktop ? "ml-auto shrink-0" : "shrink-0"}
+            iconOnly={!isDesktop}
+          />
           <div className="relative" ref={menuRef}>
             <button
               className="flex h-10 w-10 items-center justify-center rounded-full border border-white/15 text-muted-foreground transition-colors hover:bg-white/5 hover:text-foreground"
@@ -1124,8 +1131,9 @@ export function Album() {
                 />
               </AppPopover>
             )}
-            {menuOpen && !isDesktop && (
+            {!isDesktop ? (
               <MobileActionSheet
+                open={menuOpen}
                 panelRef={mobileMenuRef}
                 onClose={() => setMenuOpen(false)}
               >
@@ -1171,14 +1179,8 @@ export function Album() {
                   }}
                 />
               </MobileActionSheet>
-            )}
+            ) : null}
           </div>
-          <BandcampSupportButton
-            entityType="album"
-            entityUid={data.entity_uid}
-            fallbackArtistEntityUid={data.artist_entity_uid}
-            className="ml-auto shrink-0"
-          />
         </div>
       </div>
 

--- a/app/listen/src/pages/Settings.tsx
+++ b/app/listen/src/pages/Settings.tsx
@@ -1693,7 +1693,7 @@ function ShowsLocationSection() {
               />
             )}
             {showDropdown && searchResults.length > 0 && (
-              <div className="absolute inset-x-0 top-full z-50 mt-1 overflow-hidden rounded-xl border border-white/10 bg-[#1a1a2e] shadow-xl">
+              <div className="absolute inset-x-0 top-full z-app-dropdown mt-1 overflow-hidden rounded-xl border border-white/10 bg-[#1a1a2e] shadow-xl">
                 {searchResults.map((result) => (
                   <button
                     key={`${result.latitude}-${result.longitude}`}

--- a/app/listen/src/pages/Stats.tsx
+++ b/app/listen/src/pages/Stats.tsx
@@ -971,7 +971,7 @@ function PulseConstellation({ points }: { points: StatsTrendPoint[] }) {
 
               <div
                 className={cn(
-                  "pointer-events-none absolute bottom-full z-50 mb-3 w-64 -translate-x-1/2 rounded-2xl border border-white/10 bg-[#0d0f15]/95 p-3 text-left opacity-0 shadow-2xl shadow-black/45 backdrop-blur transition group-hover:opacity-100 group-focus-within:opacity-100",
+                  "pointer-events-none absolute bottom-full z-app-popover mb-3 w-64 -translate-x-1/2 rounded-2xl border border-white/10 bg-[#0d0f15]/95 p-3 text-left opacity-0 shadow-2xl shadow-black/45 backdrop-blur transition group-hover:opacity-100 group-focus-within:opacity-100",
                   index < 2
                     ? "left-0 translate-x-0"
                     : index > coordinates.length - 3

--- a/app/shared/ui/primitives/AppModal.test.tsx
+++ b/app/shared/ui/primitives/AppModal.test.tsx
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import {
   AppModal,
@@ -37,6 +37,19 @@ describe("AppModal", () => {
       </AppModal>,
     );
     await userEvent.click(screen.getByRole("dialog"));
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("dismisses on pointer down and ignores the follow-up click", () => {
+    const onClose = vi.fn();
+    render(
+      <AppModal open onClose={onClose}>
+        Content
+      </AppModal>,
+    );
+    const overlay = screen.getByRole("dialog");
+    fireEvent.pointerDown(overlay);
+    fireEvent.click(overlay);
     expect(onClose).toHaveBeenCalledTimes(1);
   });
 

--- a/app/shared/ui/primitives/AppModal.test.tsx
+++ b/app/shared/ui/primitives/AppModal.test.tsx
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { fireEvent, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import {
@@ -8,6 +8,11 @@ import {
   ModalFooter,
   ModalCloseButton,
 } from "./AppModal";
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+});
 
 describe("AppModal", () => {
   it("renders nothing when closed", () => {
@@ -27,6 +32,20 @@ describe("AppModal", () => {
     );
     expect(screen.getByRole("dialog")).toBeInTheDocument();
     expect(screen.getByText("Content")).toBeInTheDocument();
+  });
+
+  it("portals the overlay to document.body", () => {
+    const { container } = render(
+      <div className="stacking-context">
+        <AppModal open onClose={() => {}}>
+          Portal content
+        </AppModal>
+      </div>,
+    );
+
+    const dialog = screen.getByRole("dialog");
+    expect(container).not.toContainElement(dialog);
+    expect(document.body).toContainElement(dialog);
   });
 
   it("calls onClose when overlay is clicked", async () => {
@@ -50,6 +69,67 @@ describe("AppModal", () => {
     const overlay = screen.getByRole("dialog");
     fireEvent.pointerDown(overlay);
     fireEvent.click(overlay);
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("snaps back when dragged less than half the sheet height", () => {
+    const onClose = vi.fn();
+    render(
+      <AppModal open onClose={onClose} mobileSafeArea>
+        Content
+      </AppModal>,
+    );
+    const dialog = screen.getByRole("dialog");
+    const panel = dialog.querySelector("[tabindex='-1']") as HTMLElement;
+    const handle = dialog.querySelector(".touch-pan-y") as HTMLElement;
+    vi.spyOn(panel, "getBoundingClientRect").mockReturnValue({
+      bottom: 240,
+      height: 200,
+      left: 0,
+      right: 320,
+      top: 40,
+      width: 320,
+      x: 0,
+      y: 40,
+      toJSON: () => {},
+    });
+
+    fireEvent.touchStart(handle, { touches: [{ clientY: 0 }] });
+    fireEvent.touchMove(panel, { touches: [{ clientY: 80 }] });
+    fireEvent.touchEnd(panel);
+
+    expect(onClose).not.toHaveBeenCalled();
+    expect(panel.style.transform).toBe("");
+  });
+
+  it("dismisses after dragging more than half the sheet height", () => {
+    vi.useFakeTimers();
+    const onClose = vi.fn();
+    render(
+      <AppModal open onClose={onClose} mobileSafeArea>
+        Content
+      </AppModal>,
+    );
+    const dialog = screen.getByRole("dialog");
+    const panel = dialog.querySelector("[tabindex='-1']") as HTMLElement;
+    const handle = dialog.querySelector(".touch-pan-y") as HTMLElement;
+    vi.spyOn(panel, "getBoundingClientRect").mockReturnValue({
+      bottom: 240,
+      height: 200,
+      left: 0,
+      right: 320,
+      top: 40,
+      width: 320,
+      x: 0,
+      y: 40,
+      toJSON: () => {},
+    });
+
+    fireEvent.touchStart(handle, { touches: [{ clientY: 0 }] });
+    fireEvent.touchMove(panel, { touches: [{ clientY: 140 }] });
+    fireEvent.touchEnd(panel);
+    vi.advanceTimersByTime(180);
+
     expect(onClose).toHaveBeenCalledTimes(1);
   });
 

--- a/app/shared/ui/primitives/AppModal.tsx
+++ b/app/shared/ui/primitives/AppModal.tsx
@@ -8,6 +8,7 @@ import {
   type PointerEvent as ReactPointerEvent,
   type ReactNode,
 } from "react";
+import { createPortal } from "react-dom";
 import { X } from "lucide-react";
 
 import { cn } from "@crate/ui/lib/cn";
@@ -128,26 +129,69 @@ export function AppModal({
   }, [open]);
 
   // Swipe-to-dismiss (mobile bottom sheet — drag handle only)
+  const [isDragging, setIsDragging] = useState(false);
+  const [isDragClosing, setIsDragClosing] = useState(false);
   const [swipeY, setSwipeY] = useState(0);
+  const swipeYRef = useRef(0);
   const swipeStartRef = useRef<number | null>(null);
   const dragHandleRef = useRef<HTMLDivElement>(null);
-  const onSwipeStart = useCallback((e: React.TouchEvent) => {
-    if (!dragHandleRef.current) return;
-    const handleRect = dragHandleRef.current.getBoundingClientRect();
-    const touchY = e.touches[0]!.clientY;
-    if (touchY > handleRect.bottom + 8) return;
-    swipeStartRef.current = touchY;
+  const dragCloseTimerRef = useRef<number | null>(null);
+  const setDragOffset = useCallback((offset: number) => {
+    swipeYRef.current = offset;
+    setSwipeY(offset);
   }, []);
-  const onSwipeMove = useCallback((e: React.TouchEvent) => {
-    if (swipeStartRef.current === null) return;
-    const dy = e.touches[0]!.clientY - swipeStartRef.current;
-    setSwipeY(dy > 0 ? Math.min(dy * 0.6, 300) : 0);
+  const getPanelHeight = useCallback(() => {
+    const height = panelRef.current?.getBoundingClientRect().height ?? 0;
+    return height > 0 ? height : 240;
   }, []);
+  const requestDragClose = useCallback(() => {
+    if (isDragClosing) return;
+    setIsDragging(false);
+    setIsDragClosing(true);
+    setDragOffset(getPanelHeight() + 24);
+    dragCloseTimerRef.current = window.setTimeout(() => {
+      onClose();
+    }, 180);
+  }, [getPanelHeight, isDragClosing, onClose, setDragOffset]);
+  const onSwipeStart = useCallback(
+    (e: React.TouchEvent) => {
+      if (!dragHandleRef.current) return;
+      const handleRect = dragHandleRef.current.getBoundingClientRect();
+      const touchY = e.touches[0]!.clientY;
+      if (touchY > handleRect.bottom + 8) return;
+      e.stopPropagation();
+      swipeStartRef.current = touchY;
+      setIsDragging(true);
+      setDragOffset(0);
+    },
+    [setDragOffset],
+  );
+  const onSwipeMove = useCallback(
+    (e: React.TouchEvent) => {
+      if (swipeStartRef.current === null) return;
+      e.preventDefault();
+      e.stopPropagation();
+      const dy = e.touches[0]!.clientY - swipeStartRef.current;
+      setDragOffset(dy > 0 ? Math.min(dy, getPanelHeight() + 24) : 0);
+    },
+    [getPanelHeight, setDragOffset],
+  );
   const onSwipeEnd = useCallback(() => {
-    if (swipeY > 80) onClose();
-    setSwipeY(0);
+    if (swipeStartRef.current === null) return;
+    const shouldDismiss = swipeYRef.current >= getPanelHeight() / 2;
     swipeStartRef.current = null;
-  }, [swipeY, onClose]);
+    if (shouldDismiss) {
+      requestDragClose();
+      return;
+    }
+    setIsDragging(false);
+    setDragOffset(0);
+  }, [getPanelHeight, requestDragClose, setDragOffset]);
+  const onSwipeCancel = useCallback(() => {
+    setIsDragging(false);
+    setDragOffset(0);
+    swipeStartRef.current = null;
+  }, [setDragOffset]);
   const isDismissedRef = useRef(false);
   const handleOverlayPointerDown = useCallback(
     (event: ReactPointerEvent<HTMLDivElement>) => {
@@ -176,9 +220,26 @@ export function AppModal({
     [closeOnOverlay, onClose],
   );
 
+  useEffect(() => {
+    if (open) {
+      setIsDragging(false);
+      setIsDragClosing(false);
+      setDragOffset(0);
+      return;
+    }
+  }, [open, setDragOffset]);
+
+  useEffect(() => {
+    return () => {
+      if (dragCloseTimerRef.current != null) {
+        window.clearTimeout(dragCloseTimerRef.current);
+      }
+    };
+  }, []);
+
   if (!open) return null;
 
-  return (
+  return createPortal(
     <div
       role="dialog"
       aria-modal="true"
@@ -193,7 +254,8 @@ export function AppModal({
         ref={panelRef}
         tabIndex={-1}
         className={cn(
-          "bg-modal-surface w-full overflow-hidden rounded-t-3xl border border-white/10 shadow-2xl animate-sheet-up sm:rounded-3xl sm:animate-pop-in",
+          "bg-modal-surface w-full overflow-hidden rounded-t-3xl border border-white/10 shadow-2xl sm:rounded-3xl",
+          isDragClosing ? "" : "animate-sheet-up sm:animate-pop-in",
           mobileSafeArea
             ? "max-h-[calc(var(--listen-viewport-height)-var(--listen-safe-top)-0.75rem)] pb-[var(--listen-safe-bottom)] sm:max-h-[92vh] sm:pb-0"
             : "max-h-[92vh]",
@@ -202,7 +264,9 @@ export function AppModal({
         )}
         style={{
           transform: swipeY > 0 ? `translateY(${swipeY}px)` : undefined,
-          transition: swipeY > 0 ? "none" : undefined,
+          transition: isDragging
+            ? "none"
+            : "transform 220ms cubic-bezier(0.22, 1, 0.36, 1)",
         }}
         onClick={(event) => event.stopPropagation()}
         onPointerDown={(event) => {
@@ -212,6 +276,7 @@ export function AppModal({
         onTouchStart={onSwipeStart}
         onTouchMove={onSwipeMove}
         onTouchEnd={onSwipeEnd}
+        onTouchCancel={onSwipeCancel}
       >
         {/* Drag handle — visible on mobile only */}
         <div
@@ -225,7 +290,8 @@ export function AppModal({
         </div>
         {children}
       </div>
-    </div>
+    </div>,
+    document.body,
   );
 }
 

--- a/app/shared/ui/primitives/AppModal.tsx
+++ b/app/shared/ui/primitives/AppModal.tsx
@@ -4,6 +4,8 @@ import {
   useRef,
   useState,
   type HTMLAttributes,
+  type MouseEvent as ReactMouseEvent,
+  type PointerEvent as ReactPointerEvent,
   type ReactNode,
 } from "react";
 import { X } from "lucide-react";
@@ -146,6 +148,33 @@ export function AppModal({
     setSwipeY(0);
     swipeStartRef.current = null;
   }, [swipeY, onClose]);
+  const isDismissedRef = useRef(false);
+  const handleOverlayPointerDown = useCallback(
+    (event: ReactPointerEvent<HTMLDivElement>) => {
+      if (!closeOnOverlay) return;
+      event.preventDefault();
+      event.stopPropagation();
+      isDismissedRef.current = true;
+      onClose();
+    },
+    [closeOnOverlay, onClose],
+  );
+
+  const handleOverlayClick = useCallback(
+    (event: ReactMouseEvent<HTMLDivElement>) => {
+      if (!closeOnOverlay) return;
+      if (isDismissedRef.current) {
+        isDismissedRef.current = false;
+        event.preventDefault();
+        event.stopPropagation();
+        return;
+      }
+      event.preventDefault();
+      event.stopPropagation();
+      onClose();
+    },
+    [closeOnOverlay, onClose],
+  );
 
   if (!open) return null;
 
@@ -157,9 +186,8 @@ export function AppModal({
         "z-app-modal fixed inset-0 flex items-end justify-center bg-black/72 p-0 backdrop-blur-md animate-fade-in sm:items-center sm:p-6",
         overlayClassName,
       )}
-      onClick={() => {
-        if (closeOnOverlay) onClose();
-      }}
+      onClick={handleOverlayClick}
+      onPointerDown={handleOverlayPointerDown}
     >
       <div
         ref={panelRef}
@@ -177,6 +205,10 @@ export function AppModal({
           transition: swipeY > 0 ? "none" : undefined,
         }}
         onClick={(event) => event.stopPropagation()}
+        onPointerDown={(event) => {
+          isDismissedRef.current = false;
+          event.stopPropagation();
+        }}
         onTouchStart={onSwipeStart}
         onTouchMove={onSwipeMove}
         onTouchEnd={onSwipeEnd}

--- a/app/shared/ui/primitives/AppPopover.tsx
+++ b/app/shared/ui/primitives/AppPopover.tsx
@@ -9,10 +9,11 @@ import { cn } from "@crate/ui/lib/cn";
 export const APP_FLOATING_SURFACE_BASE =
   "rounded-md border border-[var(--idle-border)] bg-popover-surface shadow-[0_24px_64px_rgba(0,0,0,0.42)] backdrop-blur-xl animate-pop-in";
 export const APP_POPOVER_SURFACE = `z-app-popover ${APP_FLOATING_SURFACE_BASE}`;
+export const APP_CONTEXT_MENU_SURFACE = `z-app-context-menu ${APP_FLOATING_SURFACE_BASE}`;
 export const APP_DROPDOWN_SURFACE = `z-app-dropdown ${APP_FLOATING_SURFACE_BASE}`;
 
 interface AppPopoverProps extends ComponentPropsWithoutRef<"div"> {
-  layer?: "popover" | "dropdown";
+  layer?: "popover" | "dropdown" | "context";
 }
 
 export const AppPopover = forwardRef<HTMLDivElement, AppPopoverProps>(
@@ -21,7 +22,11 @@ export const AppPopover = forwardRef<HTMLDivElement, AppPopoverProps>(
       <div
         ref={ref}
         className={cn(
-          layer === "dropdown" ? APP_DROPDOWN_SURFACE : APP_POPOVER_SURFACE,
+          layer === "dropdown"
+            ? APP_DROPDOWN_SURFACE
+            : layer === "context"
+              ? APP_CONTEXT_MENU_SURFACE
+              : APP_POPOVER_SURFACE,
           className,
         )}
         {...props}

--- a/app/shared/ui/primitives/ImageLightbox.tsx
+++ b/app/shared/ui/primitives/ImageLightbox.tsx
@@ -61,7 +61,7 @@ export function ImageLightbox({ src, alt, children }: ImageLightboxProps) {
             }
             close();
           }}
-          className="fixed inset-0 z-50 flex items-center justify-center bg-black/80 animate-in fade-in duration-200"
+          className="fixed inset-0 z-app-modal flex items-center justify-center bg-black/80 animate-in fade-in duration-200"
         >
           <img
             src={src}

--- a/app/shared/ui/primitives/ImageLightbox.tsx
+++ b/app/shared/ui/primitives/ImageLightbox.tsx
@@ -1,4 +1,12 @@
-import { useState, useEffect, useCallback } from "react";
+import {
+  useCallback,
+  useEffect,
+  useRef,
+  type MouseEvent as ReactMouseEvent,
+  type PointerEvent as ReactPointerEvent,
+  useState,
+  type TouchEvent as ReactTouchEvent,
+} from "react";
 
 interface ImageLightboxProps {
   src: string;
@@ -8,6 +16,21 @@ interface ImageLightboxProps {
 
 export function ImageLightbox({ src, alt, children }: ImageLightboxProps) {
   const [open, setOpen] = useState(false);
+  const isDismissedRef = useRef(false);
+  const handleOverlayPointerDown = (
+    event: ReactPointerEvent<HTMLDivElement>,
+  ) => {
+    event.preventDefault();
+    event.stopPropagation();
+    isDismissedRef.current = true;
+    close();
+  };
+  const handleOverlayTouchStart = (event: ReactTouchEvent<HTMLDivElement>) => {
+    event.preventDefault();
+    event.stopPropagation();
+    isDismissedRef.current = true;
+    close();
+  };
 
   const close = useCallback(() => setOpen(false), []);
 
@@ -27,7 +50,17 @@ export function ImageLightbox({ src, alt, children }: ImageLightboxProps) {
       </div>
       {open && (
         <div
-          onClick={close}
+          onPointerDown={handleOverlayPointerDown}
+          onTouchStart={handleOverlayTouchStart}
+          onClick={(event: ReactMouseEvent<HTMLDivElement>) => {
+            if (isDismissedRef.current) {
+              isDismissedRef.current = false;
+              event.preventDefault();
+              event.stopPropagation();
+              return;
+            }
+            close();
+          }}
           className="fixed inset-0 z-50 flex items-center justify-center bg-black/80 animate-in fade-in duration-200"
         >
           <img

--- a/app/shared/ui/shadcn/alert-dialog.tsx
+++ b/app/shared/ui/shadcn/alert-dialog.tsx
@@ -34,7 +34,7 @@ function AlertDialogOverlay({
     <AlertDialogPrimitive.Overlay
       data-slot="alert-dialog-overlay"
       className={cn(
-        "fixed inset-0 z-50 bg-black/50 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:animate-in data-[state=open]:fade-in-0",
+        "fixed inset-0 z-app-modal bg-black/50 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:animate-in data-[state=open]:fade-in-0",
         className,
       )}
       {...props}
@@ -56,7 +56,7 @@ function AlertDialogContent({
         data-slot="alert-dialog-content"
         data-size={size}
         className={cn(
-          "group/alert-dialog-content fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-md border bg-background p-6 shadow-lg duration-200 data-[size=sm]:max-w-xs data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95 data-[size=default]:sm:max-w-lg",
+          "group/alert-dialog-content fixed top-[50%] left-[50%] z-app-modal grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-md border bg-background p-6 shadow-lg duration-200 data-[size=sm]:max-w-xs data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95 data-[size=default]:sm:max-w-lg",
           className,
         )}
         {...props}

--- a/app/shared/ui/shadcn/context-menu.tsx
+++ b/app/shared/ui/shadcn/context-menu.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import { ContextMenu as ContextMenuPrimitive } from "radix-ui";
 
-import { APP_DROPDOWN_SURFACE } from "../primitives/AppPopover";
+import { APP_CONTEXT_MENU_SURFACE } from "../primitives/AppPopover";
 import { cn } from "@crate/ui/lib/cn";
 
 function ContextMenu({
@@ -27,7 +27,7 @@ function ContextMenuContent({
       <ContextMenuPrimitive.Content
         data-slot="context-menu-content"
         className={cn(
-          `${APP_DROPDOWN_SURFACE} max-h-[var(--radix-context-menu-content-available-height)] min-w-[11rem] overflow-x-hidden overflow-y-auto p-1 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95`,
+          `${APP_CONTEXT_MENU_SURFACE} max-h-[var(--radix-context-menu-content-available-height)] min-w-[11rem] overflow-x-hidden overflow-y-auto p-1 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95`,
           className,
         )}
         {...props}

--- a/app/shared/ui/shadcn/tooltip.tsx
+++ b/app/shared/ui/shadcn/tooltip.tsx
@@ -40,7 +40,7 @@ function TooltipContent({
         data-slot="tooltip-content"
         sideOffset={sideOffset}
         className={cn(
-          "z-50 w-fit origin-(--radix-tooltip-content-transform-origin) animate-in rounded-md bg-foreground px-3 py-1.5 text-xs text-balance text-background fade-in-0 zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95",
+          "z-app-popover w-fit origin-(--radix-tooltip-content-transform-origin) animate-in rounded-md bg-foreground px-3 py-1.5 text-xs text-balance text-background fade-in-0 zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95",
           className,
         )}
         {...props}

--- a/app/shared/ui/tokens/animations.css
+++ b/app/shared/ui/tokens/animations.css
@@ -67,6 +67,9 @@
 .animate-sheet-up {
   animation: sheetUp 0.3s cubic-bezier(0.32, 0.72, 0, 1) forwards;
 }
+.animate-sheet-down {
+  animation: sheetDown 0.18s cubic-bezier(0.22, 1, 0.36, 1) forwards;
+}
 
 /* Fade / slide */
 @keyframes fadeIn {
@@ -75,6 +78,14 @@
   }
   to {
     opacity: 1;
+  }
+}
+@keyframes fadeOut {
+  from {
+    opacity: 1;
+  }
+  to {
+    opacity: 0;
   }
 }
 @keyframes fadeSlideUp {
@@ -89,6 +100,9 @@
 }
 .animate-fade-in {
   animation: fadeIn 0.18s ease-out forwards;
+}
+.animate-fade-out {
+  animation: fadeOut 0.14s ease-in forwards;
 }
 .animate-fade-slide-up {
   animation: fadeSlideUp 0.2s ease-out forwards;

--- a/app/shared/ui/tokens/z-index.css
+++ b/app/shared/ui/tokens/z-index.css
@@ -10,6 +10,7 @@
   --z-player: 1350;
   --z-popover: 1400;
   --z-player-overlay: 1410;
+  --z-context-menu: 1520;
   --z-dropdown: 1450;
   --z-modal: 1500;
   --z-upcoming-overlay: 1510;
@@ -35,6 +36,9 @@
 }
 .z-app-popover {
   z-index: var(--z-popover);
+}
+.z-app-context-menu {
+  z-index: var(--z-context-menu);
 }
 .z-app-player-overlay {
   z-index: var(--z-player-overlay);

--- a/app/shared/ui/tokens/z-index.css
+++ b/app/shared/ui/tokens/z-index.css
@@ -8,12 +8,12 @@
   --z-extended-player: 1200;
   --z-fullscreen-player: 1420;
   --z-player: 1350;
-  --z-popover: 1400;
-  --z-player-overlay: 1410;
-  --z-context-menu: 1520;
-  --z-dropdown: 1450;
-  --z-modal: 1500;
-  --z-upcoming-overlay: 1510;
+  --z-popover: 2200;
+  --z-player-overlay: 2210;
+  --z-context-menu: 2300;
+  --z-dropdown: 2250;
+  --z-modal: 2400;
+  --z-upcoming-overlay: 2350;
 }
 
 .z-app-header {

--- a/app/tests/test_browse_pre_release_album.py
+++ b/app/tests/test_browse_pre_release_album.py
@@ -1,8 +1,11 @@
 from typing import Any, cast
 
 from crate.api import browse_artist
-from crate.api.browse_album import _pre_release_album_payload
-from crate.api.browse_album import api_album_by_artist_slug
+from crate.api.browse_album import (
+    _pre_release_album_payload,
+    api_album_by_artist_slug,
+    api_album_by_id,
+)
 import crate.db.releases as release_queries
 
 
@@ -117,6 +120,32 @@ def test_album_slug_route_prefers_pre_release_payload_over_local_partial_album(
 
     assert payload == {"id": -91, "is_pre_release": True}
     assert called_local_album is False
+
+
+def test_api_album_by_id_routes_negative_id_to_pre_release_payload(monkeypatch):
+    monkeypatch.setattr(
+        "crate.api.browse_album.get_library_artist_by_slug",
+        lambda _slug: {"id": 7, "slug": "converge", "name": "Converge"},
+    )
+    monkeypatch.setattr(
+        "crate.api.browse_album.get_release_by_virtual_album_id",
+        lambda _album_id: {
+            "id": 91,
+            "artist_name": "Converge",
+            "album_title": "Hum Of Hurt",
+        },
+    )
+    monkeypatch.setattr(
+        "crate.api.browse_album._pre_release_album_payload",
+        lambda _request, _artist, _release: {
+            "id": -91,
+            "is_pre_release": True,
+        },
+    )
+
+    payload = api_album_by_id(cast(Any, object()), -91)
+
+    assert payload == {"id": -91, "is_pre_release": True}
 
 
 def test_find_upcoming_release_matches_artist_prefixed_album_slug(monkeypatch):

--- a/app/ui/src/components/ui/image-lightbox.tsx
+++ b/app/ui/src/components/ui/image-lightbox.tsx
@@ -28,7 +28,7 @@ export function ImageLightbox({ src, alt, children }: ImageLightboxProps) {
       {open && (
         <div
           onClick={close}
-          className="fixed inset-0 z-50 flex items-center justify-center bg-black/80 animate-in fade-in duration-200"
+          className="fixed inset-0 z-app-modal flex items-center justify-center bg-black/80 animate-in fade-in duration-200"
         >
           <img
             src={src}

--- a/app/ui/src/pages/Shows.tsx
+++ b/app/ui/src/pages/Shows.tsx
@@ -394,7 +394,7 @@ export function Shows() {
       {/* Detail overlay */}
       {selectedShow && (
         <div
-          className="fixed inset-0 z-50 flex items-center justify-center bg-black/70"
+          className="fixed inset-0 z-app-modal flex items-center justify-center bg-black/70"
           onClick={() => setSelectedShow(null)}
         >
           <div onClick={(e) => e.stopPropagation()}>


### PR DESCRIPTION
## Summary
- Homogeneous action menu/header treatment across track, album, and artist cards.
- Fixed z-index/overlay behavior for mobile context menus so they no longer stay behind PlayerBar/top bars.
- Added shared track action header component and applied it in relevant menus.
- Improved AppModal/AppPopover/Lightbox interactions and close behavior.
- Updated fullscreen player/queue popovers and queue UI layering.
- Restyled modal/backdrop behavior and z-index tuning in shared UI tokens.
- Updated topbar search model to avoid stale/duplicated actions and keep UX consistent.
- Added/updated TopBarSearch test.

## Verification
- npm run --workspace=app/shared/ui test
- npm run --workspace=app/shared/ui typecheck
- npm run --workspace=app/listen test -- src/components/layout/topbar/TopBarSearch.test.tsx
- npm run --workspace=app/listen typecheck