### PR TITLE
Refine Listen discovery, radio and playlist UX

### DIFF
--- a/app/crate/api/radio.py
+++ b/app/crate/api/radio.py
@@ -9,7 +9,10 @@ from crate.api.openapi_responses import (
     error_response,
     merge_responses,
 )
-from crate.api.schemas.radio import RadioResponse
+from crate.api.schemas.radio import (
+    PersonalizedRadioStationsResponse,
+    RadioResponse,
+)
 from crate.bliss import (
     generate_album_radio,
     generate_artist_radio,
@@ -29,6 +32,7 @@ from crate.db.queries.radio import (
     get_album_for_radio,
     get_playlist_for_radio,
 )
+from crate.db.queries.radio_stations import get_user_radio_stations
 
 router = APIRouter(tags=["radio"])
 
@@ -88,6 +92,21 @@ def _resolve_track_path(
 
 
 _RADIO_CACHE_TTL = 300  # 5 minutes
+
+
+@router.get(
+    "/api/radio/stations",
+    response_model=PersonalizedRadioStationsResponse,
+    response_model_exclude_none=True,
+    responses=AUTH_ERROR_RESPONSES,
+    summary="Get personalized radio station seeds",
+)
+def api_radio_stations(request: Request):
+    user = _require_auth(request)
+    user_id = user.get("id")
+    if user_id is None:
+        raise HTTPException(status_code=401, detail="Authentication required")
+    return get_user_radio_stations(int(user_id))
 
 
 def api_artist_radio(

--- a/app/crate/api/schemas/browse.py
+++ b/app/crate/api/schemas/browse.py
@@ -15,6 +15,7 @@ class BrowseGenreFilterOptionResponse(BaseModel):
     model_config = ConfigDict(extra="allow")
 
     name: str
+    slug: str | None = None
     cnt: int | None = None
     count: int | None = None
     description: str | None = None

--- a/app/crate/api/schemas/genres.py
+++ b/app/crate/api/schemas/genres.py
@@ -14,6 +14,8 @@ class GenreArtistRef(BaseModel):
     artist_id: int | None = None
     artist_slug: str | None = None
     weight: float | None = None
+    membership_score: float | None = None
+    membership_tier: str | None = None
     source: str | None = None
     album_count: int | None = None
     track_count: int | None = None
@@ -35,6 +37,9 @@ class GenreAlbumRef(BaseModel):
     track_count: int | None = None
     has_cover: bool | int | None = None
     weight: float | None = None
+    membership_score: float | None = None
+    membership_tier: str | None = None
+    direct_genre_match: bool | None = None
 
 
 class GenreShowRef(BaseModel):
@@ -71,6 +76,25 @@ class GenreShowRef(BaseModel):
     distance_km: float | None = None
 
 
+class GenreRelatedRef(BaseModel):
+    model_config = ConfigDict(extra="allow")
+
+    slug: str
+    name: str
+    page_slug: str | None = None
+    relation_type: str
+    relation_label: str
+    description: str | None = None
+    artist_count: int = 0
+    album_count: int = 0
+    content_score: int = 0
+    cover_url: str | None = None
+    top_artist_id: int | None = None
+    top_artist_slug: str | None = None
+    top_artist_name: str | None = None
+    top_artist_photo_url: str | None = None
+
+
 class GenreSummaryResponse(IdentityFieldsMixin):
     model_config = ConfigDict(extra="allow")
 
@@ -103,6 +127,7 @@ class GenreDetailResponse(GenreSummaryResponse):
     artists: list[GenreArtistRef] = Field(default_factory=list)
     albums: list[GenreAlbumRef] = Field(default_factory=list)
     shows: list[GenreShowRef] = Field(default_factory=list)
+    related_genres: list[GenreRelatedRef] = Field(default_factory=list)
 
 
 class GenreGraphNode(BaseModel):

--- a/app/crate/api/schemas/radio.py
+++ b/app/crate/api/schemas/radio.py
@@ -53,3 +53,29 @@ class RadioSession(BaseModel):
 class RadioResponse(BaseModel):
     session: RadioSession
     tracks: list[RadioTrack]
+
+
+class PersonalizedRadioStation(BaseModel):
+    model_config = ConfigDict(extra="allow")
+
+    type: str
+    seed_type: str
+    seed_value: str
+    seed_label: str
+    seed_subtitle: str | None = None
+    title: str
+    subtitle: str = ""
+    play_count: int = 0
+    minutes_listened: int = 0
+    artist_id: int | None = None
+    artist_entity_uid: str | None = None
+    artist_slug: str | None = None
+    artist_name: str | None = None
+    genre_slug: str | None = None
+    genre_name: str | None = None
+    cover_url: str | None = None
+
+
+class PersonalizedRadioStationsResponse(BaseModel):
+    artist_stations: list[PersonalizedRadioStation]
+    genre_stations: list[PersonalizedRadioStation]

--- a/app/crate/db/queries/bliss_artist_similarity.py
+++ b/app/crate/db/queries/bliss_artist_similarity.py
@@ -8,6 +8,10 @@ from crate.db.queries.bliss_shared import (
     bliss_session_scope,
     normalize_similarity_score,
 )
+from crate.db.queries.playable_media_filters import (
+    playable_media_params,
+    playable_track_clause,
+)
 
 
 def get_similar_artist_rows(
@@ -198,7 +202,7 @@ def get_artist_tracks(session=None, artist_id: int | None = None) -> list[dict]:
         result = (
             active_session.execute(
                 text(
-                    """
+                    f"""
                 SELECT
                     t.id AS track_id,
                     t.path,
@@ -220,10 +224,11 @@ def get_artist_tracks(session=None, artist_id: int | None = None) -> list[dict]:
                 JOIN library_albums a ON t.album_id = a.id
                 JOIN library_artists ar ON LOWER(a.artist) = LOWER(ar.name)
                 WHERE ar.id = :artist_id
+                  AND {playable_track_clause("t", "a")}
                 ORDER BY COALESCE(t.lastfm_playcount, 0) DESC, t.id
                 """
                 ),
-                {"artist_id": artist_id},
+                {"artist_id": artist_id, **playable_media_params()},
             )
             .mappings()
             .all()

--- a/app/crate/db/queries/bliss_radio_candidates.py
+++ b/app/crate/db/queries/bliss_radio_candidates.py
@@ -3,6 +3,10 @@ from __future__ import annotations
 from sqlalchemy import text
 
 from crate.db.queries.bliss_shared import bliss_session_scope
+from crate.db.queries.playable_media_filters import (
+    playable_media_params,
+    playable_track_clause,
+)
 
 
 def get_similar_artist_tracks_for_radio(
@@ -16,7 +20,7 @@ def get_similar_artist_tracks_for_radio(
         result = (
             active_session.execute(
                 text(
-                    """
+                    f"""
                 WITH ranked AS (
                     SELECT
                         t.id AS track_id,
@@ -43,6 +47,7 @@ def get_similar_artist_tracks_for_radio(
                     FROM library_tracks t
                     JOIN library_albums a ON t.album_id = a.id
                     WHERE t.bliss_vector IS NOT NULL
+                      AND {playable_track_clause("t", "a")}
                       AND LOWER(a.artist) = ANY(:similar_artist_keys)
                 )
                 SELECT *
@@ -51,7 +56,11 @@ def get_similar_artist_tracks_for_radio(
                 LIMIT :limit
                 """
                 ),
-                {"similar_artist_keys": similar_artist_keys[:16], "limit": limit},
+                {
+                    "similar_artist_keys": similar_artist_keys[:16],
+                    "limit": limit,
+                    **playable_media_params(),
+                },
             )
             .mappings()
             .all()
@@ -66,16 +75,17 @@ def get_album_tracks_for_radio(session=None, album_id: int | None = None) -> lis
         result = (
             active_session.execute(
                 text(
-                    """
+                    f"""
                 SELECT t.id AS track_id, t.path, t.title, t.artist, a.artist AS album_artist, a.name AS album, a.year, t.duration,
                        t.bliss_vector, t.bpm, t.audio_key, t.audio_scale, t.energy, t.danceability, t.valence, t.rating
                 FROM library_tracks t
                 JOIN library_albums a ON t.album_id = a.id
                 WHERE a.id = :album_id
+                  AND {playable_track_clause("t", "a")}
                 ORDER BY t.disc_number, t.track_number
                 """
                 ),
-                {"album_id": album_id},
+                {"album_id": album_id, **playable_media_params()},
             )
             .mappings()
             .all()
@@ -92,7 +102,7 @@ def get_playlist_tracks_for_radio(
         result = (
             active_session.execute(
                 text(
-                    """
+                    f"""
                 SELECT
                     lt.id AS track_id,
                     lt.path,
@@ -138,10 +148,11 @@ def get_playlist_tracks_for_radio(
                   ON lt.id = pt.resolved_track_id
                  AND (lt.entity_uid IS NOT NULL OR lt.storage_id IS NOT NULL)
                 LEFT JOIN library_albums la ON la.id = lt.album_id
+                WHERE {playable_track_clause("lt", "la")}
                 ORDER BY pt.position
                 """
                 ),
-                {"playlist_id": playlist_id},
+                {"playlist_id": playlist_id, **playable_media_params()},
             )
             .mappings()
             .all()

--- a/app/crate/db/queries/bliss_similarity_candidates.py
+++ b/app/crate/db/queries/bliss_similarity_candidates.py
@@ -4,6 +4,10 @@ from sqlalchemy import text
 
 from crate.db.bliss_vectors import to_pgvector_literal
 from crate.db.queries.bliss_shared import bliss_session_scope
+from crate.db.queries.playable_media_filters import (
+    playable_media_params,
+    playable_track_clause,
+)
 
 
 def get_bliss_candidates(
@@ -19,7 +23,7 @@ def get_bliss_candidates(
         result = (
             active_session.execute(
                 text(
-                    """
+                    f"""
                 SELECT t.id AS track_id, t.path, t.title, t.artist, a.artist AS album_artist, a.name AS album, a.year, t.duration,
                        t.bliss_vector, t.bpm, t.audio_key, t.audio_scale, t.energy,
                        t.danceability, t.valence, t.rating,
@@ -27,6 +31,7 @@ def get_bliss_candidates(
                 FROM library_tracks t
                 JOIN library_albums a ON t.album_id = a.id
                 WHERE t.bliss_embedding IS NOT NULL AND t.path != :exclude_path
+                  AND {playable_track_clause("t", "a")}
                 ORDER BY bliss_dist ASC
                 LIMIT :limit
                 """
@@ -35,6 +40,7 @@ def get_bliss_candidates(
                     "probe_vector": probe_vector,
                     "exclude_path": exclude_path,
                     "limit": limit,
+                    **playable_media_params(),
                 },
             )
             .mappings()
@@ -56,7 +62,7 @@ def get_recommend_without_bliss_candidates(
         result = (
             active_session.execute(
                 text(
-                    """
+                    f"""
                 WITH ranked AS (
                     SELECT
                         t.id AS track_id,
@@ -82,6 +88,7 @@ def get_recommend_without_bliss_candidates(
                     FROM library_tracks t
                     JOIN library_albums a ON t.album_id = a.id
                     WHERE t.path <> ALL(:seed_paths)
+                      AND {playable_track_clause("t", "a")}
                       AND (
                         LOWER(a.artist) = ANY(:similar_artist_names)
                         OR t.bpm IS NOT NULL
@@ -101,6 +108,7 @@ def get_recommend_without_bliss_candidates(
                     "similar_artist_names": similar_artist_names or ["__no_similar__"],
                     "artist_pick_limit": artist_pick_limit,
                     "row_limit": row_limit,
+                    **playable_media_params(),
                 },
             )
             .mappings()
@@ -121,13 +129,16 @@ def get_multi_seed_bliss_candidates(
         result = (
             active_session.execute(
                 text(
-                    """
+                    f"""
                 WITH seeds AS (
                     SELECT
                         t.path AS seed_path,
                         t.bliss_embedding AS seed_bliss_embedding
                     FROM library_tracks t
-                    WHERE t.path = ANY(:bliss_seed_paths) AND t.bliss_embedding IS NOT NULL
+                    JOIN library_albums a ON t.album_id = a.id
+                    WHERE t.path = ANY(:bliss_seed_paths)
+                      AND t.bliss_embedding IS NOT NULL
+                      AND {playable_track_clause("t", "a")}
                 ),
                 ranked AS (
                     SELECT
@@ -158,6 +169,7 @@ def get_multi_seed_bliss_candidates(
                      AND t.path <> s.seed_path
                      AND t.path <> ALL(:all_seed_paths)
                     JOIN library_albums a ON t.album_id = a.id
+                    WHERE {playable_track_clause("t", "a")}
                 )
                 SELECT *
                 FROM ranked
@@ -168,6 +180,7 @@ def get_multi_seed_bliss_candidates(
                     "bliss_seed_paths": bliss_seed_paths,
                     "all_seed_paths": all_seed_paths,
                     "per_seed_limit": per_seed_limit,
+                    **playable_media_params(),
                 },
             )
             .mappings()

--- a/app/crate/db/queries/bliss_track_lookup.py
+++ b/app/crate/db/queries/bliss_track_lookup.py
@@ -3,6 +3,10 @@ from __future__ import annotations
 from sqlalchemy import text
 
 from crate.db.queries.bliss_shared import bliss_session_scope
+from crate.db.queries.playable_media_filters import (
+    playable_media_params,
+    playable_track_clause,
+)
 
 
 def get_track_with_artist(session=None, track_path: str = "") -> dict | None:
@@ -12,7 +16,7 @@ def get_track_with_artist(session=None, track_path: str = "") -> dict | None:
         row = (
             active_session.execute(
                 text(
-                    """
+                    f"""
                 SELECT t.id AS track_id, t.path, t.title, t.artist, a.artist AS album_artist, a.name AS album, a.year, t.duration,
                        t.bliss_vector, t.bpm, t.audio_key, t.audio_scale, t.energy,
                        t.danceability, t.valence, t.rating,
@@ -21,9 +25,10 @@ def get_track_with_artist(session=None, track_path: str = "") -> dict | None:
                 JOIN library_albums a ON t.album_id = a.id
                 LEFT JOIN library_artists ar ON LOWER(a.artist) = LOWER(ar.name)
                 WHERE t.path = :track_path
+                  AND {playable_track_clause("t", "a")}
                 """
                 ),
-                {"track_path": track_path},
+                {"track_path": track_path, **playable_media_params()},
             )
             .mappings()
             .first()
@@ -44,7 +49,7 @@ def get_same_artist_tracks(
             result = (
                 active_session.execute(
                     text(
-                        """
+                        f"""
                     SELECT
                         t.id AS track_id,
                         t.path,
@@ -64,7 +69,9 @@ def get_same_artist_tracks(
                     FROM library_tracks t
                     JOIN library_albums a ON t.album_id = a.id
                     JOIN library_artists ar ON LOWER(a.artist) = LOWER(ar.name)
-                    WHERE ar.id = :artist_id AND t.path != :exclude_path
+                    WHERE ar.id = :artist_id
+                      AND t.path != :exclude_path
+                      AND {playable_track_clause("t", "a")}
                     ORDER BY COALESCE(t.lastfm_playcount, 0) DESC, t.id
                     LIMIT :limit
                     """
@@ -73,6 +80,7 @@ def get_same_artist_tracks(
                         "artist_id": artist_id,
                         "exclude_path": exclude_path,
                         "limit": limit,
+                        **playable_media_params(),
                     },
                 )
                 .mappings()
@@ -82,7 +90,7 @@ def get_same_artist_tracks(
             result = (
                 active_session.execute(
                     text(
-                        """
+                        f"""
                     SELECT
                         t.id AS track_id,
                         t.path,
@@ -101,7 +109,9 @@ def get_same_artist_tracks(
                         t.valence
                     FROM library_tracks t
                     JOIN library_albums a ON t.album_id = a.id
-                    WHERE LOWER(a.artist) = LOWER(:artist_name) AND t.path != :exclude_path
+                    WHERE LOWER(a.artist) = LOWER(:artist_name)
+                      AND t.path != :exclude_path
+                      AND {playable_track_clause("t", "a")}
                     ORDER BY COALESCE(t.lastfm_playcount, 0) DESC, t.id
                     LIMIT :limit
                     """
@@ -110,6 +120,7 @@ def get_same_artist_tracks(
                         "artist_name": artist_name,
                         "exclude_path": exclude_path,
                         "limit": limit,
+                        **playable_media_params(),
                     },
                 )
                 .mappings()
@@ -127,7 +138,7 @@ def get_seed_tracks_by_paths(
         result = (
             active_session.execute(
                 text(
-                    """
+                    f"""
                 SELECT
                     t.id AS track_id,
                     t.path,
@@ -148,9 +159,10 @@ def get_seed_tracks_by_paths(
                 FROM library_tracks t
                 JOIN library_albums a ON t.album_id = a.id
                 WHERE t.path = ANY(:seed_paths)
+                  AND {playable_track_clause("t", "a")}
                 """
                 ),
-                {"seed_paths": seed_paths},
+                {"seed_paths": seed_paths, **playable_media_params()},
             )
             .mappings()
             .all()

--- a/app/crate/db/queries/browse_artist_filters.py
+++ b/app/crate/db/queries/browse_artist_filters.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from sqlalchemy import text
 
 from crate.db.tx import read_scope
+from crate.genre_taxonomy import resolve_genre_slug, slugify_genre
 
 MIN_GENRE_MEMBERSHIP_SCORE = 0.45
 
@@ -122,10 +123,17 @@ def get_browse_filter_genres(
         for row in rows:
             item = dict(row)
             top_artists = item.get("top_artists") or []
+            genre_name = str(item["name"])
+            genre_slug = (
+                item.get("genre_slug")
+                or item.get("slug")
+                or resolve_genre_slug(genre_name)
+                or slugify_genre(genre_name)
+            )
             items.append(
                 {
-                    "name": item["name"],
-                    "slug": item["genre_slug"],
+                    "name": genre_name,
+                    "slug": genre_slug,
                     "cnt": item["cnt"],
                     "count": item["cnt"],
                     "description": item.get("description"),

--- a/app/crate/db/queries/browse_artist_filters.py
+++ b/app/crate/db/queries/browse_artist_filters.py
@@ -4,12 +4,16 @@ from sqlalchemy import text
 
 from crate.db.tx import read_scope
 
+MIN_GENRE_MEMBERSHIP_SCORE = 0.45
+
 
 def get_browse_filter_genres(
     country: str = "", decade: str = "", format: str = ""
 ) -> list[dict]:
     where_clauses = ["1=1"]
-    params: dict[str, str | int] = {}
+    params: dict[str, str | int | float] = {
+        "min_membership_score": MIN_GENRE_MEMBERSHIP_SCORE
+    }
 
     if country:
         where_clauses.append("{artist_alias}.country = :country")
@@ -47,6 +51,7 @@ def get_browse_filter_genres(
                     f"""
                 SELECT
                     g.name,
+                    g.slug AS genre_slug,
                     COUNT(DISTINCT la.name) AS cnt,
                     COALESCE(
                         NULLIF(tn.description, ''),
@@ -67,20 +72,23 @@ def get_browse_filter_genres(
                 LEFT JOIN genre_taxonomy_nodes tn ON tn.id = gta.genre_id
                 LEFT JOIN LATERAL (
                     SELECT
-                        ARRAY_AGG(ranked.name ORDER BY ranked.listeners_sort DESC, ranked.playcount_sort DESC, ranked.album_count_sort DESC, ranked.name ASC) AS top_artists,
-                        (ARRAY_AGG(ranked.id ORDER BY ranked.listeners_sort DESC, ranked.playcount_sort DESC, ranked.album_count_sort DESC, ranked.name ASC))[1] AS top_artist_id
+                        ARRAY_AGG(ranked.name ORDER BY ranked.weight_sort DESC, ranked.listeners_sort DESC, ranked.playcount_sort DESC, ranked.album_count_sort DESC, ranked.name ASC) AS top_artists,
+                        (ARRAY_AGG(ranked.id ORDER BY ranked.weight_sort DESC, ranked.listeners_sort DESC, ranked.playcount_sort DESC, ranked.album_count_sort DESC, ranked.name ASC))[1] AS top_artist_id
                     FROM (
                         SELECT
                             la2.id,
                             la2.name,
                             COALESCE(la2.listeners, 0) AS listeners_sort,
                             COALESCE(la2.lastfm_playcount, 0) AS playcount_sort,
-                            COALESCE(la2.album_count, 0) AS album_count_sort
+                            COALESCE(la2.album_count, 0) AS album_count_sort,
+                            COALESCE(ag2.weight, 0) AS weight_sort
                         FROM library_artists la2
                         JOIN artist_genres ag2 ON la2.name = ag2.artist_name
                         WHERE ag2.genre_id = g.id
+                          AND COALESCE(ag2.weight, 0) >= :min_membership_score
                           AND {top_artist_where_sql}
                         ORDER BY
+                            COALESCE(ag2.weight, 0) DESC,
                             COALESCE(la2.listeners, 0) DESC,
                             COALESCE(la2.lastfm_playcount, 0) DESC,
                             COALESCE(la2.album_count, 0) DESC,
@@ -89,9 +97,11 @@ def get_browse_filter_genres(
                     ) ranked
                 ) top_artists ON TRUE
                 WHERE {where_sql}
+                  AND COALESCE(ag.weight, 0) >= :min_membership_score
                 GROUP BY
                     g.id,
                     g.name,
+                    g.slug,
                     tn.slug,
                     tn.description,
                     tn.external_description,
@@ -115,6 +125,7 @@ def get_browse_filter_genres(
             items.append(
                 {
                     "name": item["name"],
+                    "slug": item["genre_slug"],
                     "cnt": item["cnt"],
                     "count": item["cnt"],
                     "description": item.get("description"),

--- a/app/crate/db/queries/genres_library_detail.py
+++ b/app/crate/db/queries/genres_library_detail.py
@@ -2,8 +2,33 @@ from __future__ import annotations
 
 from sqlalchemy import text
 
-from crate.db.queries.genres_shared import get_genre_summary_by_slug
+from crate.db.queries.genres_shared import (
+    get_genre_summary_by_slug,
+    get_taxonomy_node_stats,
+)
 from crate.db.tx import read_scope
+from crate.genre_taxonomy import get_genre_catalog, resolve_genre_slug
+
+MIN_GENRE_MEMBERSHIP_SCORE = 0.45
+ARTIST_ALBUM_FALLBACK_FACTOR = 0.70
+RELATED_GENRE_LIMIT = 24
+
+_RELATION_LABELS = {
+    "child": "Subgenre",
+    "sibling": "Sibling",
+    "related": "Related",
+    "influenced_by": "Influenced by",
+    "influences": "Influences",
+    "fusion": "Fusion",
+}
+_RELATION_PRIORITY = {
+    "child": 60,
+    "related": 50,
+    "sibling": 40,
+    "influenced_by": 30,
+    "influences": 20,
+    "fusion": 10,
+}
 
 
 def _genre_target_cte() -> str:
@@ -11,17 +36,121 @@ def _genre_target_cte() -> str:
         WITH target_genres AS (
             SELECT :genre_id AS id
         ),
-        ranked_artist_genres AS (
+        artist_memberships AS (
             SELECT
-                ag.*,
-                ROW_NUMBER() OVER (
-                    PARTITION BY ag.artist_name
-                    ORDER BY ag.weight DESC NULLS LAST, g.name ASC
-                ) AS genre_rank
+                ag.artist_name,
+                ag.genre_id,
+                ag.weight::DOUBLE PRECISION AS weight,
+                ag.weight::DOUBLE PRECISION AS membership_score,
+                CASE
+                    WHEN ag.weight >= 0.90 THEN 'core'
+                    WHEN ag.weight >= 0.70 THEN 'strong'
+                    WHEN ag.weight >= :min_membership_score THEN 'adjacent'
+                    ELSE 'weak'
+                END AS membership_tier,
+                ag.source
             FROM artist_genres ag
-            JOIN genres g ON g.id = ag.genre_id
+            WHERE ag.genre_id IN (SELECT id FROM target_genres)
         )
     """
+
+
+def _related_genre_candidates(canonical_slug: str) -> dict[str, str]:
+    catalog = get_genre_catalog()
+    meta = catalog.get(canonical_slug)
+    if not meta:
+        return {}
+
+    candidates: dict[str, str] = {}
+
+    def add(slug: str, relation_type: str) -> None:
+        if not slug or slug == canonical_slug or slug not in catalog:
+            return
+        current = candidates.get(slug)
+        if (
+            current is None
+            or _RELATION_PRIORITY[relation_type] > _RELATION_PRIORITY[current]
+        ):
+            candidates[slug] = relation_type
+
+    for slug, item in catalog.items():
+        parents = item.get("parents", [])
+        if canonical_slug in parents:
+            add(slug, "child")
+
+    parent_slugs = set(meta.get("parents", []))
+    if parent_slugs:
+        for slug, item in catalog.items():
+            if slug != canonical_slug and parent_slugs.intersection(
+                item.get("parents", [])
+            ):
+                add(slug, "sibling")
+
+    for slug in meta.get("related", []):
+        add(slug, "related")
+
+    for slug in meta.get("influenced_by", []):
+        add(slug, "influenced_by")
+
+    for slug, item in catalog.items():
+        if canonical_slug in item.get("influenced_by", []):
+            add(slug, "influences")
+        if canonical_slug in item.get("fusion_of", []):
+            add(slug, "fusion")
+
+    return candidates
+
+
+def _build_related_genres(session, slug: str | None) -> list[dict]:
+    canonical_slug = resolve_genre_slug(slug or "")
+    if not canonical_slug:
+        return []
+
+    relation_by_slug = _related_genre_candidates(canonical_slug)
+    if not relation_by_slug:
+        return []
+
+    stats = get_taxonomy_node_stats(session, list(relation_by_slug))
+    items: list[dict] = []
+    for related_slug, relation_type in relation_by_slug.items():
+        item = stats.get(related_slug, {})
+        artist_count = int(item.get("artist_count") or 0)
+        album_count = int(item.get("album_count") or 0)
+        content_score = artist_count * 3 + album_count
+        if content_score <= 0:
+            continue
+        page_slug = item.get("page_slug") or related_slug
+        items.append(
+            {
+                "slug": related_slug,
+                "name": item.get("page_name") or item.get("name") or related_slug,
+                "page_slug": page_slug,
+                "relation_type": relation_type,
+                "relation_label": _RELATION_LABELS[relation_type],
+                "description": item.get("description")
+                or item.get("external_description")
+                or "",
+                "artist_count": artist_count,
+                "album_count": album_count,
+                "content_score": content_score,
+                "cover_url": item.get("cover_url"),
+                "top_artist_id": item.get("top_artist_id"),
+                "top_artist_slug": item.get("top_artist_slug"),
+                "top_artist_name": item.get("top_artist_name"),
+                "top_artist_photo_url": item.get("top_artist_photo_url"),
+            }
+        )
+
+    items.sort(
+        key=lambda item: (
+            -item["content_score"],
+            -_RELATION_PRIORITY.get(item["relation_type"], 0),
+            -item["artist_count"],
+            -item["album_count"],
+            item["name"],
+        )
+    )
+    return items[:RELATED_GENRE_LIMIT]
 
 
 def get_genre_detail(slug: str) -> dict | None:
@@ -49,19 +178,30 @@ def get_genre_detail(slug: str) -> dict | None:
                     la.track_count,
                     la.has_photo,
                     la.spotify_popularity,
-                    la.listeners
-                FROM ranked_artist_genres ag
+                    la.listeners,
+                    ag.membership_score,
+                    ag.membership_tier
+                FROM artist_memberships ag
                 JOIN library_artists la ON ag.artist_name = la.name
-                WHERE ag.genre_rank = 1
-                  AND ag.genre_id IN (SELECT id FROM target_genres)
+                WHERE ag.membership_score >= :min_membership_score
                 ORDER BY
+                    CASE ag.membership_tier
+                        WHEN 'core' THEN 3
+                        WHEN 'strong' THEN 2
+                        WHEN 'adjacent' THEN 1
+                        ELSE 0
+                    END DESC,
+                    ag.weight DESC NULLS LAST,
                     la.listeners DESC NULLS LAST,
                     la.spotify_popularity DESC NULLS LAST,
                     la.album_count DESC NULLS LAST,
                     ag.artist_name ASC
                 """
                 ),
-                {"genre_id": genre["id"]},
+                {
+                    "genre_id": genre["id"],
+                    "min_membership_score": MIN_GENRE_MEMBERSHIP_SCORE,
+                },
             )
             .mappings()
             .all()
@@ -74,41 +214,82 @@ def get_genre_detail(slug: str) -> dict | None:
                     _genre_target_cte()
                     + """
                 ,
-                primary_artists AS (
-                    SELECT artist_name, weight
-                    FROM ranked_artist_genres
-                    WHERE genre_rank = 1
-                      AND genre_id IN (SELECT id FROM target_genres)
-                ),
                 album_genre_weights AS (
                     SELECT album_id, MAX(weight) AS weight
                     FROM album_genres
                     WHERE genre_id IN (SELECT id FROM target_genres)
                     GROUP BY album_id
+                ),
+                album_memberships AS (
+                    SELECT
+                        a.id AS album_id,
+                        a.slug AS album_slug,
+                        a.artist,
+                        ar.id AS artist_id,
+                        ar.slug AS artist_slug,
+                        a.name,
+                        a.year,
+                        a.track_count,
+                        a.has_cover,
+                        a.popularity,
+                        a.lastfm_playcount,
+                        ar.listeners,
+                        ar.spotify_popularity,
+                        GREATEST(
+                            COALESCE(alg.weight, 0.0),
+                            COALESCE(pa.membership_score, 0.0) * :artist_album_fallback_factor
+                        )::DOUBLE PRECISION AS membership_score,
+                        (alg.album_id IS NOT NULL) AS direct_genre_match
+                    FROM library_albums a
+                    LEFT JOIN artist_memberships pa ON pa.artist_name = a.artist
+                    LEFT JOIN library_artists ar ON ar.name = a.artist
+                    LEFT JOIN album_genre_weights alg ON alg.album_id = a.id
+                    WHERE alg.album_id IS NOT NULL
+                       OR pa.membership_score >= :min_membership_score
                 )
                 SELECT
-                    a.id AS album_id,
-                    a.slug AS album_slug,
-                    a.artist,
-                    ar.id AS artist_id,
-                    ar.slug AS artist_slug,
-                    a.name,
-                    a.year,
-                    a.track_count,
-                    a.has_cover,
-                    COALESCE(alg.weight, pa.weight, 0.5) AS weight
-                FROM library_albums a
-                JOIN primary_artists pa ON pa.artist_name = a.artist
-                LEFT JOIN library_artists ar ON ar.name = a.artist
-                LEFT JOIN album_genre_weights alg ON alg.album_id = a.id
+                    album_id,
+                    album_slug,
+                    artist,
+                    artist_id,
+                    artist_slug,
+                    name,
+                    year,
+                    track_count,
+                    has_cover,
+                    membership_score AS weight,
+                    membership_score,
+                    CASE
+                        WHEN membership_score >= 0.90 THEN 'core'
+                        WHEN membership_score >= 0.70 THEN 'strong'
+                        WHEN membership_score >= :min_membership_score THEN 'adjacent'
+                        ELSE 'weak'
+                    END AS membership_tier,
+                    direct_genre_match
+                FROM album_memberships
+                WHERE membership_score >= :min_membership_score
                 ORDER BY
-                    ar.listeners DESC NULLS LAST,
-                    ar.spotify_popularity DESC NULLS LAST,
-                    a.year DESC NULLS LAST,
-                    a.name ASC
+                    CASE
+                        WHEN membership_score >= 0.90 THEN 3
+                        WHEN membership_score >= 0.70 THEN 2
+                        WHEN membership_score >= :min_membership_score THEN 1
+                        ELSE 0
+                    END DESC,
+                    direct_genre_match DESC,
+                    membership_score DESC NULLS LAST,
+                    COALESCE(popularity, 0) DESC NULLS LAST,
+                    COALESCE(lastfm_playcount, 0) DESC NULLS LAST,
+                    listeners DESC NULLS LAST,
+                    spotify_popularity DESC NULLS LAST,
+                    year DESC NULLS LAST,
+                    name ASC
                 """
                 ),
-                {"genre_id": genre["id"]},
+                {
+                    "genre_id": genre["id"],
+                    "min_membership_score": MIN_GENRE_MEMBERSHIP_SCORE,
+                    "artist_album_fallback_factor": ARTIST_ALBUM_FALLBACK_FACTOR,
+                },
             )
             .mappings()
             .all()
@@ -118,6 +299,10 @@ def get_genre_detail(slug: str) -> dict | None:
         genre["album_count"] = len(genre["albums"])
         genre["track_count"] = sum(
             int(album.get("track_count") or 0) for album in genre["albums"]
+        )
+        genre["related_genres"] = _build_related_genres(
+            session,
+            genre.get("canonical_slug") or genre.get("slug"),
         )
 
         return genre
@@ -143,11 +328,10 @@ def get_genre_upcoming_shows(
                     _genre_target_cte()
                     + """
                 ,
-                primary_artists AS (
-                    SELECT artist_name, weight
-                    FROM ranked_artist_genres
-                    WHERE genre_rank = 1
-                      AND genre_id IN (SELECT id FROM target_genres)
+                genre_artists AS (
+                    SELECT artist_name, membership_score
+                    FROM artist_memberships
+                    WHERE membership_score >= :min_membership_score
                 ),
                 candidate_shows AS (
                     SELECT
@@ -176,7 +360,7 @@ def get_genre_upcoming_shows(
                             LIMIT 3
                         ) AS artist_genres
                     FROM shows s
-                    JOIN primary_artists pa ON pa.artist_name = s.artist_name
+                    JOIN genre_artists pa ON pa.artist_name = s.artist_name
                     LEFT JOIN library_artists la ON la.name = s.artist_name
                     WHERE s.date >= CURRENT_DATE
                       AND COALESCE(s.status, '') != 'cancelled'
@@ -220,6 +404,7 @@ def get_genre_upcoming_shows(
                 ),
                 {
                     "genre_id": genre["id"],
+                    "min_membership_score": MIN_GENRE_MEMBERSHIP_SCORE,
                     "lat": latitude,
                     "lon": longitude,
                     "lat_min": latitude - delta,

--- a/app/crate/db/queries/genres_shared.py
+++ b/app/crate/db/queries/genres_shared.py
@@ -11,6 +11,10 @@ from crate.genre_taxonomy import (
 )
 
 
+def _artist_photo_public_url(artist_id: int) -> str:
+    return f"/api/artists/{artist_id}/photo?size=640&format=webp"
+
+
 def invalid_genre_taxonomy_reason(slug: str) -> str | None:
     normalized = (slug or "").strip().lower()
     if not normalized:
@@ -161,6 +165,7 @@ def get_taxonomy_node_stats(session, slugs: list[str]) -> dict[str, dict]:
                 n.name,
                 n.description,
                 n.external_description,
+                n.cover_path,
                 n.is_top_level,
                 COUNT(DISTINCT ag.artist_name)::INTEGER AS artist_count,
                 COUNT(DISTINCT alg.album_id)::INTEGER AS album_count
@@ -170,7 +175,7 @@ def get_taxonomy_node_stats(session, slugs: list[str]) -> dict[str, dict]:
             LEFT JOIN artist_genres ag ON ag.genre_id = g.id
             LEFT JOIN album_genres alg ON alg.genre_id = g.id
             WHERE n.slug = ANY(:slugs)
-            GROUP BY n.id, n.slug, n.name, n.description, n.external_description, n.is_top_level
+            GROUP BY n.id, n.slug, n.name, n.description, n.external_description, n.cover_path, n.is_top_level
             """
             ),
             {"slugs": slugs},
@@ -178,7 +183,12 @@ def get_taxonomy_node_stats(session, slugs: list[str]) -> dict[str, dict]:
         .mappings()
         .all()
     )
-    stats = {row["slug"]: dict(row) for row in rows}
+    stats = {}
+    for row in rows:
+        item = dict(row)
+        cover_path = item.pop("cover_path", None)
+        item["cover_url"] = genre_cover_public_url(row["slug"]) if cover_path else None
+        stats[row["slug"]] = item
 
     rows = (
         session.execute(
@@ -220,6 +230,55 @@ def get_taxonomy_node_stats(session, slugs: list[str]) -> dict[str, dict]:
         bucket["page_slug"] = row["genre_slug"]
         bucket["page_name"] = row["genre_name"]
 
+    rows = (
+        session.execute(
+            text(
+                """
+            WITH top_artists AS (
+                SELECT
+                    n.slug AS taxonomy_slug,
+                    la.id AS artist_id,
+                    la.slug AS artist_slug,
+                    la.name AS artist_name,
+                    ag.weight,
+                    la.listeners,
+                    la.album_count
+                FROM genre_taxonomy_nodes n
+                JOIN genre_taxonomy_aliases gta ON gta.genre_id = n.id
+                JOIN genres g ON g.slug = gta.alias_slug
+                JOIN artist_genres ag ON ag.genre_id = g.id
+                JOIN library_artists la ON la.name = ag.artist_name
+                WHERE n.slug = ANY(:slugs)
+                  AND COALESCE(la.has_photo, 0) <> 0
+            )
+            SELECT DISTINCT ON (taxonomy_slug)
+                taxonomy_slug,
+                artist_id,
+                artist_slug,
+                artist_name
+            FROM top_artists
+            ORDER BY
+                taxonomy_slug,
+                weight DESC NULLS LAST,
+                listeners DESC NULLS LAST,
+                album_count DESC NULLS LAST,
+                artist_name ASC
+            """
+            ),
+            {"slugs": slugs},
+        )
+        .mappings()
+        .all()
+    )
+    for row in rows:
+        bucket = stats.get(row["taxonomy_slug"])
+        if not bucket:
+            continue
+        bucket["top_artist_id"] = row["artist_id"]
+        bucket["top_artist_slug"] = row["artist_slug"]
+        bucket["top_artist_name"] = row["artist_name"]
+        bucket["top_artist_photo_url"] = _artist_photo_public_url(row["artist_id"])
+
     for slug in slugs:
         bucket = stats.setdefault(
             slug,
@@ -231,10 +290,19 @@ def get_taxonomy_node_stats(session, slugs: list[str]) -> dict[str, dict]:
                 "is_top_level": False,
                 "artist_count": 0,
                 "album_count": 0,
+                "cover_url": None,
+                "top_artist_id": None,
+                "top_artist_slug": None,
+                "top_artist_name": None,
+                "top_artist_photo_url": None,
             },
         )
         bucket.setdefault("page_slug", None)
         bucket.setdefault("page_name", None)
+        bucket.setdefault("top_artist_id", None)
+        bucket.setdefault("top_artist_slug", None)
+        bucket.setdefault("top_artist_name", None)
+        bucket.setdefault("top_artist_photo_url", None)
     return stats
 
 

--- a/app/crate/db/queries/paths_bliss_candidate_queries.py
+++ b/app/crate/db/queries/paths_bliss_candidate_queries.py
@@ -3,6 +3,10 @@ from __future__ import annotations
 from sqlalchemy import text
 
 from crate.db.bliss_vectors import to_pgvector_literal
+from crate.db.queries.playable_media_filters import (
+    playable_media_params,
+    playable_track_clause,
+)
 from crate.db.queries.paths_shared import array_distance_sql
 from crate.db.tx import optional_scope, read_scope
 
@@ -36,7 +40,7 @@ def find_anchor_track_row(
             row = (
                 session.execute(
                     text(
-                        """
+                        f"""
                     SELECT t.id, t.entity_uid, t.title, a.artist, a.name AS album,
                            t.album_id, a.entity_uid::text AS album_entity_uid,
                            ar.entity_uid::text AS artist_entity_uid,
@@ -52,6 +56,7 @@ def find_anchor_track_row(
                         CAST(t.id AS text) = :track_ref
                         OR (t.entity_uid IS NOT NULL AND CAST(t.entity_uid AS text) = :track_ref)
                       )
+                      AND {playable_track_clause("t", "a")}
                     ORDER BY
                       CASE
                         WHEN CAST(t.id AS text) = :track_ref THEN 0
@@ -60,7 +65,7 @@ def find_anchor_track_row(
                     LIMIT 1
                     """
                     ),
-                    {"track_ref": endpoint_value},
+                    {"track_ref": endpoint_value, **playable_media_params()},
                 )
                 .mappings()
                 .first()
@@ -113,13 +118,14 @@ def find_anchor_track_row(
                 JOIN library_albums a ON a.id = t.album_id
                 LEFT JOIN library_artists ar ON ar.name = a.artist
                 WHERE t.bliss_embedding IS NOT NULL
+                AND {playable_track_clause("t", "a")}
                 {scope_clause}
                 {exclude_clause}
                 ORDER BY t.bliss_embedding <=> CAST(:probe_vector AS vector(20))
                 LIMIT 1
                 """
                 ),
-                params,
+                {**params, **playable_media_params()},
             )
             .mappings()
             .first()
@@ -143,13 +149,14 @@ def find_anchor_track_row(
                     JOIN library_albums a ON a.id = t.album_id
                     LEFT JOIN library_artists ar ON ar.name = a.artist
                     WHERE t.bliss_vector IS NOT NULL
+                    AND {playable_track_clause("t", "a")}
                     {scope_clause}
                     {exclude_clause}
                     ORDER BY {fallback_distance}
                     LIMIT 1
                     """
                     ),
-                    params,
+                    {**params, **playable_media_params()},
                 )
                 .mappings()
                 .first()
@@ -192,12 +199,13 @@ def find_candidate_rows(
                 JOIN library_albums a ON a.id = t.album_id
                 LEFT JOIN library_artists ar ON ar.name = a.artist
                 WHERE t.bliss_embedding IS NOT NULL
+                AND {playable_track_clause("t", "a")}
                 {exclude_clause}
                 ORDER BY t.bliss_embedding <=> CAST(:probe_vector AS vector(20))
                 LIMIT {int(limit)}
                 """
                 ),
-                params,
+                {**params, **playable_media_params()},
             )
             .mappings()
             .all()
@@ -221,12 +229,13 @@ def find_candidate_rows(
                     JOIN library_albums a ON a.id = t.album_id
                     LEFT JOIN library_artists ar ON ar.name = a.artist
                     WHERE t.bliss_vector IS NOT NULL
+                    AND {playable_track_clause("t", "a")}
                     {exclude_clause}
                     ORDER BY {fallback_distance}
                     LIMIT {int(limit)}
                     """
                     ),
-                    params,
+                    {**params, **playable_media_params()},
                 )
                 .mappings()
                 .all()
@@ -330,6 +339,7 @@ def find_seeded_radio_candidate_rows(
                     JOIN library_albums a ON a.id = t.album_id
                     LEFT JOIN library_artists ar ON ar.name = a.artist
                     WHERE t.bliss_vector IS NOT NULL
+                      AND {playable_track_clause("t", "a")}
                       {exclude_clause}
                       AND (
                           LOWER(a.artist) = ANY(:seed_artist_keys)
@@ -349,7 +359,7 @@ def find_seeded_radio_candidate_rows(
                 LIMIT :limit
                 """
                 ),
-                params,
+                {**params, **playable_media_params()},
             )
             .mappings()
             .all()

--- a/app/crate/db/queries/playable_media_filters.py
+++ b/app/crate/db/queries/playable_media_filters.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+
+_HIDDEN_PATH_COMPONENT_REGEX = r"(^|/)\.[^/]+(/|$)"
+
+
+def playable_album_clause(album_alias: str = "a") -> str:
+    return f"""
+        {album_alias}.quarantined_at IS NULL
+        AND COALESCE({album_alias}.path, '') !~ :hidden_path_component_regex
+        AND LOWER(COALESCE({album_alias}.artist, '')) <> '.crate-trash'
+        AND LOWER(COALESCE({album_alias}.name, '')) <> '.crate-trash'
+    """
+
+
+def playable_track_clause(
+    track_alias: str = "t",
+    album_alias: str | None = "a",
+) -> str:
+    clauses = [
+        f"COALESCE({track_alias}.path, '') !~ :hidden_path_component_regex",
+        f"LOWER(COALESCE({track_alias}.artist, '')) <> '.crate-trash'",
+        f"LOWER(COALESCE({track_alias}.album, '')) <> '.crate-trash'",
+    ]
+    if album_alias:
+        clauses.append(playable_album_clause(album_alias))
+    return "\nAND ".join(clauses)
+
+
+def playable_media_params() -> dict[str, str]:
+    return {"hidden_path_component_regex": _HIDDEN_PATH_COMPONENT_REGEX}
+
+
+__all__ = [
+    "playable_album_clause",
+    "playable_media_params",
+    "playable_track_clause",
+]

--- a/app/crate/db/queries/radio_library_queries.py
+++ b/app/crate/db/queries/radio_library_queries.py
@@ -6,6 +6,11 @@ import random
 
 from sqlalchemy import text
 
+from crate.db.queries.playable_media_filters import (
+    playable_album_clause,
+    playable_media_params,
+    playable_track_clause,
+)
 from crate.db.tx import optional_scope, read_scope
 
 
@@ -13,8 +18,17 @@ def get_track_path_by_id(track_id: int) -> str | None:
     with read_scope() as session:
         row = (
             session.execute(
-                text("SELECT path FROM library_tracks WHERE id = :track_id LIMIT 1"),
-                {"track_id": track_id},
+                text(
+                    f"""
+                    SELECT t.path
+                    FROM library_tracks t
+                    LEFT JOIN library_albums a ON a.id = t.album_id
+                    WHERE t.id = :track_id
+                      AND {playable_track_clause("t", "a")}
+                    LIMIT 1
+                    """
+                ),
+                {"track_id": track_id, **playable_media_params()},
             )
             .mappings()
             .first()
@@ -27,14 +41,16 @@ def get_track_path_by_pattern(path: str, escaped_like: str) -> str | None:
         row = (
             session.execute(
                 text(
-                    """
-                SELECT path
-                FROM library_tracks
-                WHERE path = :path
+                    f"""
+                SELECT t.path
+                FROM library_tracks t
+                LEFT JOIN library_albums a ON a.id = t.album_id
+                WHERE t.path = :path
+                  AND {playable_track_clause("t", "a")}
                 LIMIT 1
                 """
                 ),
-                {"path": path, "escaped_like": escaped_like},
+                {"path": path, "escaped_like": escaped_like, **playable_media_params()},
             )
             .mappings()
             .first()
@@ -47,14 +63,15 @@ def get_album_for_radio(album_id: int) -> dict | None:
         row = (
             session.execute(
                 text(
-                    """
+                    f"""
                 SELECT id, artist, name
-                FROM library_albums
+                FROM library_albums a
                 WHERE id = :album_id
+                  AND {playable_album_clause("a")}
                 LIMIT 1
                 """
                 ),
-                {"album_id": album_id},
+                {"album_id": album_id, **playable_media_params()},
             )
             .mappings()
             .first()
@@ -87,12 +104,15 @@ def get_random_library_seed_rows(limit: int = 30, *, session=None) -> list[dict]
         max_row = (
             s.execute(
                 text(
-                    """
-                SELECT MAX(id)::INTEGER AS max_id
-                FROM library_tracks
-                WHERE bliss_vector IS NOT NULL
+                    f"""
+                SELECT MAX(t.id)::INTEGER AS max_id
+                FROM library_tracks t
+                LEFT JOIN library_albums a ON a.id = t.album_id
+                WHERE t.bliss_vector IS NOT NULL
+                  AND {playable_track_clause("t", "a")}
                 """
-                )
+                ),
+                playable_media_params(),
             )
             .mappings()
             .first()
@@ -105,16 +125,18 @@ def get_random_library_seed_rows(limit: int = 30, *, session=None) -> list[dict]
         rows = list(
             s.execute(
                 text(
-                    """
+                    f"""
                 SELECT t.id AS track_id, t.artist, t.title, t.bliss_vector
                 FROM library_tracks t
+                LEFT JOIN library_albums a ON a.id = t.album_id
                 WHERE t.bliss_vector IS NOT NULL
+                  AND {playable_track_clause("t", "a")}
                   AND t.id >= :start_id
                 ORDER BY t.id
                 LIMIT :limit
                 """
                 ),
-                {"limit": limit, "start_id": start_id},
+                {"limit": limit, "start_id": start_id, **playable_media_params()},
             )
             .mappings()
             .all()
@@ -123,16 +145,22 @@ def get_random_library_seed_rows(limit: int = 30, *, session=None) -> list[dict]
             rows += list(
                 s.execute(
                     text(
-                        """
+                        f"""
                     SELECT t.id AS track_id, t.artist, t.title, t.bliss_vector
                     FROM library_tracks t
+                    LEFT JOIN library_albums a ON a.id = t.album_id
                     WHERE t.bliss_vector IS NOT NULL
+                      AND {playable_track_clause("t", "a")}
                       AND t.id < :start_id
                     ORDER BY t.id
                     LIMIT :remaining
                     """
                     ),
-                    {"remaining": limit - len(rows), "start_id": start_id},
+                    {
+                        "remaining": limit - len(rows),
+                        "start_id": start_id,
+                        **playable_media_params(),
+                    },
                 )
                 .mappings()
                 .all()
@@ -152,9 +180,16 @@ def get_track_bliss_vector(track_id: int, *, session=None) -> list[float] | None
         row = (
             s.execute(
                 text(
-                    "SELECT bliss_vector FROM library_tracks WHERE id = :id AND bliss_vector IS NOT NULL"
+                    f"""
+                    SELECT t.bliss_vector
+                    FROM library_tracks t
+                    LEFT JOIN library_albums a ON a.id = t.album_id
+                    WHERE t.id = :id
+                      AND t.bliss_vector IS NOT NULL
+                      AND {playable_track_clause("t", "a")}
+                    """
                 ),
-                {"id": track_id},
+                {"id": track_id, **playable_media_params()},
             )
             .mappings()
             .first()

--- a/app/crate/db/queries/radio_seed_queries.py
+++ b/app/crate/db/queries/radio_seed_queries.py
@@ -4,6 +4,10 @@ from __future__ import annotations
 
 from sqlalchemy import text
 
+from crate.db.queries.playable_media_filters import (
+    playable_media_params,
+    playable_track_clause,
+)
 from crate.db.tx import optional_scope
 from crate.track_versions import track_song_identity
 
@@ -50,32 +54,34 @@ def get_track_seed_context(
         row = (
             s.execute(
                 text(
-                    """
+                    f"""
                 SELECT
-                    id AS track_id,
-                    bliss_vector,
-                    title,
-                    artist
-                FROM library_tracks
-                WHERE bliss_vector IS NOT NULL
+                    t.id AS track_id,
+                    t.bliss_vector,
+                    t.title,
+                    t.artist
+                FROM library_tracks t
+                LEFT JOIN library_albums a ON a.id = t.album_id
+                WHERE t.bliss_vector IS NOT NULL
+                  AND {playable_track_clause("t", "a")}
                   AND (
-                    CAST(id AS text) = :track_ref
-                    OR (entity_uid IS NOT NULL AND CAST(entity_uid AS text) = :track_ref)
-                    OR (storage_id IS NOT NULL AND CAST(storage_id AS text) = :track_ref)
-                    OR path = :track_ref
+                    CAST(t.id AS text) = :track_ref
+                    OR (t.entity_uid IS NOT NULL AND CAST(t.entity_uid AS text) = :track_ref)
+                    OR (t.storage_id IS NOT NULL AND CAST(t.storage_id AS text) = :track_ref)
+                    OR t.path = :track_ref
                   )
                 ORDER BY
                   CASE
-                    WHEN CAST(id AS text) = :track_ref THEN 0
-                    WHEN entity_uid IS NOT NULL AND CAST(entity_uid AS text) = :track_ref THEN 1
-                    WHEN storage_id IS NOT NULL AND CAST(storage_id AS text) = :track_ref THEN 2
-                    WHEN path = :track_ref THEN 3
+                    WHEN CAST(t.id AS text) = :track_ref THEN 0
+                    WHEN t.entity_uid IS NOT NULL AND CAST(t.entity_uid AS text) = :track_ref THEN 1
+                    WHEN t.storage_id IS NOT NULL AND CAST(t.storage_id AS text) = :track_ref THEN 2
+                    WHEN t.path = :track_ref THEN 3
                     ELSE 4
                   END
                 LIMIT 1
                 """
                 ),
-                {"track_ref": track_ref},
+                {"track_ref": track_ref, **playable_media_params()},
             )
             .mappings()
             .first()
@@ -104,7 +110,7 @@ def get_album_seed_context(
         rows = (
             s.execute(
                 text(
-                    """
+                    f"""
                 SELECT
                     t.id AS track_id,
                     t.artist,
@@ -115,6 +121,7 @@ def get_album_seed_context(
                 FROM library_tracks t
                 JOIN library_albums a ON a.id = t.album_id
                 WHERE t.bliss_vector IS NOT NULL
+                  AND {playable_track_clause("t", "a")}
                   AND (
                     CAST(a.id AS text) = :album_ref
                     OR (a.entity_uid IS NOT NULL AND CAST(a.entity_uid AS text) = :album_ref)
@@ -122,7 +129,7 @@ def get_album_seed_context(
                 ORDER BY t.disc_number, t.track_number, t.id
                 """
                 ),
-                {"album_ref": album_ref},
+                {"album_ref": album_ref, **playable_media_params()},
             )
             .mappings()
             .all()
@@ -161,7 +168,7 @@ def get_playlist_seed_context(
         rows = (
             s.execute(
                 text(
-                    """
+                    f"""
                 SELECT lt.id AS track_id, lt.artist, lt.title, lt.bliss_vector
                 FROM (
                     SELECT
@@ -190,12 +197,14 @@ def get_playlist_seed_context(
                 JOIN library_tracks lt
                   ON lt.id = pt.resolved_track_id
                  AND (lt.entity_uid IS NOT NULL OR lt.storage_id IS NOT NULL)
+                LEFT JOIN library_albums la ON la.id = lt.album_id
                 WHERE lt.bliss_vector IS NOT NULL
+                  AND {playable_track_clause("lt", "la")}
                 ORDER BY pt.position
                 LIMIT :limit
                 """
                 ),
-                {"playlist_id": playlist_id, "limit": limit},
+                {"playlist_id": playlist_id, "limit": limit, **playable_media_params()},
             )
             .mappings()
             .all()
@@ -232,7 +241,7 @@ def _get_track_seed_contexts_batch(
         rows = (
             s.execute(
                 text(
-                    """
+                    f"""
                 SELECT ranked.id AS track_id, ranked.bliss_vector, ranked.title, ranked.artist
                 FROM (
                     SELECT
@@ -251,6 +260,7 @@ def _get_track_seed_contexts_batch(
                                 END
                         ) AS rn
                     FROM library_tracks lt
+                    LEFT JOIN library_albums la ON la.id = lt.album_id
                     JOIN unnest(:track_refs) WITH ORDINALITY AS refs(match_ref, ordinal) ON (
                         CAST(lt.id AS text) = refs.match_ref
                         OR (lt.entity_uid IS NOT NULL AND CAST(lt.entity_uid AS text) = refs.match_ref)
@@ -258,6 +268,7 @@ def _get_track_seed_contexts_batch(
                         OR lt.path = refs.match_ref
                     )
                     WHERE lt.bliss_vector IS NOT NULL
+                      AND {playable_track_clause("lt", "la")}
                       AND refs.match_ref IS NOT NULL
                       AND refs.match_ref != ''
                 ) ranked
@@ -265,7 +276,7 @@ def _get_track_seed_contexts_batch(
                 ORDER BY ordinal
                 """
                 ),
-                {"track_refs": refs},
+                {"track_refs": refs, **playable_media_params()},
             )
             .mappings()
             .all()

--- a/app/crate/db/queries/radio_stations.py
+++ b/app/crate/db/queries/radio_stations.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from decimal import Decimal
+
 from crate.db.home_context import get_cached_home_context, merged_artists_from_context
 from crate.db.queries.genres_taxonomy import get_genre_taxonomy_cover_path
 from crate.genre_covers import genre_cover_public_url
@@ -7,6 +9,10 @@ from crate.genre_taxonomy import get_genre_display_name, resolve_genre_slug
 
 
 def _int_value(value: object) -> int:
+    if value is None:
+        return 0
+    if not isinstance(value, int | float | Decimal | str):
+        return 0
     try:
         return int(value or 0)
     except (TypeError, ValueError):

--- a/app/crate/db/queries/radio_stations.py
+++ b/app/crate/db/queries/radio_stations.py
@@ -1,0 +1,132 @@
+from __future__ import annotations
+
+from crate.db.home_context import get_cached_home_context, merged_artists_from_context
+from crate.db.queries.genres_taxonomy import get_genre_taxonomy_cover_path
+from crate.genre_covers import genre_cover_public_url
+from crate.genre_taxonomy import get_genre_display_name, resolve_genre_slug
+
+
+def _int_value(value: object) -> int:
+    try:
+        return int(value or 0)
+    except (TypeError, ValueError):
+        return 0
+
+
+def _is_hidden_artist_name(value: object) -> bool:
+    artist_name = str(value or "").strip().lower()
+    return bool(artist_name) and (
+        artist_name.startswith(".") or artist_name == "crate-trash"
+    )
+
+
+def _artist_station(row: dict) -> dict | None:
+    artist_id = row.get("artist_id")
+    artist_name = (row.get("artist_name") or "").strip()
+    artist_slug = row.get("artist_slug")
+    if artist_id is None or not artist_name or _is_hidden_artist_name(artist_name):
+        return None
+    if _is_hidden_artist_name(artist_slug):
+        return None
+
+    return {
+        "type": "artist",
+        "seed_type": "artist",
+        "seed_value": str(artist_id),
+        "seed_label": artist_name,
+        "seed_subtitle": "Artist",
+        "artist_id": artist_id,
+        "artist_slug": artist_slug,
+        "artist_name": artist_name,
+        "title": f"{artist_name} Radio",
+        "subtitle": "",
+        "play_count": _int_value(row.get("play_count")),
+        "minutes_listened": _int_value(row.get("minutes_listened")),
+    }
+
+
+def _genre_station(row: dict) -> dict | None:
+    genre_name = (row.get("genre_name") or row.get("name") or "").strip()
+    if not genre_name:
+        return None
+
+    genre_slug = resolve_genre_slug(genre_name)
+    if not genre_slug:
+        return None
+
+    display_name = get_genre_display_name(genre_slug)
+    cover_url = (
+        genre_cover_public_url(genre_slug)
+        if get_genre_taxonomy_cover_path(genre_slug)
+        else None
+    )
+    return {
+        "type": "genre",
+        "seed_type": "genre",
+        "seed_value": genre_slug,
+        "seed_label": display_name,
+        "seed_subtitle": "Genre",
+        "genre_slug": genre_slug,
+        "genre_name": display_name,
+        "cover_url": cover_url,
+        "title": f"{display_name} Radio",
+        "subtitle": "",
+        "play_count": _int_value(row.get("play_count")),
+        "minutes_listened": _int_value(row.get("minutes_listened")),
+    }
+
+
+def _build_artist_stations(context: dict, *, limit: int) -> list[dict]:
+    stations: list[dict] = []
+    seen: set[int] = set()
+    for row in merged_artists_from_context(context):
+        station = _artist_station(row)
+        if not station:
+            continue
+        artist_id = station["artist_id"]
+        if artist_id in seen:
+            continue
+        seen.add(artist_id)
+        stations.append(station)
+        if len(stations) >= limit:
+            break
+    return stations
+
+
+def _build_genre_stations(context: dict, *, limit: int) -> list[dict]:
+    stations: list[dict] = []
+    seen: set[str] = set()
+    for row in context.get("top_genres") or []:
+        station = _genre_station(row)
+        if not station:
+            continue
+        genre_slug = station["genre_slug"]
+        if genre_slug in seen:
+            continue
+        seen.add(genre_slug)
+        stations.append(station)
+        if len(stations) >= limit:
+            break
+    return stations
+
+
+def build_radio_stations_from_context(
+    context: dict,
+    *,
+    artist_limit: int = 12,
+    genre_limit: int = 12,
+) -> dict:
+    return {
+        "artist_stations": _build_artist_stations(context, limit=artist_limit),
+        "genre_stations": _build_genre_stations(context, limit=genre_limit),
+    }
+
+
+def get_user_radio_stations(user_id: int) -> dict:
+    context = get_cached_home_context(
+        user_id,
+        top_artist_limit=24,
+        top_album_limit=1,
+        top_genre_limit=16,
+    )
+    return build_radio_stations_from_context(context)

--- a/app/crate/db/queries/radio_user_queries.py
+++ b/app/crate/db/queries/radio_user_queries.py
@@ -4,6 +4,11 @@ from __future__ import annotations
 
 from sqlalchemy import text
 
+from crate.db.queries.playable_media_filters import (
+    playable_album_clause,
+    playable_media_params,
+    playable_track_clause,
+)
 from crate.db.tx import optional_scope
 
 _FEEDBACK_SAMPLE_PER_ACTION = 25
@@ -20,17 +25,19 @@ def get_recent_liked_seed_rows(
         rows = (
             s.execute(
                 text(
-                    """
+                    f"""
                 SELECT t.id AS track_id, t.artist, t.title, t.bliss_vector
                 FROM user_liked_tracks lt
                 JOIN library_tracks t ON t.id = lt.track_id
+                LEFT JOIN library_albums a ON a.id = t.album_id
                 WHERE lt.user_id = :user_id
                   AND t.bliss_vector IS NOT NULL
+                  AND {playable_track_clause("t", "a")}
                 ORDER BY lt.created_at DESC
                 LIMIT :limit
                 """
                 ),
-                {"user_id": user_id, "limit": limit},
+                {"user_id": user_id, "limit": limit, **playable_media_params()},
             )
             .mappings()
             .all()
@@ -53,7 +60,7 @@ def get_followed_artist_seed_rows(
         rows = (
             s.execute(
                 text(
-                    """
+                    f"""
                 SELECT DISTINCT ON (t.id)
                     t.id AS track_id, t.artist, t.title, t.bliss_vector
                 FROM user_follows af
@@ -61,11 +68,12 @@ def get_followed_artist_seed_rows(
                 JOIN library_tracks t ON t.album_id = a.id
                 WHERE af.user_id = :user_id
                   AND t.bliss_vector IS NOT NULL
+                  AND {playable_track_clause("t", "a")}
                 ORDER BY t.id
                 LIMIT :limit
                 """
                 ),
-                {"user_id": user_id, "limit": limit},
+                {"user_id": user_id, "limit": limit, **playable_media_params()},
             )
             .mappings()
             .all()
@@ -88,16 +96,18 @@ def get_saved_album_seed_rows(
         rows = (
             s.execute(
                 text(
-                    """
+                    f"""
                 SELECT t.id AS track_id, t.artist, t.title, t.bliss_vector
                 FROM user_saved_albums sa
-                JOIN library_tracks t ON t.album_id = sa.album_id
+                JOIN library_albums a ON a.id = sa.album_id
+                JOIN library_tracks t ON t.album_id = a.id
                 WHERE sa.user_id = :user_id
                   AND t.bliss_vector IS NOT NULL
+                  AND {playable_track_clause("t", "a")}
                 LIMIT :limit
                 """
                 ),
-                {"user_id": user_id, "limit": limit},
+                {"user_id": user_id, "limit": limit, **playable_media_params()},
             )
             .mappings()
             .all()
@@ -120,19 +130,21 @@ def get_recent_play_seed_rows(
         rows = (
             s.execute(
                 text(
-                    """
+                    f"""
                 SELECT t.id AS track_id, t.artist, t.title, t.bliss_vector
                 FROM user_play_events pe
                 LEFT JOIN library_tracks t
                   ON t.id = pe.track_id
                   OR (pe.track_id IS NULL AND pe.track_entity_uid IS NOT NULL AND t.entity_uid = pe.track_entity_uid)
+                LEFT JOIN library_albums a ON a.id = t.album_id
                 WHERE pe.user_id = :user_id
                   AND t.bliss_vector IS NOT NULL
+                  AND {playable_track_clause("t", "a")}
                 ORDER BY pe.ended_at DESC
                 LIMIT :limit
                 """
                 ),
-                {"user_id": user_id, "limit": limit},
+                {"user_id": user_id, "limit": limit, **playable_media_params()},
             )
             .mappings()
             .all()
@@ -184,7 +196,7 @@ def get_discovery_seed_sources(user_id: int, *, session=None) -> dict[int, list[
         rows = (
             s.execute(
                 text(
-                    """
+                    f"""
                 WITH liked AS (
                     SELECT
                         t.id AS track_id,
@@ -194,8 +206,10 @@ def get_discovery_seed_sources(user_id: int, *, session=None) -> dict[int, list[
                         ROW_NUMBER() OVER (ORDER BY lt.created_at DESC, t.id) AS source_rank
                     FROM user_liked_tracks lt
                     JOIN library_tracks t ON t.id = lt.track_id
+                    LEFT JOIN library_albums a ON a.id = t.album_id
                     WHERE lt.user_id = :uid
                       AND t.bliss_vector IS NOT NULL
+                      AND {playable_track_clause("t", "a")}
                     ORDER BY lt.created_at DESC, t.id
                     LIMIT 10
                 ),
@@ -211,6 +225,7 @@ def get_discovery_seed_sources(user_id: int, *, session=None) -> dict[int, list[
                     JOIN library_tracks t ON t.album_id = a.id
                     WHERE af.user_id = :uid
                       AND t.bliss_vector IS NOT NULL
+                      AND {playable_track_clause("t", "a")}
                     ORDER BY t.id
                     LIMIT 30
                 ),
@@ -222,9 +237,11 @@ def get_discovery_seed_sources(user_id: int, *, session=None) -> dict[int, list[
                         t.bliss_vector,
                         ROW_NUMBER() OVER (ORDER BY sa.created_at DESC, t.id) AS source_rank
                     FROM user_saved_albums sa
-                    JOIN library_tracks t ON t.album_id = sa.album_id
+                    JOIN library_albums a ON a.id = sa.album_id
+                    JOIN library_tracks t ON t.album_id = a.id
                     WHERE sa.user_id = :uid
                       AND t.bliss_vector IS NOT NULL
+                      AND {playable_track_clause("t", "a")}
                     ORDER BY sa.created_at DESC, t.id
                     LIMIT 30
                 ),
@@ -240,8 +257,10 @@ def get_discovery_seed_sources(user_id: int, *, session=None) -> dict[int, list[
                       ON t.id = pe.track_id
                       OR (pe.track_id IS NULL AND pe.track_entity_uid IS NOT NULL
                           AND t.entity_uid = pe.track_entity_uid)
+                    LEFT JOIN library_albums a ON a.id = t.album_id
                     WHERE pe.user_id = :uid
                       AND t.bliss_vector IS NOT NULL
+                      AND {playable_track_clause("t", "a")}
                     ORDER BY pe.ended_at DESC, t.id
                     LIMIT 20
                 )
@@ -258,7 +277,7 @@ def get_discovery_seed_sources(user_id: int, *, session=None) -> dict[int, list[
                 ORDER BY priority, source_rank
                 """
                 ),
-                {"uid": user_id},
+                {"uid": user_id, **playable_media_params()},
             )
             .mappings()
             .all()
@@ -275,23 +294,27 @@ def get_discovery_excluded_artist_keys(user_id: int, *, session=None) -> list[st
         rows = (
             s.execute(
                 text(
-                    """
+                    f"""
                 WITH followed AS (
                     SELECT artist_name
                     FROM user_follows
                     WHERE user_id = :uid
+                      AND LOWER(COALESCE(artist_name, '')) <> '.crate-trash'
                 ),
                 liked AS (
                     SELECT t.artist AS artist_name
                     FROM user_liked_tracks lt
                     JOIN library_tracks t ON t.id = lt.track_id
+                    LEFT JOIN library_albums a ON a.id = t.album_id
                     WHERE lt.user_id = :uid
+                      AND {playable_track_clause("t", "a")}
                 ),
                 saved AS (
                     SELECT a.artist AS artist_name
                     FROM user_saved_albums sa
                     JOIN library_albums a ON a.id = sa.album_id
                     WHERE sa.user_id = :uid
+                      AND {playable_album_clause("a")}
                 ),
                 recent_plays AS (
                     SELECT COALESCE(NULLIF(TRIM(pe.artist), ''), t.artist) AS artist_name
@@ -300,7 +323,12 @@ def get_discovery_excluded_artist_keys(user_id: int, *, session=None) -> list[st
                       ON t.id = pe.track_id
                       OR (pe.track_id IS NULL AND pe.track_entity_uid IS NOT NULL
                           AND t.entity_uid = pe.track_entity_uid)
+                    LEFT JOIN library_albums a ON a.id = t.album_id
                     WHERE pe.user_id = :uid
+                      AND (
+                        t.id IS NULL
+                        OR {playable_track_clause("t", "a")}
+                      )
                       AND (
                         pe.ended_at IS NULL
                         OR pe.ended_at > now() - INTERVAL '180 days'
@@ -318,10 +346,12 @@ def get_discovery_excluded_artist_keys(user_id: int, *, session=None) -> list[st
                     UNION ALL
                     SELECT artist_name FROM recent_plays
                 ) known
-                WHERE artist_name IS NOT NULL AND TRIM(artist_name) != ''
+                WHERE artist_name IS NOT NULL
+                  AND TRIM(artist_name) != ''
+                  AND LOWER(TRIM(artist_name)) <> '.crate-trash'
                 """
                 ),
-                {"uid": user_id},
+                {"uid": user_id, **playable_media_params()},
             )
             .mappings()
             .all()
@@ -336,25 +366,31 @@ def load_feedback_history(
         rows = (
             s.execute(
                 text(
-                    """
+                    f"""
                 (
-                    SELECT action, bliss_vector
-                    FROM radio_feedback
-                    WHERE user_id = :user_id
-                      AND action = 'like'
-                      AND bliss_vector IS NOT NULL
-                      AND created_at > now() - (:max_age_days * INTERVAL '1 day')
+                    SELECT rf.action, rf.bliss_vector
+                    FROM radio_feedback rf
+                    JOIN library_tracks t ON t.id = rf.track_id
+                    LEFT JOIN library_albums a ON a.id = t.album_id
+                    WHERE rf.user_id = :user_id
+                      AND rf.action = 'like'
+                      AND rf.bliss_vector IS NOT NULL
+                      AND {playable_track_clause("t", "a")}
+                      AND rf.created_at > now() - (:max_age_days * INTERVAL '1 day')
                     ORDER BY random()
                     LIMIT :per_action_limit
                 )
                 UNION ALL
                 (
-                    SELECT action, bliss_vector
-                    FROM radio_feedback
-                    WHERE user_id = :user_id
-                      AND action = 'dislike'
-                      AND bliss_vector IS NOT NULL
-                      AND created_at > now() - (:max_age_days * INTERVAL '1 day')
+                    SELECT rf.action, rf.bliss_vector
+                    FROM radio_feedback rf
+                    JOIN library_tracks t ON t.id = rf.track_id
+                    LEFT JOIN library_albums a ON a.id = t.album_id
+                    WHERE rf.user_id = :user_id
+                      AND rf.action = 'dislike'
+                      AND rf.bliss_vector IS NOT NULL
+                      AND {playable_track_clause("t", "a")}
+                      AND rf.created_at > now() - (:max_age_days * INTERVAL '1 day')
                     ORDER BY random()
                     LIMIT :per_action_limit
                 )
@@ -364,6 +400,7 @@ def load_feedback_history(
                     "user_id": user_id,
                     "max_age_days": int(max_age_days),
                     "per_action_limit": _FEEDBACK_SAMPLE_PER_ACTION,
+                    **playable_media_params(),
                 },
             )
             .mappings()

--- a/app/listen/src/components/artist/ArtistHeroSection.test.tsx
+++ b/app/listen/src/components/artist/ArtistHeroSection.test.tsx
@@ -179,6 +179,55 @@ describe("ArtistHeroSection", () => {
     ).toHaveTextContent("More");
   });
 
+  it("keeps the circular artist picture in the desktop hero", () => {
+    render(
+      <MemoryRouter>
+        <ArtistHeroSection
+          artist={{
+            id: 7,
+            entity_uid: "artist-entity-7",
+            slug: "crossed",
+            name: "Crossed",
+            albums: [],
+            total_tracks: 10,
+            total_size_mb: 120,
+            primary_format: "flac",
+            genres: ["hardcore"],
+            issue_count: 0,
+          }}
+          artistInfo={{
+            bio: "",
+            tags: [],
+            similar: [],
+            listeners: 1000,
+            playcount: 2000,
+            image_url: null,
+            url: "",
+          }}
+          photoUrl="/artist.jpg"
+          tags={["hardcore"]}
+          following={false}
+          onPlay={vi.fn()}
+          onShuffle={vi.fn()}
+          onArtistRadio={vi.fn()}
+          onToggleFollow={vi.fn()}
+          onShare={vi.fn()}
+          onOpenBio={vi.fn()}
+        />
+      </MemoryRouter>,
+    );
+
+    const picture = screen.getByAltText("Crossed");
+    expect(picture).toHaveAttribute("src", "/artist.jpg");
+    expect(picture.parentElement).toHaveClass(
+      "hidden",
+      "sm:block",
+      "rounded-full",
+      "h-40",
+      "w-40",
+    );
+  });
+
   it("renders the desktop more menu outside the horizontally scrolling action row", async () => {
     render(
       <MemoryRouter>

--- a/app/listen/src/components/artist/ArtistHeroSection.tsx
+++ b/app/listen/src/components/artist/ArtistHeroSection.tsx
@@ -196,25 +196,44 @@ export function ArtistHeroSection({
         ? createPortal(mobileMenuTrigger, document.body)
         : null}
       <div className="relative h-[420px] overflow-hidden sm:h-[400px]">
+        {photoUrl ? (
+          <img
+            src={photoUrl}
+            alt=""
+            className="absolute inset-0 h-full w-full scale-[1.02] object-cover object-[right_20%] brightness-[0.72] contrast-110 opacity-[0.82] sm:hidden"
+          />
+        ) : heroBackgroundSrc ? (
+          <img
+            src={heroBackgroundSrc}
+            alt=""
+            className="absolute inset-0 h-full w-full scale-[1.02] object-cover object-[right_20%] brightness-[0.72] contrast-110 opacity-[0.82] sm:hidden"
+          />
+        ) : null}
         {heroBackgroundSrc ? (
           <img
             src={heroBackgroundSrc}
             alt=""
-            className="absolute inset-0 h-full w-full scale-[1.02] object-cover object-[right_20%] grayscale brightness-[0.5] contrast-110 opacity-[0.45]"
+            className="absolute inset-0 h-full w-full scale-[1.02] object-cover object-[right_20%] grayscale brightness-[0.5] contrast-110 opacity-[0.45] hidden sm:block"
           />
         ) : null}
-        <div className="absolute inset-0 bg-black/28" />
+        <div className="absolute inset-0 bg-black/10 sm:bg-black/32" />
         <div
-          className="absolute inset-0"
+          className="absolute inset-0 sm:hidden"
           style={{
             background:
-              "linear-gradient(to bottom, transparent 0%, rgba(8, 10, 14, 0.14) 34%, rgba(8, 10, 14, 0.46) 60%, var(--surface-app) 100%)",
+              "linear-gradient(to bottom, transparent 0%, rgba(8, 10, 14, 0.04) 34%, rgba(8, 10, 14, 0.28) 64%, var(--surface-app) 100%)",
+          }}
+        />
+        <div
+          className="absolute inset-0 hidden sm:block"
+          style={{
+            background:
+              "linear-gradient(to bottom, transparent 0%, rgba(8, 10, 14, 0.16) 34%, rgba(8, 10, 14, 0.5) 64%, var(--surface-app) 100%)",
           }}
         />
         <div className="relative mx-auto flex h-full w-full max-w-[1480px] items-end px-4 pb-6 sm:px-6">
           <div className="flex w-full flex-col gap-5 sm:flex-row sm:items-end">
-            {/* Avatar — small inline on mobile, large circle on desktop */}
-            <div className="hidden sm:block h-40 w-40 flex-shrink-0 overflow-hidden rounded-full bg-white/5 shadow-2xl ring-2 ring-white/10">
+            <div className="hidden h-40 w-40 flex-shrink-0 overflow-hidden rounded-full bg-white/5 shadow-2xl ring-2 ring-white/10 sm:block">
               <img
                 src={photoUrl}
                 alt={artist.name}
@@ -224,41 +243,11 @@ export function ArtistHeroSection({
                 }}
               />
             </div>
-
             <div className="max-w-3xl pb-1">
-              <div className="flex items-center gap-3 sm:block">
-                <div className="sm:hidden h-14 w-14 flex-shrink-0 overflow-hidden rounded-full bg-white/5 shadow-xl ring-2 ring-white/10">
-                  <img
-                    src={photoUrl}
-                    alt={artist.name}
-                    className="h-full w-full object-cover"
-                    onError={(e) => {
-                      (e.target as HTMLImageElement).style.display = "none";
-                    }}
-                  />
-                </div>
-                <div>
-                  <h1 className="mb-1 text-2xl font-bold text-foreground sm:mb-2 sm:text-4xl">
-                    {artist.name}
-                  </h1>
-                  <div className="flex flex-wrap items-center gap-2 text-xs text-muted-foreground sm:hidden">
-                    {artistInfo?.listeners ? (
-                      <span className="flex items-center gap-1">
-                        <Users size={12} />
-                        {formatCompact(artistInfo.listeners)}
-                      </span>
-                    ) : null}
-                    {artist.total_tracks > 0 ? (
-                      <span>{artist.total_tracks} tracks</span>
-                    ) : null}
-                    {artist.albums.length > 0 ? (
-                      <span>{artist.albums.length} albums</span>
-                    ) : null}
-                  </div>
-                </div>
-              </div>
-
-              <div className="hidden sm:flex flex-wrap items-center gap-3 text-sm text-muted-foreground">
+              <h1 className="mb-1 text-3xl font-bold text-foreground sm:mb-2 sm:text-4xl">
+                {artist.name}
+              </h1>
+              <div className="flex flex-wrap items-center gap-x-3 gap-y-1 text-sm text-muted-foreground">
                 {artistInfo?.listeners ? (
                   <span className="flex items-center gap-1">
                     <Users size={14} />

--- a/app/listen/src/components/explore/ExploreViews.tsx
+++ b/app/listen/src/components/explore/ExploreViews.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState, type ReactNode } from "react";
+import { useEffect, useMemo, useState, type ReactNode } from "react";
 import { createPortal } from "react-dom";
 import { useNavigate } from "react-router";
 import {
@@ -25,6 +25,7 @@ import { AlbumCard } from "@/components/cards/AlbumCard";
 import { ArtistCard } from "@/components/cards/ArtistCard";
 import { TrackRow, type TrackRowData } from "@/components/cards/TrackRow";
 import { PlaylistCard } from "@/components/playlists/PlaylistCard";
+import { CrateLoader } from "@/components/ui/CrateLoader";
 import {
   itemKey,
   UpcomingShowCard,
@@ -34,6 +35,8 @@ import { usePlayerActions } from "@/contexts/PlayerContext";
 import { useApi } from "@/hooks/use-api";
 import { api, resolveMaybeApiAssetUrl } from "@/lib/api";
 import { startShapedRadio } from "@/lib/radio";
+import { publicShareUrl } from "@/lib/share-url";
+import { openShareSheet } from "@/lib/social-share";
 
 import {
   type DecadeArtists,
@@ -42,6 +45,10 @@ import {
   type SystemPlaylist,
   loadSystemPlaylistTracks,
 } from "./explore-model";
+import { artistPhotoApiUrl } from "@/lib/library-routes";
+
+const GENRE_SECONDARY_ACTION_CLASS =
+  "flex min-h-14 min-w-[56px] shrink-0 touch-manipulation flex-col items-center justify-center gap-1 px-1.5 py-1 text-[11px] font-medium text-white/62 transition-[color,filter,transform] hover:-translate-y-px hover:text-primary hover:drop-shadow-[0_0_10px_rgba(34,211,238,0.32)] disabled:cursor-not-allowed disabled:opacity-35 disabled:hover:translate-y-0 disabled:hover:drop-shadow-none";
 
 export function ExplorePill({
   label,
@@ -212,10 +219,22 @@ export function GenreDetailView({
   );
   const genreShows = data?.shows?.slice(0, 5) ?? [];
   const nextShow = genreShows[0] ?? null;
-  const heroCoverUrl = upscaleGenreCoverUrl(
-    data?.cover_url,
-    data?.canonical_slug || data?.slug,
+  const fallbackGenreSlug = data?.canonical_slug || data?.slug;
+  const heroCoverCandidates = useMemo(
+    () =>
+      buildGenreHeroCoverCandidates(
+        data?.cover_url,
+        fallbackGenreSlug,
+        data?.artists,
+      ),
+    [data?.cover_url, fallbackGenreSlug, data?.artists],
   );
+  const heroCoverFingerprint = heroCoverCandidates.join("|");
+  const [heroCoverIndex, setHeroCoverIndex] = useState(0);
+  useEffect(() => {
+    setHeroCoverIndex(0);
+  }, [heroCoverFingerprint]);
+  const heroCoverUrl = heroCoverCandidates[heroCoverIndex] ?? null;
 
   async function handlePlayGenreRadio() {
     if (!data || startingRadio) return;
@@ -242,22 +261,15 @@ export function GenreDetailView({
     navigate(`/upcoming?${params.toString()}`);
   }
 
-  async function shareGenre() {
+  function shareGenre() {
     if (!data) return;
-    const url = `${window.location.origin}/explore?genre=${encodeURIComponent(
-      data.slug,
-    )}`;
-    const title = `${data.name} on Crate`;
-    try {
-      if (navigator.share) {
-        await navigator.share({ title, url });
-      } else {
-        await navigator.clipboard?.writeText(url);
-        toast.success("Genre link copied");
-      }
-    } catch {
-      toast.error("Could not share genre");
-    }
+    openShareSheet({
+      kind: "genre",
+      title: data.name,
+      subtitle: "Genre",
+      imageUrl: heroCoverUrl,
+      url: publicShareUrl(`/explore?genre=${encodeURIComponent(data.slug)}`),
+    });
   }
 
   const genreMenuActions = useMemo<ItemActionMenuEntry[]>(() => {
@@ -283,10 +295,10 @@ export function GenreDetailView({
         onSelect: shareGenre,
       }),
     ];
-  }, [data, nextShow, startingRadio]);
+  }, [data, heroCoverUrl, nextShow, startingRadio]);
   const genreMenu = useItemActionMenu(genreMenuActions);
 
-  if (loading) return <ExploreLoadingState />;
+  if (loading) return <CrateLoader label="Loading genre." />;
   if (!data)
     return <p className="text-sm text-muted-foreground">Genre not found.</p>;
 
@@ -302,8 +314,12 @@ export function GenreDetailView({
     data.albums.reduce((total, album) => total + (album.track_count || 0), 0);
   const visibleArtists = isDesktop ? data.artists : data.artists.slice(0, 12);
   const visibleAlbums = isDesktop ? data.albums : data.albums.slice(0, 12);
+  const visibleRelatedGenres = (data.related_genres ?? []).slice(
+    0,
+    isDesktop ? 12 : 6,
+  );
   const genreMenuTrigger =
-    typeof document !== "undefined"
+    !isDesktop && typeof document !== "undefined"
       ? createPortal(
           <div
             className="fixed z-app-header"
@@ -319,8 +335,8 @@ export function GenreDetailView({
               className="flex h-11 w-11 touch-manipulation items-center justify-center text-white/72 transition-[color,filter,transform] hover:-translate-y-px hover:text-primary hover:drop-shadow-[0_0_10px_rgba(34,211,238,0.32)]"
               onClick={genreMenu.openFromTrigger}
               onContextMenu={genreMenu.handleContextMenu}
-              aria-label="Genre actions"
-              title="Genre actions"
+              aria-label="More"
+              title="More"
             >
               <MoreHorizontal
                 data-testid="genre-mobile-hero-menu-icon"
@@ -361,7 +377,11 @@ export function GenreDetailView({
               alt={`${data.name} genre cover`}
               className="absolute inset-0 h-full w-full scale-[1.02] object-cover brightness-[0.66] contrast-110 opacity-[0.68] saturate-125"
               onError={(event) => {
-                event.currentTarget.style.display = "none";
+                if (heroCoverIndex + 1 < heroCoverCandidates.length) {
+                  setHeroCoverIndex((index) => index + 1);
+                } else {
+                  event.currentTarget.style.display = "none";
+                }
               }}
             />
           ) : null}
@@ -388,36 +408,121 @@ export function GenreDetailView({
                 <span className="text-white/20">/</span>
                 <span>{trackCount} tracks</span>
               </div>
-              <div className="mt-6 flex flex-col gap-3 sm:flex-row sm:items-center">
-                <button
-                  type="button"
-                  onClick={() => void handlePlayGenreRadio()}
-                  disabled={startingRadio}
-                  aria-label="Play genre radio"
-                  className="inline-flex h-12 items-center justify-center gap-2 rounded-full bg-primary px-7 text-sm font-bold text-black shadow-[0_0_24px_rgba(34,211,238,0.28)] transition-[filter,transform,box-shadow] hover:-translate-y-px hover:shadow-[0_0_34px_rgba(34,211,238,0.40)] disabled:cursor-wait disabled:opacity-70"
-                >
-                  {startingRadio ? (
-                    <Loader2 size={17} className="animate-spin" />
-                  ) : (
-                    <Play size={17} />
-                  )}
-                  <span>Play</span>
-                </button>
-                {nextShow ? (
-                  <button
-                    type="button"
-                    onClick={() => openGenreRadar(nextShow)}
-                    aria-label="Open next genre show in Radar"
-                    className="inline-flex h-12 items-center justify-center gap-2 rounded-full border border-white/10 bg-white/[0.08] px-7 text-sm font-bold text-white shadow-[0_16px_36px_rgba(0,0,0,0.22)] backdrop-blur-md transition-[border-color,color,filter,transform] hover:-translate-y-px hover:border-primary/35 hover:text-primary hover:drop-shadow-[0_0_10px_rgba(34,211,238,0.28)]"
-                  >
-                    <Calendar size={17} />
-                    <span>Next show</span>
-                  </button>
-                ) : null}
-              </div>
             </div>
           </div>
         </section>
+
+        <div className="px-0 py-1 sm:px-0">
+          <div className="mx-auto flex w-full max-w-[1480px] flex-col gap-5 md:flex-row md:items-center md:justify-between md:gap-6">
+            <div
+              role="group"
+              aria-label="Primary genre actions"
+              className="grid grid-cols-2 gap-3 md:flex md:shrink-0 md:items-center md:gap-3"
+            >
+              <button
+                type="button"
+                onClick={() => void handlePlayGenreRadio()}
+                disabled={startingRadio}
+                aria-label="Play genre radio"
+                className="flex h-12 shrink-0 items-center justify-center gap-2 rounded-full bg-primary px-5 text-sm font-semibold text-primary-foreground shadow-[0_0_18px_rgba(34,211,238,0.24)] transition-[background-color,box-shadow,transform] hover:-translate-y-px hover:bg-primary/90 hover:shadow-[0_0_24px_rgba(34,211,238,0.34)] disabled:cursor-wait disabled:opacity-70 md:px-7 md:text-[15px]"
+              >
+                {startingRadio ? (
+                  <Loader2 size={17} className="animate-spin" />
+                ) : (
+                  <Play size={17} fill="currentColor" />
+                )}
+                <span>Play</span>
+              </button>
+              {nextShow ? (
+                <button
+                  type="button"
+                  onClick={() => openGenreRadar(nextShow)}
+                  aria-label="Open next genre show in Radar"
+                  className="flex h-12 shrink-0 items-center justify-center gap-2 rounded-full bg-white/[0.08] px-5 text-sm font-semibold text-foreground shadow-[inset_0_0_0_1px_rgba(255,255,255,0.04)] transition-[background-color,color,filter,transform] hover:-translate-y-px hover:bg-white/[0.12] hover:text-primary hover:drop-shadow-[0_0_8px_rgba(34,211,238,0.24)] md:w-auto md:px-7"
+                >
+                  <Calendar size={17} />
+                  <span>Next show</span>
+                </button>
+              ) : null}
+            </div>
+
+            {isDesktop ? (
+              <div
+                role="group"
+                aria-label="Secondary genre actions"
+                className="ml-auto flex shrink-0 items-center gap-4"
+              >
+                <button
+                  type="button"
+                  className={GENRE_SECONDARY_ACTION_CLASS}
+                  onClick={shareGenre}
+                  aria-label="Share genre"
+                >
+                  <Share2 size={CRATE_ICON_SIZE.lg} />
+                  <span>Share</span>
+                </button>
+                <div className="relative shrink-0">
+                  <button
+                    ref={genreMenu.triggerRef}
+                    type="button"
+                    className={GENRE_SECONDARY_ACTION_CLASS}
+                    onClick={genreMenu.openFromTrigger}
+                    onContextMenu={genreMenu.handleContextMenu}
+                    aria-label="More"
+                  >
+                    <MoreHorizontal size={CRATE_ICON_SIZE.lg} />
+                    <span>More</span>
+                  </button>
+                  <ItemActionMenu
+                    actions={genreMenuActions}
+                    header={{
+                      type: "media",
+                      title: data.name,
+                      subtitle: "Genre",
+                      detail: `${artistCount} artists · ${albumCount} albums`,
+                      imageUrl: heroCoverUrl,
+                      imageAlt: data.name,
+                      imageShape: "square",
+                      fallbackIcon: Radio,
+                    }}
+                    open={genreMenu.open}
+                    position={genreMenu.position}
+                    menuRef={genreMenu.menuRef}
+                    onClose={genreMenu.close}
+                  />
+                </div>
+              </div>
+            ) : null}
+          </div>
+        </div>
+
+        {visibleRelatedGenres.length > 0 ? (
+          <section className="space-y-3">
+            <div className="flex items-end justify-between gap-3 px-1">
+              <div>
+                <h2 className="text-lg font-bold">Related scenes</h2>
+                <p className="mt-1 text-xs text-muted-foreground">
+                  Adjacent genres with the most music in your library.
+                </p>
+              </div>
+            </div>
+            <div className="grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-4 xl:grid-cols-6">
+              {visibleRelatedGenres.map((genre) => (
+                <RelatedGenreCard
+                  key={`${genre.relation_type}-${genre.slug}`}
+                  genre={genre}
+                  onOpen={() =>
+                    navigate(
+                      `/explore?genre=${encodeURIComponent(
+                        genre.page_slug || genre.slug,
+                      )}`,
+                    )
+                  }
+                />
+              ))}
+            </div>
+          </section>
+        ) : null}
 
         {genreShows.length > 0 ? (
           <section className="space-y-3">
@@ -482,6 +587,103 @@ export function GenreDetailView({
   );
 }
 
+type RelatedGenre = NonNullable<GenreDetail["related_genres"]>[number];
+
+function RelatedGenreCard({
+  genre,
+  onOpen,
+}: {
+  genre: RelatedGenre;
+  onOpen: () => void;
+}) {
+  const imageCandidates = useMemo(
+    () => buildRelatedGenreImageCandidates(genre),
+    [genre],
+  );
+  const imageFingerprint = imageCandidates.join("|");
+  const [imageIndex, setImageIndex] = useState(0);
+  useEffect(() => {
+    setImageIndex(0);
+  }, [imageFingerprint]);
+
+  const coverUrl = imageCandidates[imageIndex] ?? null;
+  const contentLabel = [
+    genre.artist_count > 0
+      ? `${genre.artist_count} artist${genre.artist_count === 1 ? "" : "s"}`
+      : null,
+    genre.album_count > 0
+      ? `${genre.album_count} album${genre.album_count === 1 ? "" : "s"}`
+      : null,
+  ]
+    .filter(Boolean)
+    .join(" · ");
+
+  return (
+    <button
+      type="button"
+      onClick={onOpen}
+      className="group relative isolate min-h-[132px] overflow-hidden rounded-lg border border-white/10 bg-white/[0.045] p-3 text-left shadow-[0_18px_46px_rgba(0,0,0,0.22)] transition-[border-color,filter,transform] hover:-translate-y-px hover:border-primary/35 hover:drop-shadow-[0_0_14px_rgba(34,211,238,0.18)]"
+    >
+      {coverUrl ? (
+        <img
+          src={coverUrl}
+          alt=""
+          className="absolute inset-0 -z-10 h-full w-full scale-[1.04] object-cover opacity-35 saturate-125 transition duration-300 group-hover:opacity-45"
+          loading="lazy"
+          onError={(event) => {
+            if (imageIndex + 1 < imageCandidates.length) {
+              setImageIndex((index) => index + 1);
+            } else {
+              event.currentTarget.style.display = "none";
+            }
+          }}
+        />
+      ) : null}
+      <div className="absolute inset-0 -z-10 bg-[linear-gradient(180deg,rgba(5,8,12,0.18)_0%,rgba(5,8,12,0.82)_100%)]" />
+      <div className="flex h-full min-h-[108px] flex-col justify-between gap-4">
+        <div>
+          <div className="text-[10px] font-semibold uppercase tracking-[0.16em] text-primary/85">
+            {genre.relation_label}
+          </div>
+          <div className="mt-2 line-clamp-2 text-sm font-semibold leading-5 text-foreground">
+            {genre.name}
+          </div>
+        </div>
+        <div className="flex items-center justify-between gap-2">
+          <span className="truncate text-[11px] text-muted-foreground">
+            {contentLabel}
+          </span>
+          <ArrowRight
+            size={14}
+            className="shrink-0 text-white/35 transition group-hover:translate-x-0.5 group-hover:text-primary"
+          />
+        </div>
+      </div>
+    </button>
+  );
+}
+
+function buildRelatedGenreImageCandidates(genre: RelatedGenre) {
+  const candidates = [
+    resolveMaybeApiAssetUrl(genre.cover_url),
+    relatedGenreCoverUrl(genre.page_slug),
+    relatedGenreCoverUrl(genre.slug),
+    resolveMaybeApiAssetUrl(genre.top_artist_photo_url),
+  ].filter((url): url is string => Boolean(url));
+
+  return [...new Set(candidates)];
+}
+
+function relatedGenreCoverUrl(slug?: string | null) {
+  const normalizedSlug = slug?.trim();
+  if (!normalizedSlug) return null;
+  return resolveMaybeApiAssetUrl(
+    `/api/genres/${encodeURIComponent(
+      normalizedSlug,
+    )}/cover?size=640&format=webp`,
+  );
+}
+
 function upscaleGenreCoverUrl(
   url?: string | null,
   fallbackSlug?: string | null,
@@ -502,6 +704,52 @@ function upscaleGenreCoverUrl(
   return `${sized}${sized.includes("?") ? "&" : "?"}hero=genre-detail-v5`;
 }
 
+function buildGenreHeroCoverCandidates(
+  url?: string | null,
+  fallbackSlug?: string | null,
+  artists?: GenreDetail["artists"],
+) {
+  const primary = upscaleGenreCoverUrl(url);
+  const fallback = fallbackSlug
+    ? upscaleGenreCoverUrl(undefined, fallbackSlug)
+    : null;
+  const fallbackArtistPhoto = buildGenreHeroArtistPhotoFallback(artists);
+
+  const candidates: string[] = [];
+
+  if (primary) candidates.push(primary);
+  if (fallback) candidates.push(fallback);
+  if (fallbackArtistPhoto) candidates.push(fallbackArtistPhoto);
+
+  return [...new Set(candidates)];
+}
+
+function buildGenreHeroArtistPhotoFallback(artists?: GenreDetail["artists"]) {
+  if (!artists?.length) return null;
+  const topArtist = artists
+    .filter((artist) => artist.artist_id != null && artist.has_photo)
+    .sort((a, b) => {
+      const aListeners = a.listeners ?? -1;
+      const bListeners = b.listeners ?? -1;
+      return bListeners - aListeners;
+    })[0];
+
+  if (!topArtist?.artist_id) return null;
+
+  const resolved = artistPhotoApiUrl(
+    {
+      artistId: topArtist.artist_id,
+    },
+    {
+      size: 1280,
+      format: "webp",
+    },
+  );
+
+  if (!resolved) return null;
+  return `${resolved}${resolved.includes("?") ? "&" : "?"}hero=genre-detail-v5`;
+}
+
 export function DecadeDetailView({
   decade,
   onBack,
@@ -513,7 +761,7 @@ export function DecadeDetailView({
     `/api/artists?decade=${decade}&limit=50`,
   );
 
-  if (loading) return <ExploreLoadingState />;
+  if (loading) return <CrateLoader label="Loading decade." />;
 
   return (
     <div className="space-y-6">
@@ -594,7 +842,7 @@ export function PlaylistCategoryView({
     }
   }
 
-  if (loading) return <ExploreLoadingState />;
+  if (loading) return <CrateLoader label="Loading playlist category." />;
 
   return (
     <div className="space-y-6">

--- a/app/listen/src/components/explore/explore-model.ts
+++ b/app/listen/src/components/explore/explore-model.ts
@@ -60,6 +60,7 @@ export interface SearchResults {
 export interface BrowseFilters {
   genres: {
     name: string;
+    slug?: string | null;
     count: number;
     description?: string | null;
     top_artists?: string[];
@@ -145,6 +146,19 @@ export interface GenreDetail {
     has_cover: boolean;
   }[];
   shows?: UpcomingItem[];
+  related_genres?: {
+    slug: string;
+    name: string;
+    page_slug?: string | null;
+    relation_type: string;
+    relation_label: string;
+    description?: string | null;
+    artist_count: number;
+    album_count: number;
+    content_score?: number;
+    cover_url?: string | null;
+    top_artist_photo_url?: string | null;
+  }[];
 }
 
 export interface DecadeArtists {

--- a/app/listen/src/components/home/HomeDiscoverySections.test.tsx
+++ b/app/listen/src/components/home/HomeDiscoverySections.test.tsx
@@ -156,6 +156,59 @@ describe("HomeTasteHero", () => {
 
     expect(onDismiss).toHaveBeenCalledWith(hero);
   });
+
+  it("hides carousel arrow buttons on mobile", () => {
+    mockMobilePointer();
+
+    renderWithListenProviders(
+      <HomeTasteHero
+        heroes={[heroFixture(), heroFixture({ id: 8, name: "Botch" })]}
+        isFollowing={() => false}
+        onOpenArtist={vi.fn()}
+        onPlay={vi.fn()}
+        onToggleFollow={vi.fn()}
+        onInfo={vi.fn()}
+      />,
+    );
+
+    expect(screen.queryByRole("button", { name: "Previous" })).toBeNull();
+    expect(screen.queryByRole("button", { name: "Next" })).toBeNull();
+  });
+
+  it("moves the mobile carousel with a natural horizontal swipe", () => {
+    mockMobilePointer();
+    vi.useFakeTimers();
+
+    try {
+      vi.setSystemTime(new Date("2026-06-18T10:00:00.000Z"));
+      renderWithListenProviders(
+        <HomeTasteHero
+          heroes={[heroFixture(), heroFixture({ id: 8, name: "Botch" })]}
+          isFollowing={() => false}
+          onOpenArtist={vi.fn()}
+          onPlay={vi.fn()}
+          onToggleFollow={vi.fn()}
+          onInfo={vi.fn()}
+        />,
+      );
+
+      const activeSlide = screen.getByRole("button", { name: /Converge/i });
+
+      fireEvent.touchStart(activeSlide, {
+        touches: [{ clientX: 240, clientY: 180 }],
+      });
+      vi.setSystemTime(new Date("2026-06-18T10:00:00.720Z"));
+      fireEvent.touchEnd(activeSlide, {
+        changedTouches: [{ clientX: 132, clientY: 194 }],
+      });
+
+      expect(
+        screen.getByRole("heading", { name: "Botch" }),
+      ).toBeInTheDocument();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
 });
 
 describe("RecentEntityRow", () => {

--- a/app/listen/src/components/home/HomeDiscoverySections.tsx
+++ b/app/listen/src/components/home/HomeDiscoverySections.tsx
@@ -48,6 +48,7 @@ import {
   artistPagePath,
   artistPhotoApiUrl,
 } from "@/lib/library-routes";
+import { resolveMaybeApiAssetUrl } from "@/lib/api";
 import { cn } from "@/lib/utils";
 
 import type {
@@ -66,6 +67,9 @@ const numberFormatter = new Intl.NumberFormat("en-US", {
   maximumFractionDigits: 1,
 });
 const HERO_BACKGROUND_VERSION = "home-hero-bg-v2";
+const HERO_SWIPE_MIN_DISTANCE_PX = 44;
+const HERO_SWIPE_MAX_DURATION_MS = 1_200;
+const HERO_SWIPE_AXIS_DOMINANCE = 1.2;
 
 function statValue(value: number): string {
   return numberFormatter.format(value || 0);
@@ -407,10 +411,11 @@ export function HomeTasteHero({
   const [idx, setIdx] = useState(0);
   const rootRef = useRef<HTMLDivElement | null>(null);
   const autoRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const touchRef = useRef<{ x: number; t: number } | null>(null);
+  const touchRef = useRef<{ x: number; y: number; t: number } | null>(null);
   const exposedRef = useRef<Set<string>>(new Set());
   const visibleRef = useRef(false);
   const count = heroes.length;
+  const isDesktop = useIsDesktop();
   const readyBackgrounds = useHeroBackgroundPreloader(heroes, idx);
 
   const go = (to: number) => setIdx(((to % count) + count) % count);
@@ -473,7 +478,13 @@ export function HomeTasteHero({
   const onTouchStart = (e: React.TouchEvent) => {
     pause();
     const touch = e.touches[0];
-    if (touch) touchRef.current = { x: touch.clientX, t: Date.now() };
+    if (touch) {
+      touchRef.current = {
+        x: touch.clientX,
+        y: touch.clientY,
+        t: Date.now(),
+      };
+    }
   };
   const onTouchEnd = (e: React.TouchEvent) => {
     const start = touchRef.current;
@@ -487,8 +498,15 @@ export function HomeTasteHero({
       return;
     }
     const dx = endTouch.clientX - start.x;
+    const dy = endTouch.clientY - start.y;
     const dt = Date.now() - start.t;
-    if (Math.abs(dx) > 40 && dt < 500) {
+    const horizontal = Math.abs(dx);
+    const vertical = Math.abs(dy);
+    if (
+      horizontal > HERO_SWIPE_MIN_DISTANCE_PX &&
+      horizontal > vertical * HERO_SWIPE_AXIS_DOMINANCE &&
+      dt <= HERO_SWIPE_MAX_DURATION_MS
+    ) {
       go(idx + (dx < 0 ? 1 : -1));
     }
     touchRef.current = null;
@@ -537,7 +555,7 @@ export function HomeTasteHero({
   return (
     <div
       ref={rootRef}
-      className="relative"
+      className="relative touch-pan-y"
       onMouseEnter={pause}
       onMouseLeave={resume}
       onTouchStart={onTouchStart}
@@ -547,7 +565,7 @@ export function HomeTasteHero({
       {slides}
 
       {/* Nav arrows */}
-      {count > 1 && (
+      {isDesktop && count > 1 && (
         <>
           <button
             onClick={() => {
@@ -835,7 +853,7 @@ function RecentPlaylistEntityRow({
         type: "media",
         title: item.playlist_name,
         subtitle: item.playlist_description || item.subtitle,
-        imageUrl: item.playlist_cover_data_url,
+        imageUrl: resolveMaybeApiAssetUrl(item.playlist_cover_data_url),
         imageAlt: item.playlist_name,
         imageShape: "square",
         fallbackIcon: Sparkles,

--- a/app/listen/src/components/home/HomeUpcomingSections.tsx
+++ b/app/listen/src/components/home/HomeUpcomingSections.tsx
@@ -15,6 +15,7 @@ import {
   artistPagePath,
   artistPhotoApiUrl,
 } from "@/lib/library-routes";
+import { resolveMaybeApiAssetUrl } from "@/lib/api";
 
 import type {
   HomeUpcomingInsight,
@@ -54,7 +55,7 @@ export function HomeUpcomingSection({
   const isShow = nextUpcoming.type === "show";
   const nextUpcomingDate = formatUpcomingDate(nextUpcoming.date);
   const artistImage =
-    nextUpcoming.cover_url ||
+    resolveMaybeApiAssetUrl(nextUpcoming.cover_url) ||
     artistBackgroundApiUrl(
       {
         artistId: nextUpcoming.artist_id,

--- a/app/listen/src/components/layout/Shell.test.tsx
+++ b/app/listen/src/components/layout/Shell.test.tsx
@@ -41,6 +41,25 @@ describe("Shell", () => {
     expect(screen.queryByRole("button", { name: "Open queue" })).toBeNull();
   });
 
+  it("renders one unified glass backdrop for the mobile dock when a track is loaded", () => {
+    const { container } = renderWithListenProviders(<Shell />, {
+      playerActions: {
+        currentTrack: {
+          id: "track-1",
+          title: "Loaded Track",
+          artist: "Crate",
+        },
+      },
+    });
+
+    const dockBackdrop = container.querySelector(".listen-mobile-dock-glass");
+    const nav = screen.getByRole("navigation");
+
+    expect(dockBackdrop).toBeInTheDocument();
+    expect(dockBackdrop).toHaveClass("listen-glass-panel");
+    expect(nav).toHaveClass("bg-transparent");
+  });
+
   it("opens a mobile Collection sheet with all collection sections", () => {
     renderWithListenProviders(<Shell />);
 
@@ -65,6 +84,15 @@ describe("Shell", () => {
 
   it("uses the overlay mobile header on public genre pages", () => {
     renderWithListenProviders(<Shell />, { route: "/explore?genre=hardcore" });
+
+    expect(screen.getByTestId("topbar")).toHaveAttribute(
+      "data-hide-mobile-actions",
+      "true",
+    );
+  });
+
+  it("uses the overlay mobile header on playlist detail pages", () => {
+    renderWithListenProviders(<Shell />, { route: "/playlist/42" });
 
     expect(screen.getByTestId("topbar")).toHaveAttribute(
       "data-hide-mobile-actions",

--- a/app/listen/src/components/layout/Shell.tsx
+++ b/app/listen/src/components/layout/Shell.tsx
@@ -7,8 +7,8 @@ import {
 import { VtNavLink as NavLink } from "@crate/ui/primitives/VtNavLink";
 import {
   Home,
-  Compass,
   Radar,
+  Search,
   Collection,
   Music,
   Disc,
@@ -230,7 +230,7 @@ function Sidebar() {
             } ${navClass(isActive)}`
           }
         >
-          <Compass size={CRATE_ICON_SIZE.nav} />
+          <Search size={CRATE_ICON_SIZE.nav} />
           {expanded && <span className="text-[13px] font-medium">Explore</span>}
         </NavLink>
 
@@ -352,7 +352,7 @@ function Sidebar() {
 
 const MOBILE_NAV = [
   { to: "/", icon: Home, label: "Home" },
-  { to: "/explore", icon: Compass, label: "Explore" },
+  { to: "/explore", icon: Search, label: "Explore" },
   { to: "/upcoming", icon: Radar, label: "Radar" },
 ] as const;
 
@@ -371,7 +371,10 @@ function hasOverlayHeader(pathname: string, search = "") {
   }
   if (
     /^\/artists\/[^/]+$/.test(pathname) ||
-    /^\/albums\/[^/]+\/[^/]+$/.test(pathname)
+    /^\/albums\/[^/]+\/[^/]+$/.test(pathname) ||
+    /^\/playlist\/[^/]+$/.test(pathname) ||
+    /^\/curation\/playlist\/[^/]+$/.test(pathname) ||
+    /^\/home\/playlist\/[^/]+$/.test(pathname)
   ) {
     return true;
   }
@@ -484,20 +487,22 @@ export function Shell() {
 
       <div
         aria-hidden="true"
-        className="pointer-events-none fixed inset-x-0 bottom-0 z-20"
+        className="listen-glass-panel listen-mobile-dock-glass pointer-events-none fixed z-20 rounded-[2rem]"
         style={{
           height: hasTrack
-            ? "var(--listen-mobile-bottom-chrome-height)"
-            : "var(--listen-mobile-bottom-nav-height)",
-          background:
-            "linear-gradient(0deg, rgba(10,10,15,0.98) 0%, rgba(10,10,15,0.94) 68%, rgba(10,10,15,0) 100%)",
+            ? "calc(var(--listen-mobile-player-height) + var(--listen-mobile-bottom-nav-content-height))"
+            : "var(--listen-mobile-bottom-nav-content-height)",
+          bottom:
+            "calc(var(--listen-safe-bottom) + var(--listen-mobile-bottom-dock-inset))",
+          left: "max(1rem, var(--listen-safe-left))",
+          right: "max(1rem, var(--listen-safe-right))",
         }}
       />
 
       <PlayerBar />
 
       <nav
-        className={`z-app-player fixed isolate flex items-center justify-around overflow-visible border border-white/10 bg-[#181818]/95 px-1.5 shadow-[0_22px_60px_rgba(0,0,0,0.46)] backdrop-blur-2xl ${
+        className={`z-app-player fixed isolate flex items-center justify-around overflow-visible bg-transparent px-1.5 ${
           hasTrack ? "rounded-b-[2rem] border-t-0" : "rounded-[2rem]"
         }`}
         style={{

--- a/app/listen/src/components/layout/topbar/TopBarSearch.test.tsx
+++ b/app/listen/src/components/layout/topbar/TopBarSearch.test.tsx
@@ -97,6 +97,30 @@ describe("TopBarSearch", () => {
     expect(searchButton).toHaveTextContent("Search");
   });
 
+  it("uses the shared glass surface for the mobile search shell", () => {
+    mockHoverPointer(false);
+    renderWithListenProviders(<TopBarSearch />);
+
+    const searchButton = screen.getByRole("button", { name: "Search" });
+
+    expect(searchButton.closest(".listen-glass-panel")).toBeInTheDocument();
+  });
+
+  it("keeps the desktop search shell on the non-glass main style", () => {
+    mockHoverPointer(true);
+    renderWithListenProviders(<TopBarSearch />);
+
+    const searchButton = screen.getByRole("button", { name: "Search" });
+    const searchShell = searchButton.parentElement?.parentElement;
+
+    expect(searchShell).toBeInTheDocument();
+    expect(searchShell).toHaveClass("md:bg-transparent", "md:border-0");
+    expect(searchShell).not.toHaveClass(
+      "listen-glass-panel",
+      "listen-search-glass",
+    );
+  });
+
   it("opens on hover and collapses again when idle", async () => {
     const user = userEvent.setup();
     mockHoverPointer(true);

--- a/app/listen/src/components/layout/topbar/TopBarSearch.tsx
+++ b/app/listen/src/components/layout/topbar/TopBarSearch.tsx
@@ -18,6 +18,7 @@ import {
 import { useNavigate } from "react-router";
 
 import { AppPopover } from "@crate/ui/primitives/AppPopover";
+import { useIsDesktop } from "@crate/ui/lib/use-breakpoint";
 import { usePlayerActions } from "@/contexts/PlayerContext";
 import { useHoverCapability } from "@/hooks/use-hover-capability";
 import { useDismissibleLayer } from "@crate/ui/lib/use-dismissible-layer";
@@ -86,6 +87,7 @@ export function TopBarSearch() {
   const navigate = useNavigate();
   const { play } = usePlayerActions();
   const canHover = useHoverCapability();
+  const isDesktop = useIsDesktop();
   const [query, setQuery] = useState("");
   const [results, setResults] = useState<TopBarSearchItem[]>([]);
   const [loading, setLoading] = useState(false);
@@ -503,12 +505,17 @@ export function TopBarSearch() {
       }}
     >
       <div
+        data-state={searchOpen ? "open" : "closed"}
         className={cn(
           "relative overflow-visible rounded-xl transition-[background-color,border-color,box-shadow,transform] duration-500 ease-[cubic-bezier(0.22,1.18,0.36,1)] motion-reduce:transition-none",
-          "focus-within:border focus-within:border-cyan-400/25 focus-within:bg-app-surface/78 focus-within:shadow-[0_0_0_1px_rgba(34,211,238,0.08),0_18px_42px_rgba(0,0,0,0.22)]",
-          searchOpen
-            ? "border border-white/8 bg-app-surface/68 shadow-[0_18px_42px_rgba(0,0,0,0.22)]"
-            : "border border-cyan-200/16 bg-black/28 shadow-[0_0_0_1px_rgba(255,255,255,0.03),0_14px_34px_rgba(0,0,0,0.24)] backdrop-blur-md md:border-0 md:bg-transparent md:shadow-none md:backdrop-blur-0",
+          isDesktop
+            ? cn(
+                "focus-within:border focus-within:border-cyan-400/25 focus-within:bg-app-surface/78 focus-within:shadow-[0_0_0_1px_rgba(34,211,238,0.08),0_18px_42px_rgba(0,0,0,0.22)]",
+                searchOpen
+                  ? "border border-white/8 bg-app-surface/68 shadow-[0_18px_42px_rgba(0,0,0,0.22)]"
+                  : "border border-cyan-200/16 bg-black/28 shadow-[0_0_0_1px_rgba(255,255,255,0.03),0_14px_34px_rgba(0,0,0,0.24)] backdrop-blur-md md:border-0 md:bg-transparent md:shadow-none md:backdrop-blur-0",
+              )
+            : "listen-glass-panel listen-search-glass",
           searchOpen ? "md:scale-x-[1.01]" : "md:scale-x-100",
         )}
       >

--- a/app/listen/src/components/player/PlayerBar.test.tsx
+++ b/app/listen/src/components/player/PlayerBar.test.tsx
@@ -143,6 +143,33 @@ describe("PlayerBar mobile mini-player", () => {
     expect(screen.queryByTestId("player-track-menu")).toBeNull();
   });
 
+  it("leaves the mobile dock glass to the shared Shell backdrop", () => {
+    const track = createMockTrack({
+      title: "Glass Dock",
+      artist: "Crate",
+    });
+
+    const { container } = renderWithListenProviders(<PlayerBar />, {
+      playerActions: { currentTrack: track, queue: [track] },
+    });
+
+    expect(container.querySelector(".listen-mobile-player-glass")).toBeNull();
+  });
+
+  it("keeps the desktop PlayerBar off the mobile dock glass surface", () => {
+    useIsDesktopMock.mockReturnValue(true);
+    const track = createMockTrack({
+      title: "Desktop Surface",
+      artist: "Crate",
+    });
+
+    const { container } = renderWithListenProviders(<PlayerBar />, {
+      playerActions: { currentTrack: track, queue: [track] },
+    });
+
+    expect(container.querySelector(".listen-mobile-player-glass")).toBeNull();
+  });
+
   it("likes the current track with a long press on the cover", async () => {
     vi.useFakeTimers();
     const track = createMockTrack({
@@ -200,5 +227,29 @@ describe("PlayerBar mobile mini-player", () => {
     });
 
     expect(screen.queryByText("Buffering...")).toBeNull();
+  });
+
+  it("keeps the mobile dock artwork, info, and controls vertically aligned", () => {
+    const track = createMockTrack({
+      title: "The Season",
+      artist: "Minor Empires",
+      albumCover: "https://example.test/cover.jpg",
+    });
+
+    renderWithListenProviders(<PlayerBar />, {
+      playerActions: { currentTrack: track, queue: [track] },
+    });
+
+    const trackButton = screen.getByLabelText("Open fullscreen player");
+    const mobileRow = trackButton.parentElement;
+    const mobilePlayButton = screen
+      .getAllByRole("button", { name: "Play" })
+      .find((button) => button.className.includes("h-12"));
+    const mobileControls = mobilePlayButton?.parentElement;
+
+    expect(mobilePlayButton).toBeInTheDocument();
+    expect(mobileRow).toHaveClass("px-4", "pt-3", "pb-0.5");
+    expect(mobileControls).toHaveClass("self-stretch");
+    expect(mobileControls).not.toHaveClass("translate-y-1");
   });
 });

--- a/app/listen/src/components/player/PlayerBar.tsx
+++ b/app/listen/src/components/player/PlayerBar.tsx
@@ -1036,12 +1036,18 @@ export function PlayerBar() {
           <div
             aria-hidden="true"
             className={cn(
-              "pointer-events-none absolute inset-0 z-0 border border-white/10 md:rounded-2xl md:bg-app-surface/68 md:shadow-[0_24px_56px_rgba(0,0,0,0.34)] md:backdrop-blur-xl",
-              !isDesktop &&
-                "rounded-t-[2rem] rounded-b-none border-b-0 bg-[#181818]/95 shadow-[0_22px_60px_rgba(0,0,0,0.46)] backdrop-blur-2xl",
+              "pointer-events-none absolute inset-0 z-0",
+              isDesktop
+                ? "border border-white/10 md:rounded-2xl md:bg-app-surface/68 md:shadow-[0_24px_56px_rgba(0,0,0,0.34)] md:backdrop-blur-xl"
+                : "rounded-t-[2rem] rounded-b-none",
             )}
           />
-          <div className="relative z-10 flex h-full items-center gap-2 px-3 lg:px-4">
+          <div
+            className={cn(
+              "relative z-10 flex h-full items-center gap-2",
+              isDesktop ? "px-3 lg:px-4" : "px-4 pt-3 pb-0.5",
+            )}
+          >
             {/* ── Block 1: Track Info ── */}
             <div
               role={isDesktop ? undefined : "button"}
@@ -1429,7 +1435,7 @@ export function PlayerBar() {
             </div>
 
             {/* ── Mobile/tablet play controls (md only, no progress) ── */}
-            <div className="flex items-center gap-1 md:hidden">
+            <div className="flex items-center gap-1 self-stretch md:hidden">
               <SpectrumPlayButton
                 onClick={handlePlayPause}
                 aria-label={effectiveIsPlaying ? "Pause" : "Play"}

--- a/app/listen/src/components/playlists/PlaylistHeroSection.test.tsx
+++ b/app/listen/src/components/playlists/PlaylistHeroSection.test.tsx
@@ -1,0 +1,265 @@
+import { fireEvent, render, screen, within } from "@testing-library/react";
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { Play, Radio, Share2, Shuffle } from "@crate/ui/icons";
+
+import { PlaylistHeroSection } from "./PlaylistHeroSection";
+
+function mockDesktopPointer() {
+  Object.defineProperty(window, "matchMedia", {
+    writable: true,
+    value: vi.fn().mockImplementation((query: string) => ({
+      matches:
+        query.includes("min-width: 768px") ||
+        query.includes("hover: hover") ||
+        query.includes("pointer: fine"),
+      media: query,
+      onchange: null,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    })),
+  });
+}
+
+function mockMobilePointer() {
+  Object.defineProperty(navigator, "maxTouchPoints", {
+    configurable: true,
+    value: 1,
+  });
+  Object.defineProperty(window, "matchMedia", {
+    writable: true,
+    value: vi.fn().mockImplementation((query: string) => ({
+      matches:
+        query.includes("hover: none") || query.includes("pointer: coarse"),
+      media: query,
+      onchange: null,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    })),
+  });
+}
+
+function renderArtwork(className: string) {
+  return (
+    <div
+      data-testid="playlist-artwork"
+      className={className}
+      aria-label="Playlist artwork"
+    />
+  );
+}
+
+beforeAll(() => {
+  Object.defineProperty(navigator, "maxTouchPoints", {
+    configurable: true,
+    value: 0,
+  });
+});
+
+beforeEach(() => {
+  Object.defineProperty(navigator, "maxTouchPoints", {
+    configurable: true,
+    value: 0,
+  });
+  mockDesktopPointer();
+});
+
+describe("PlaylistHeroSection", () => {
+  it("keeps the hero background in the artist/album language without blur", () => {
+    const { container } = render(
+      <PlaylistHeroSection
+        title="Friday Damage"
+        metaItems={["12 tracks"]}
+        artwork={renderArtwork}
+        onPlay={vi.fn()}
+        onShuffle={vi.fn()}
+        secondaryActions={[]}
+        menuItems={[
+          {
+            key: "play",
+            label: "Play playlist",
+            icon: Play,
+            onSelect: vi.fn(),
+          },
+        ]}
+      />,
+    );
+
+    expect(container.querySelector('[class*="blur-"]')).not.toBeInTheDocument();
+  });
+
+  it("uses an explicit mobile hero height so copy sits directly above CTAs", () => {
+    const { container } = render(
+      <PlaylistHeroSection
+        title="Friday Damage"
+        metaItems={["12 tracks"]}
+        artwork={renderArtwork}
+        onPlay={vi.fn()}
+        onShuffle={vi.fn()}
+        secondaryActions={[]}
+        menuItems={[
+          {
+            key: "play",
+            label: "Play playlist",
+            icon: Play,
+            onSelect: vi.fn(),
+          },
+        ]}
+      />,
+    );
+
+    const hero = container.firstElementChild as HTMLElement;
+    expect(hero).toHaveClass("h-[420px]");
+    expect(hero).not.toHaveClass("min-h-[430px]");
+  });
+
+  it("uses artist/album-style primary pills and secondary icon labels", () => {
+    render(
+      <PlaylistHeroSection
+        title="Friday Damage"
+        description="A playlist for badly lit rooms."
+        metaItems={["12 tracks", "42 min"]}
+        artwork={renderArtwork}
+        onPlay={vi.fn()}
+        onShuffle={vi.fn()}
+        secondaryActions={[
+          {
+            key: "radio",
+            label: "Radio",
+            ariaLabel: "Playlist Radio",
+            icon: Radio,
+            onClick: vi.fn(),
+          },
+          {
+            key: "share",
+            label: "Share",
+            ariaLabel: "Share",
+            icon: Share2,
+            onClick: vi.fn(),
+          },
+        ]}
+        menuItems={[
+          {
+            key: "play",
+            label: "Play playlist",
+            icon: Play,
+            onSelect: vi.fn(),
+          },
+          {
+            key: "shuffle",
+            label: "Shuffle playlist",
+            icon: Shuffle,
+            onSelect: vi.fn(),
+          },
+        ]}
+      />,
+    );
+
+    const primary = screen.getByRole("group", {
+      name: "Primary playlist actions",
+    });
+    expect(
+      within(primary).getByRole("button", { name: "Play" }),
+    ).toHaveTextContent("Play");
+    expect(
+      within(primary).getByRole("button", { name: "Shuffle" }),
+    ).toHaveTextContent("Shuffle");
+
+    const secondary = screen.getByRole("group", {
+      name: "Secondary playlist actions",
+    });
+    expect(
+      within(secondary).getByRole("button", { name: "Playlist Radio" }),
+    ).toHaveTextContent("Radio");
+    expect(
+      within(secondary).getByRole("button", { name: "Share" }),
+    ).toHaveTextContent("Share");
+    expect(
+      within(secondary).getByRole("button", { name: "More" }),
+    ).toHaveTextContent("More");
+  });
+
+  it("opens the normalized glass context menu with playlist media header", async () => {
+    render(
+      <PlaylistHeroSection
+        title="Friday Damage"
+        subtitle="Public playlist"
+        metaItems={["12 tracks"]}
+        artwork={renderArtwork}
+        onPlay={vi.fn()}
+        onShuffle={vi.fn()}
+        secondaryActions={[]}
+        menuItems={[
+          {
+            key: "play",
+            label: "Play playlist",
+            icon: Play,
+            onSelect: vi.fn(),
+          },
+        ]}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "More" }));
+
+    const menu = await screen.findByRole("menu");
+    expect(menu).toHaveClass(
+      "listen-glass-panel",
+      "w-72",
+      "rounded-2xl",
+      "z-app-context-menu",
+    );
+    expect(within(menu).getByText("Friday Damage")).toBeInTheDocument();
+    expect(
+      screen.getByRole("menuitem", { name: "Play playlist" }),
+    ).toBeInTheDocument();
+  });
+
+  it("moves More to the fixed mobile hero corner", async () => {
+    mockMobilePointer();
+
+    render(
+      <PlaylistHeroSection
+        title="Friday Damage"
+        metaItems={["12 tracks"]}
+        artwork={renderArtwork}
+        onPlay={vi.fn()}
+        onShuffle={vi.fn()}
+        secondaryActions={[
+          {
+            key: "radio",
+            label: "Radio",
+            ariaLabel: "Playlist Radio",
+            icon: Radio,
+            onClick: vi.fn(),
+          },
+        ]}
+        menuItems={[
+          {
+            key: "play",
+            label: "Play playlist",
+            icon: Play,
+            onSelect: vi.fn(),
+          },
+        ]}
+      />,
+    );
+
+    const secondary = screen.getByRole("group", {
+      name: "Secondary playlist actions",
+    });
+    expect(
+      within(secondary).queryByRole("button", { name: "More" }),
+    ).toBeNull();
+
+    const heroMenu = screen.getByTestId("playlist-mobile-hero-menu");
+    expect(heroMenu).toHaveAttribute("aria-label", "More");
+    expect(heroMenu.parentElement).toHaveClass("fixed", "z-app-header");
+
+    fireEvent.click(heroMenu);
+    expect(
+      await screen.findByRole("menuitem", { name: "Play playlist" }),
+    ).toBeInTheDocument();
+  });
+});

--- a/app/listen/src/components/playlists/PlaylistHeroSection.tsx
+++ b/app/listen/src/components/playlists/PlaylistHeroSection.tsx
@@ -1,0 +1,298 @@
+import { useRef, useState, type MouseEvent, type ReactNode } from "react";
+import { createPortal } from "react-dom";
+import {
+  CRATE_ICON_SIZE,
+  ListMusic,
+  MoreHorizontal,
+  Play,
+  Shuffle,
+  type CrateIcon,
+} from "@crate/ui/icons";
+import { ContextMenu, type ContextMenuEntry } from "@crate/ui/domain/actions";
+import { useDismissibleLayer } from "@crate/ui/lib/use-dismissible-layer";
+import { useIsDesktop } from "@crate/ui/lib/use-breakpoint";
+import { resolveMaybeApiAssetUrl } from "@/lib/api";
+import { cn } from "@/lib/utils";
+
+export interface PlaylistHeroSecondaryAction {
+  key: string;
+  label: string;
+  ariaLabel?: string;
+  icon: CrateIcon;
+  iconClassName?: string;
+  className?: string;
+  active?: boolean;
+  pulseIcon?: boolean;
+  disabled?: boolean;
+  title?: string;
+  onClick: () => void;
+}
+
+interface PlaylistHeroSectionProps {
+  title: string;
+  subtitle?: string;
+  description?: string;
+  metaItems: Array<string | null | undefined | false>;
+  badges?: ReactNode;
+  artwork: (className: string) => ReactNode;
+  menuImageUrl?: string | null;
+  menuImageAlt?: string;
+  onPlay: () => void;
+  onShuffle: () => void;
+  playDisabled?: boolean;
+  shuffleDisabled?: boolean;
+  secondaryActions: PlaylistHeroSecondaryAction[];
+  menuItems: ContextMenuEntry[];
+}
+
+const SECONDARY_ACTION_CLASS =
+  "flex min-h-14 min-w-[56px] shrink-0 touch-manipulation flex-col items-center justify-center gap-1 px-1.5 py-1 text-[11px] font-medium text-white/62 transition-[color,filter,transform] hover:-translate-y-px hover:text-primary hover:drop-shadow-[0_0_10px_rgba(34,211,238,0.32)] disabled:cursor-not-allowed disabled:opacity-35 disabled:hover:translate-y-0 disabled:hover:drop-shadow-none";
+
+export function PlaylistHeroSection({
+  title,
+  subtitle,
+  description,
+  metaItems,
+  badges,
+  artwork,
+  menuImageUrl,
+  menuImageAlt,
+  onPlay,
+  onShuffle,
+  playDisabled,
+  shuffleDisabled,
+  secondaryActions,
+  menuItems,
+}: PlaylistHeroSectionProps) {
+  const isDesktop = useIsDesktop();
+  const [menuOpen, setMenuOpen] = useState(false);
+  const [desktopMenuPosition, setDesktopMenuPosition] = useState<{
+    x: number;
+    y: number;
+  } | null>(null);
+  const menuRef = useRef<HTMLDivElement>(null);
+  const desktopMenuRef = useRef<HTMLDivElement>(null);
+  const mobileMenuRef = useRef<HTMLDivElement>(null);
+  const visibleMetaItems = metaItems.filter(Boolean);
+  const menuImageSrc = resolveMaybeApiAssetUrl(menuImageUrl);
+
+  const closeMenu = () => {
+    setMenuOpen(false);
+    setDesktopMenuPosition(null);
+  };
+
+  useDismissibleLayer({
+    active: menuOpen && isDesktop,
+    refs: [menuRef, desktopMenuRef],
+    onDismiss: closeMenu,
+  });
+
+  function handleToggleMenu(event: MouseEvent<HTMLButtonElement>) {
+    if (menuOpen) {
+      closeMenu();
+      return;
+    }
+
+    if (isDesktop) {
+      const rect = event.currentTarget.getBoundingClientRect();
+      const width = 288;
+      const padding = 12;
+      const maxX = Math.max(padding, window.innerWidth - width - padding);
+      setDesktopMenuPosition({
+        x: Math.min(Math.max(padding, rect.right - width), maxX),
+        y: rect.bottom + 8,
+      });
+    }
+
+    setMenuOpen(true);
+  }
+
+  const menuHeader = {
+    type: "media" as const,
+    title,
+    subtitle,
+    detail: visibleMetaItems[0] || undefined,
+    imageUrl: menuImageSrc,
+    imageAlt: menuImageAlt || title,
+    imageShape: "square" as const,
+    fallbackIcon: ListMusic,
+  };
+
+  const mobileMenuTrigger =
+    !isDesktop && typeof document !== "undefined" ? (
+      <div
+        className="fixed z-app-header"
+        style={{
+          top: "calc(var(--listen-safe-top) + 0.625rem)",
+          right: "max(1rem, var(--listen-safe-right))",
+        }}
+        ref={menuRef}
+      >
+        <button
+          data-testid="playlist-mobile-hero-menu"
+          className="flex h-11 w-11 touch-manipulation items-center justify-center text-white/72 transition-[color,filter,transform] hover:-translate-y-px hover:text-primary hover:drop-shadow-[0_0_10px_rgba(34,211,238,0.32)]"
+          onClick={handleToggleMenu}
+          aria-label="More"
+        >
+          <MoreHorizontal
+            data-testid="playlist-mobile-hero-menu-icon"
+            size={CRATE_ICON_SIZE.navMobile}
+            className="rotate-90"
+          />
+        </button>
+        <ContextMenu
+          header={menuHeader}
+          items={menuItems}
+          menuRef={mobileMenuRef}
+          onClose={closeMenu}
+          open={menuOpen}
+          position={desktopMenuPosition}
+        />
+      </div>
+    ) : null;
+
+  return (
+    <>
+      {mobileMenuTrigger
+        ? createPortal(mobileMenuTrigger, document.body)
+        : null}
+      <div className="relative h-[420px] overflow-hidden sm:h-[420px] lg:h-[460px]">
+        <div className="absolute inset-0 scale-[1.02] opacity-[0.82] sm:grayscale sm:brightness-[0.5] sm:opacity-[0.45]">
+          {artwork("h-full w-full rounded-none")}
+        </div>
+        <div className="absolute inset-0 bg-black/12 sm:bg-black/36" />
+        <div
+          className="absolute inset-0 sm:hidden"
+          style={{
+            background:
+              "linear-gradient(to bottom, transparent 0%, rgba(8, 10, 14, 0.04) 34%, rgba(8, 10, 14, 0.28) 64%, var(--surface-app) 100%)",
+          }}
+        />
+        <div
+          className="absolute inset-0 hidden sm:block"
+          style={{
+            background:
+              "linear-gradient(to bottom, transparent 0%, rgba(8, 10, 14, 0.16) 34%, rgba(8, 10, 14, 0.52) 66%, var(--surface-app) 100%)",
+          }}
+        />
+
+        <div className="relative mx-auto flex h-full w-full max-w-[1480px] items-end px-4 pb-6 pt-[var(--listen-mobile-page-top)] sm:px-6 sm:pt-0">
+          <div className="flex w-full flex-col gap-5 sm:flex-row sm:items-end">
+            <div className="hidden w-[200px] flex-shrink-0 sm:block lg:w-[240px]">
+              {artwork(
+                "aspect-square rounded-2xl bg-white/5 shadow-2xl ring-1 ring-white/10",
+              )}
+            </div>
+
+            <div className="flex min-w-0 max-w-3xl flex-col justify-end pb-1 text-left">
+              {badges ? (
+                <div className="mb-2 flex flex-wrap items-center gap-2">
+                  {badges}
+                </div>
+              ) : null}
+              <h1 className="text-3xl font-bold text-foreground sm:text-4xl">
+                {title}
+              </h1>
+              {description ? (
+                <p className="mt-3 line-clamp-3 max-w-2xl whitespace-pre-line text-sm leading-relaxed text-white/70">
+                  {description}
+                </p>
+              ) : null}
+              {visibleMetaItems.length ? (
+                <div className="mt-3 flex flex-wrap items-center gap-x-3 gap-y-1 text-xs text-muted-foreground">
+                  {visibleMetaItems.map((item) => (
+                    <span key={String(item)}>{item}</span>
+                  ))}
+                </div>
+              ) : null}
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div className="px-4 py-4 sm:px-6">
+        <div className="mx-auto flex w-full max-w-[1480px] flex-col gap-5 md:flex-row md:items-center md:justify-between md:gap-6">
+          <div
+            role="group"
+            aria-label="Primary playlist actions"
+            className="grid grid-cols-2 gap-3 md:flex md:shrink-0 md:items-center md:gap-3"
+          >
+            <button
+              className="flex h-12 shrink-0 items-center justify-center gap-2 rounded-full bg-primary px-5 text-sm font-semibold text-primary-foreground shadow-[0_0_18px_rgba(34,211,238,0.24)] transition-[background-color,box-shadow,transform] hover:-translate-y-px hover:bg-primary/90 hover:shadow-[0_0_24px_rgba(34,211,238,0.34)] disabled:cursor-not-allowed disabled:opacity-45 md:px-7 md:text-[15px]"
+              onClick={onPlay}
+              disabled={playDisabled}
+              aria-label="Play"
+            >
+              <Play size={17} fill="currentColor" />
+              <span>Play</span>
+            </button>
+            <button
+              className="flex h-12 shrink-0 items-center justify-center gap-2 rounded-full bg-white/[0.08] px-5 text-sm font-semibold text-foreground shadow-[inset_0_0_0_1px_rgba(255,255,255,0.04)] transition-[background-color,color,filter,transform] hover:-translate-y-px hover:bg-white/[0.12] hover:text-primary hover:drop-shadow-[0_0_8px_rgba(34,211,238,0.24)] disabled:cursor-not-allowed disabled:opacity-45 md:w-auto md:px-7"
+              onClick={onShuffle}
+              disabled={shuffleDisabled}
+              aria-label="Shuffle"
+            >
+              <Shuffle size={17} />
+              <span>Shuffle</span>
+            </button>
+          </div>
+
+          <div
+            role="group"
+            aria-label="Secondary playlist actions"
+            className="grid grid-cols-5 items-start gap-2 md:ml-auto md:flex md:shrink-0 md:items-center md:gap-4"
+          >
+            {secondaryActions.map((action) => {
+              const Icon = action.icon;
+              return (
+                <button
+                  key={action.key}
+                  className={cn(
+                    SECONDARY_ACTION_CLASS,
+                    action.active
+                      ? "text-primary drop-shadow-[0_0_8px_rgba(34,211,238,0.28)]"
+                      : "text-white/62",
+                    action.className,
+                  )}
+                  onClick={action.onClick}
+                  disabled={action.disabled}
+                  aria-label={action.ariaLabel || action.label}
+                  title={action.title}
+                >
+                  <Icon
+                    size={CRATE_ICON_SIZE.lg}
+                    className={cn(
+                      action.pulseIcon && "animate-crate-icon-active-pulse",
+                      action.iconClassName,
+                    )}
+                  />
+                  <span>{action.label}</span>
+                </button>
+              );
+            })}
+            {isDesktop ? (
+              <div className="relative shrink-0" ref={menuRef}>
+                <button
+                  className={SECONDARY_ACTION_CLASS}
+                  onClick={handleToggleMenu}
+                  aria-label="More"
+                >
+                  <MoreHorizontal size={CRATE_ICON_SIZE.lg} />
+                  <span>More</span>
+                </button>
+                <ContextMenu
+                  header={menuHeader}
+                  items={menuItems}
+                  menuRef={isDesktop ? desktopMenuRef : mobileMenuRef}
+                  onClose={closeMenu}
+                  open={menuOpen}
+                  position={desktopMenuPosition}
+                />
+              </div>
+            ) : null}
+          </div>
+        </div>
+      </div>
+    </>
+  );
+}

--- a/app/listen/src/components/ui/CrateLoader.test.tsx
+++ b/app/listen/src/components/ui/CrateLoader.test.tsx
@@ -1,22 +1,73 @@
 import { render, screen } from "@testing-library/react";
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
-import { CrateLoader } from "./CrateLoader";
+import { CRATE_LOADING_PHRASES, CrateLoader } from "./CrateLoader";
 
 describe("CrateLoader", () => {
-  it("renders the Crate animated loader with an accessible status", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("renders the Crate logo loader with the play glow language", () => {
+    vi.spyOn(Math, "random").mockReturnValue(0);
     const { container } = render(<CrateLoader />);
 
     expect(screen.getByRole("status")).toHaveTextContent("Loading Music.");
+    expect(screen.getByRole("status")).toHaveTextContent("Feeding your soul");
     expect(container.querySelector("img")).toHaveAttribute(
       "src",
-      "/loaders/crate-loader.webp",
+      "/icons/logo.svg",
+    );
+    expect(container.innerHTML).toContain("animate-crate-play-aura-pulse");
+    expect(container.innerHTML).toContain("animate-crate-play-rim-pulse");
+    expect(container.innerHTML).toContain("animate-crate-play-core-pulse");
+  });
+
+  it("renders all proposed loading phrases in the rotation", () => {
+    expect(CRATE_LOADING_PHRASES).toEqual([
+      "Feeding your soul",
+      "Loading Crate",
+      "Warming the amps",
+      "Spinning up the collection",
+      "Cueing the next obsession",
+      "Tuning the room",
+      "Checking the liner notes",
+      "Dusting off the crates",
+      "Finding something loud",
+      "Syncing the signal",
+    ]);
+  });
+
+  it("renders animated ellipsis dots separately from the phrase", () => {
+    render(<CrateLoader />);
+
+    const dots = screen.getAllByTestId("crate-loader-dot");
+    expect(dots).toHaveLength(3);
+    for (const dot of dots) {
+      expect(dot).toHaveAttribute("aria-hidden", "true");
+      expect(dot).toHaveClass("animate-crate-loader-dot-bounce");
+    }
+  });
+
+  it("keeps the selected phrase stable for one mounted loader", () => {
+    const randomSpy = vi.spyOn(Math, "random").mockReturnValue(0.99);
+    const { rerender } = render(<CrateLoader />);
+
+    expect(screen.getByRole("status")).toHaveTextContent("Syncing the signal");
+    randomSpy.mockReturnValue(0);
+    rerender(<CrateLoader />);
+
+    expect(screen.getByRole("status")).toHaveTextContent("Syncing the signal");
+    expect(screen.getByRole("status")).not.toHaveTextContent(
+      "Feeding your soul",
     );
   });
 
   it("supports custom loading labels for screen readers", () => {
+    vi.spyOn(Math, "random").mockReturnValue(0);
     render(<CrateLoader label="Loading artist." />);
 
     expect(screen.getByRole("status")).toHaveTextContent("Loading artist.");
+    expect(screen.getByRole("status")).toHaveTextContent("Feeding your soul");
   });
 });

--- a/app/listen/src/components/ui/CrateLoader.tsx
+++ b/app/listen/src/components/ui/CrateLoader.tsx
@@ -1,3 +1,5 @@
+import { useMemo } from "react";
+
 import { cn } from "@/lib/utils";
 
 type CrateLoaderVariant = "compact" | "page" | "screen";
@@ -8,11 +10,24 @@ const WRAPPER_CLASSES: Record<CrateLoaderVariant, string> = {
   screen: "min-h-svh",
 };
 
-const IMAGE_CLASSES: Record<CrateLoaderVariant, string> = {
-  compact: "w-[clamp(8rem,30vw,12rem)]",
-  page: "w-[clamp(11rem,36vw,18rem)]",
-  screen: "w-[clamp(12rem,34vw,20rem)]",
+const MARK_CLASSES: Record<CrateLoaderVariant, string> = {
+  compact: "h-24 w-24 p-[3px]",
+  page: "h-32 w-32 p-1",
+  screen: "h-36 w-36 p-1",
 };
+
+export const CRATE_LOADING_PHRASES = [
+  "Feeding your soul",
+  "Loading Crate",
+  "Warming the amps",
+  "Spinning up the collection",
+  "Cueing the next obsession",
+  "Tuning the room",
+  "Checking the liner notes",
+  "Dusting off the crates",
+  "Finding something loud",
+  "Syncing the signal",
+] as const;
 
 interface CrateLoaderProps {
   className?: string;
@@ -25,26 +40,61 @@ export function CrateLoader({
   label = "Loading Music.",
   variant = "page",
 }: CrateLoaderProps) {
+  const phrase = useMemo(() => {
+    const index = Math.floor(Math.random() * CRATE_LOADING_PHRASES.length);
+    return CRATE_LOADING_PHRASES[index] ?? CRATE_LOADING_PHRASES[0];
+  }, []);
+
   return (
     <div
       role="status"
       aria-live="polite"
       className={cn(
-        "relative flex items-center justify-center overflow-hidden text-center",
+        "relative flex flex-col items-center justify-center gap-6 overflow-visible text-center",
         WRAPPER_CLASSES[variant],
         className,
       )}
     >
-      <img
-        src="/loaders/crate-loader.webp"
-        alt=""
+      <div
         aria-hidden="true"
-        draggable={false}
         className={cn(
-          "h-auto select-none drop-shadow-[0_0_24px_rgba(6,182,212,0.12)]",
-          IMAGE_CLASSES[variant],
+          "group relative isolate flex shrink-0 items-center justify-center overflow-visible rounded-full",
+          "bg-[conic-gradient(from_218deg,#0891b2_0deg,#22d3ee_84deg,#a5f3fc_166deg,#06b6d4_248deg,#0891b2_360deg)]",
+          "shadow-[0_0_5px_rgba(34,211,238,0.3),0_0_9px_rgba(39,215,255,0.14)]",
+          "brightness-110 saturate-125",
+          MARK_CLASSES[variant],
         )}
-      />
+      >
+        <span className="pointer-events-none absolute -inset-[16px] z-0 origin-[46%_57%] animate-crate-play-aura-pulse rounded-[45%_55%_49%_51%/53%_47%_56%_44%] bg-[radial-gradient(ellipse_58%_46%_at_46%_57%,rgba(34,211,238,0.38)_0%,rgba(34,211,238,0.22)_24%,rgba(34,211,238,0.09)_42%,transparent_64%),radial-gradient(ellipse_38%_32%_at_68%_34%,rgba(165,243,252,0.22)_0%,rgba(165,243,252,0.09)_34%,transparent_66%),radial-gradient(ellipse_34%_42%_at_30%_66%,rgba(8,145,178,0.25)_0%,rgba(8,145,178,0.09)_38%,transparent_68%)] opacity-[0.72]" />
+        <span className="pointer-events-none absolute inset-0 z-10 animate-crate-play-rim-pulse rounded-full bg-[conic-gradient(from_218deg,rgba(8,145,178,0.94)_0deg,rgba(34,211,238,0.98)_92deg,rgba(165,243,252,0.96)_170deg,rgba(6,182,212,0.92)_250deg,rgba(8,145,178,0.9)_360deg)]" />
+        <span className="pointer-events-none absolute inset-[2px] z-20 animate-crate-play-core-pulse rounded-full bg-[#121326] shadow-[inset_0_0_0_1px_rgba(255,255,255,0.08),inset_0_-10px_24px_rgba(0,0,0,0.48)]" />
+        <img
+          src="/icons/logo.svg"
+          alt=""
+          aria-hidden="true"
+          draggable={false}
+          className="relative z-30 h-[58%] w-[58%] select-none drop-shadow-[0_0_8px_rgba(103,232,249,0.42)]"
+        />
+      </div>
+      <p className="font-sans text-[0.9375rem] font-semibold tracking-[0.055em] text-cyan-50/80">
+        {phrase}
+        <span
+          className="inline-flex w-[1.35em] justify-start"
+          aria-hidden="true"
+        >
+          {[0, 1, 2].map((index) => (
+            <span
+              key={index}
+              aria-hidden="true"
+              data-testid="crate-loader-dot"
+              className="animate-crate-loader-dot-bounce"
+              style={{ animationDelay: `${index * 140}ms` }}
+            >
+              .
+            </span>
+          ))}
+        </span>
+      </p>
       <span className="sr-only">{label}</span>
     </div>
   );

--- a/app/listen/src/components/upcoming/UpcomingEventRow.tsx
+++ b/app/listen/src/components/upcoming/UpcomingEventRow.tsx
@@ -12,6 +12,7 @@ import {
   artistPagePath,
   artistPhotoApiUrl,
 } from "@/lib/library-routes";
+import { resolveMaybeApiAssetUrl } from "@/lib/api";
 
 import {
   canOpenUpcomingRelease,
@@ -33,7 +34,7 @@ export function UpcomingEventRow({
     ? dateObj.toLocaleDateString("en-US", { month: "short", day: "numeric" })
     : "";
   const coverUrl =
-    item.cover_url ||
+    resolveMaybeApiAssetUrl(item.cover_url) ||
     artistPhotoApiUrl(
       {
         artistId: item.artist_id,

--- a/app/listen/src/components/upcoming/UpcomingShowCard.tsx
+++ b/app/listen/src/components/upcoming/UpcomingShowCard.tsx
@@ -3,6 +3,7 @@ import { Calendar } from "@crate/ui/icons";
 
 import { ItemActionMenu, useItemActionMenu } from "@crate/ui/domain/actions";
 import { useShowActionEntries } from "@/components/actions/show-actions";
+import { resolveMaybeApiAssetUrl } from "@/lib/api";
 import { cn } from "@/lib/utils";
 
 import {
@@ -43,6 +44,7 @@ export function UpcomingShowCard({
     playProbableSetlist,
   });
   const actionMenu = useItemActionMenu(menuActions);
+  const menuCoverUrl = resolveMaybeApiAssetUrl(item.cover_url);
   const actionMenuSlot = useMemo(
     () => ({
       triggerRef: actionMenu.triggerRef,
@@ -119,7 +121,7 @@ export function UpcomingShowCard({
           title: item.artist,
           subtitle: item.title,
           detail: item.subtitle,
-          imageUrl: item.cover_url,
+          imageUrl: menuCoverUrl,
           imageAlt: item.artist,
           imageShape: "square",
           fallbackIcon: Calendar,

--- a/app/listen/src/components/upcoming/UpcomingShowCardViews.tsx
+++ b/app/listen/src/components/upcoming/UpcomingShowCardViews.tsx
@@ -16,6 +16,7 @@ import {
   artistPagePath,
   artistPhotoApiUrl,
 } from "@/lib/library-routes";
+import { resolveMaybeApiAssetUrl } from "@/lib/api";
 import { GenrePillRow } from "@crate/ui/domain/genres/GenrePill";
 
 /** Hidden img that preloads the artist background into the browser cache */
@@ -137,7 +138,7 @@ export function UpcomingShowCollapsedView({
       artistSlug: item.artist_slug,
       artistName: item.artist,
     }) ||
-    item.cover_url ||
+    resolveMaybeApiAssetUrl(item.cover_url) ||
     undefined;
 
   const d = item.date ? new Date(`${item.date}T12:00:00`) : null;
@@ -266,7 +267,7 @@ export function UpcomingShowExpandedView({
       artistSlug: item.artist_slug,
       artistName: item.artist,
     }) ||
-    item.cover_url ||
+    resolveMaybeApiAssetUrl(item.cover_url) ||
     undefined;
 
   const d = item.date ? new Date(`${item.date}T12:00:00`) : null;

--- a/app/listen/src/index.css
+++ b/app/listen/src/index.css
@@ -148,6 +148,46 @@ textarea {
   -webkit-backdrop-filter: blur(24px) saturate(1.18);
 }
 
+.listen-search-glass {
+  border-color: rgba(255, 255, 255, 0.13);
+  background: radial-gradient(
+      circle at 14% 0%,
+      rgba(6, 182, 212, 0.18),
+      transparent 38%
+    ),
+    linear-gradient(180deg, rgba(29, 31, 41, 0.78), rgba(10, 11, 16, 0.7));
+  box-shadow:
+    0 18px 46px rgba(0, 0, 0, 0.34),
+    inset 0 1px 0 rgba(255, 255, 255, 0.08);
+}
+
+.listen-search-glass:hover,
+.listen-search-glass:focus-within,
+.listen-search-glass[data-state="open"] {
+  border-color: rgba(34, 211, 238, 0.28);
+  box-shadow:
+    0 22px 58px rgba(0, 0, 0, 0.38),
+    0 0 22px rgba(34, 211, 238, 0.12),
+    inset 0 1px 0 rgba(255, 255, 255, 0.1);
+}
+
+.listen-mobile-dock-glass {
+  border-color: rgba(255, 255, 255, 0.14);
+  background: radial-gradient(
+      circle at 18% 0%,
+      rgba(6, 182, 212, 0.1),
+      transparent 42%
+    ),
+    linear-gradient(180deg, rgba(21, 23, 31, 0.96), rgba(7, 8, 12, 0.92));
+  box-shadow:
+    0 24px 72px rgba(0, 0, 0, 0.58),
+    0 0 22px rgba(34, 211, 238, 0.06),
+    inset 0 1px 0 rgba(255, 255, 255, 0.09);
+  backdrop-filter: blur(38px) saturate(1.28) brightness(0.72) contrast(0.88);
+  -webkit-backdrop-filter: blur(38px) saturate(1.28) brightness(0.72)
+    contrast(0.88);
+}
+
 .listen-glass-panel--dock {
   background: radial-gradient(
       circle at 12% 4%,

--- a/app/listen/src/lib/api.test.ts
+++ b/app/listen/src/lib/api.test.ts
@@ -217,6 +217,13 @@ describe("resolveMaybeApiAssetUrl", () => {
     );
   });
 
+  it("normalizes API asset paths without a leading slash", () => {
+    localStorage.setItem("listen-auth-token", "listen token");
+    expect(resolveMaybeApiAssetUrl("api/genres/hardcore/cover")).toBe(
+      "/api/genres/hardcore/cover",
+    );
+  });
+
   it("adds token to absolute crate API asset URLs", () => {
     localStorage.setItem("listen-auth-token", "listen-token");
     expect(
@@ -954,6 +961,16 @@ describe("native (configurable server) mode", () => {
       );
       expect(result).toBe(
         "https://api.example.com/api/network/external-artist/photo?name=Slowthai&token=native-tok",
+      );
+    });
+
+    it("resolves genre cover fallbacks against the configured server", () => {
+      setupServer();
+      const result = apiMod.resolveMaybeApiAssetUrl(
+        "api/genres/hardcore/cover?size=1280&format=webp",
+      );
+      expect(result).toBe(
+        "https://api.example.com/api/genres/hardcore/cover?size=1280&format=webp&token=native-tok",
       );
     });
   });

--- a/app/listen/src/lib/api.ts
+++ b/app/listen/src/lib/api.ts
@@ -139,6 +139,7 @@ export function resolveMaybeApiAssetUrl(
     return url;
   }
   if (url.startsWith("/api/")) return apiAssetUrl(url);
+  if (url.startsWith("api/")) return apiAssetUrl(`/${url}`);
 
   const base = getApiBase();
   if (base && url.startsWith(`${base}/api/`)) {

--- a/app/listen/src/lib/cache.ts
+++ b/app/listen/src/lib/cache.ts
@@ -157,6 +157,8 @@ export function scopesForUrl(url: string): string[] {
     scopes.push("library", "shows", "upcoming");
   else if (url.startsWith("/api/genres")) scopes.push("library");
   // Radio
+  else if (url === "/api/radio/stations")
+    scopes.push("library", "follows", "history");
   else if (url.startsWith("/api/radio")) scopes.push("library");
   // Shows
   else if (url.startsWith("/api/shows")) scopes.push("shows");

--- a/app/listen/src/lib/social-share.ts
+++ b/app/listen/src/lib/social-share.ts
@@ -21,7 +21,12 @@ const POPPINS_800_URL = new URL(
   import.meta.url,
 ).href;
 
-export type ShareSubjectKind = "track" | "album" | "artist" | "playlist";
+export type ShareSubjectKind =
+  | "track"
+  | "album"
+  | "artist"
+  | "playlist"
+  | "genre";
 
 export interface SharePayload {
   kind: ShareSubjectKind;

--- a/app/listen/src/pages/ArtistTopTracks.tsx
+++ b/app/listen/src/pages/ArtistTopTracks.tsx
@@ -4,6 +4,7 @@ import { useLocation, useNavigate, useParams } from "react-router";
 import { toast } from "sonner";
 
 import { TrackRow, type TrackRowData } from "@/components/cards/TrackRow";
+import { CrateLoader } from "@/components/ui/CrateLoader";
 import {
   buildArtistPlayerTrack,
   topTrackToTrackRowData,
@@ -84,11 +85,7 @@ export function ArtistTopTracks() {
   );
 
   if (loading) {
-    return (
-      <div className="flex items-center justify-center h-64">
-        <div className="w-8 h-8 border-2 border-primary border-t-transparent rounded-full animate-spin" />
-      </div>
-    );
+    return <CrateLoader label="Loading top tracks." />;
   }
 
   return (

--- a/app/listen/src/pages/Bandcamp.tsx
+++ b/app/listen/src/pages/Bandcamp.tsx
@@ -12,7 +12,7 @@ import type { ReactNode } from "react";
 import { toast } from "sonner";
 
 import { BandcampLogo } from "@crate/ui/domain/brand/BandcampLogo";
-import { api } from "@/lib/api";
+import { api, resolveMaybeApiAssetUrl } from "@/lib/api";
 import { useApi } from "@/hooks/use-api";
 import { cn } from "@/lib/utils";
 
@@ -463,6 +463,8 @@ function Cover({
   item: BandcampItem;
   compact?: boolean;
 }) {
+  const coverUrl = resolveMaybeApiAssetUrl(item.cover_url);
+
   return (
     <div
       className={cn(
@@ -472,9 +474,9 @@ function Cover({
           : "aspect-square w-full",
       )}
     >
-      {item.cover_url ? (
+      {coverUrl ? (
         <img
-          src={item.cover_url}
+          src={coverUrl}
           alt=""
           loading="lazy"
           className="h-full w-full object-cover transition duration-300 group-hover:scale-[1.03]"

--- a/app/listen/src/pages/CuratedPlaylist.tsx
+++ b/app/listen/src/pages/CuratedPlaylist.tsx
@@ -5,11 +5,10 @@ import {
   useRef,
   useState,
 } from "react";
-import { useNavigate, useParams } from "react-router";
+import { useParams } from "react-router";
 import { useWindowVirtualizer } from "@tanstack/react-virtual";
 import {
   AlertCircle,
-  ArrowLeft,
   ArrowDownToLine,
   ArrowDownToLineBold,
   Heart,
@@ -19,20 +18,24 @@ import {
   Radio,
   Shuffle,
   Share2,
-  Users,
 } from "@crate/ui/icons";
+import type { ContextMenuEntry } from "@crate/ui/domain/actions";
 import { toast } from "sonner";
 
 import { useApi } from "@/hooks/use-api";
 import { useLazyPlaylistOptions } from "@/hooks/use-lazy-playlist-options";
-import { api } from "@/lib/api";
+import { api, resolveMaybeApiAssetUrl } from "@/lib/api";
 import { TrackRow, type TrackRowData } from "@/components/cards/TrackRow";
+import { CrateLoader } from "@/components/ui/CrateLoader";
 import { OfflineBadge } from "@crate/ui/domain/offline/OfflineBadge";
-import type { PlaylistArtworkTrack } from "@/components/playlists/PlaylistArtwork";
 import {
-  EditorialPlaylistArtwork,
-  editorialPlaylistLabel,
-} from "@/components/playlists/EditorialPlaylistArtwork";
+  PlaylistArtwork,
+  type PlaylistArtworkTrack,
+} from "@/components/playlists/PlaylistArtwork";
+import {
+  PlaylistHeroSection,
+  type PlaylistHeroSecondaryAction,
+} from "@/components/playlists/PlaylistHeroSection";
 import {
   PlaylistTrackFilterBar,
   filterPlaylistTracks,
@@ -97,7 +100,7 @@ interface CuratedPlaylistData {
 }
 
 const VIRTUAL_TRACK_THRESHOLD = 80;
-const TRACK_ROW_ESTIMATE_PX = 58;
+const TRACK_ROW_ESTIMATE_PX = 72;
 
 interface CuratedTrackListProps {
   tracks: CuratedPlaylistTrack[];
@@ -128,6 +131,7 @@ function CuratedTrackRow({
         library_track_id: track.track_id,
       })}
       index={index}
+      showCoverThumb
       showArtist
       showAlbum
       playlistOptions={playlistOptions}
@@ -226,7 +230,6 @@ function VirtualizedCuratedTrackList(props: CuratedTrackListProps) {
 }
 
 export function CuratedPlaylist() {
-  const navigate = useNavigate();
   const { id } = useParams<{ id: string }>();
   const { playAll } = usePlayerActions();
   const { openCreatePlaylist } = usePlaylistComposer();
@@ -330,7 +333,7 @@ export function CuratedPlaylist() {
       kind: "playlist",
       title: data.name,
       subtitle: data.description,
-      imageUrl: data.cover_data_url,
+      imageUrl: resolveMaybeApiAssetUrl(data.cover_data_url),
       url: publicShareUrl(`/curation/playlist/${data.id}`),
     });
   }
@@ -382,11 +385,7 @@ export function CuratedPlaylist() {
   }
 
   if (loading) {
-    return (
-      <div className="flex items-center justify-center py-24">
-        <Loader2 size={24} className="animate-spin text-primary" />
-      </div>
-    );
+    return <CrateLoader label="Loading playlist." />;
   }
 
   if (!data) {
@@ -432,11 +431,6 @@ export function CuratedPlaylist() {
             ? `${offlineRecord.readyTrackCount}/${offlineRecord.trackCount} tracks saved. Retry to finish the offline copy.`
             : "Offline copy failed. Retry to finish the playlist mirror."
           : null;
-  const editorialLabel = editorialPlaylistLabel(
-    data.name,
-    data.is_smart ? "Core Tracks" : "Crate Selects",
-  );
-
   async function handleToggleOffline() {
     if (!data) return;
     try {
@@ -455,171 +449,186 @@ export function CuratedPlaylist() {
     }
   }
 
-  return (
-    <div className="space-y-6">
-      <button
-        onClick={() => navigate(-1)}
-        className="inline-flex items-center gap-2 text-sm text-muted-foreground hover:text-foreground transition-colors"
-      >
-        <ArrowLeft size={16} />
-        Back
-      </button>
+  const offlineIcon =
+    offlineState === "ready"
+      ? ArrowDownToLineBold
+      : offlineBusy
+        ? Loader2
+        : offlineState === "error"
+          ? AlertCircle
+          : ArrowDownToLine;
+  const secondaryActions: PlaylistHeroSecondaryAction[] = [
+    {
+      key: "radio",
+      label: "Radio",
+      ariaLabel: "Playlist Radio",
+      icon: Radio,
+      disabled: playerTracks.length === 0,
+      onClick: () => void handlePlaylistRadio(),
+    },
+    {
+      key: "offline",
+      label: "Offline",
+      ariaLabel:
+        offlineState === "ready"
+          ? "Remove offline copy"
+          : "Make available offline",
+      icon: offlineIcon,
+      iconClassName: offlineBusy ? "animate-spin" : undefined,
+      className:
+        offlineState === "ready"
+          ? "text-cyan-200 drop-shadow-[0_0_8px_rgba(34,211,238,0.28)]"
+          : offlineBusy
+            ? "text-primary"
+            : offlineState === "error"
+              ? "text-amber-300/90"
+              : undefined,
+      disabled: !offlineSupported || data.is_smart || offlineBusy,
+      title: offlineButtonLabel,
+      onClick: () => void handleToggleOffline(),
+    },
+    {
+      key: "follow",
+      label: data.is_followed ? "Following" : "Follow",
+      ariaLabel: data.is_followed ? "Remove from your library" : "Follow",
+      icon: togglingFollow ? Loader2 : data.is_followed ? HeartBold : Heart,
+      iconClassName: togglingFollow ? "animate-spin" : undefined,
+      active: data.is_followed,
+      pulseIcon: data.is_followed,
+      disabled: togglingFollow,
+      onClick: () => void handleToggleFollow(),
+    },
+    {
+      key: "share",
+      label: "Share",
+      ariaLabel: "Share",
+      icon: Share2,
+      onClick: () => void handleShare(),
+    },
+  ];
+  const playlistMenuItems: ContextMenuEntry[] = [
+    {
+      key: "play",
+      label: "Play playlist",
+      icon: Play,
+      disabled: playerTracks.length === 0,
+      onSelect: handlePlay,
+    },
+    {
+      key: "shuffle",
+      label: "Shuffle playlist",
+      icon: Shuffle,
+      disabled: playerTracks.length === 0,
+      onSelect: handleShuffle,
+    },
+    {
+      key: "radio",
+      label: "Start playlist radio",
+      icon: Radio,
+      disabled: playerTracks.length === 0,
+      onSelect: handlePlaylistRadio,
+    },
+    {
+      type: "divider",
+      key: "curated-playlist-library-divider",
+    },
+    {
+      key: "follow",
+      label: data.is_followed
+        ? "Remove from your library"
+        : "Add to your library",
+      icon: data.is_followed ? HeartBold : Heart,
+      active: data.is_followed,
+      disabled: togglingFollow,
+      onSelect: handleToggleFollow,
+    },
+    {
+      key: "offline",
+      label: offlineButtonLabel,
+      icon: offlineIcon,
+      active: offlineState === "ready",
+      disabled: !offlineSupported || data.is_smart || offlineBusy,
+      onSelect: handleToggleOffline,
+    },
+    {
+      type: "divider",
+      key: "curated-playlist-share-divider",
+    },
+    {
+      key: "share",
+      label: "Share playlist",
+      icon: Share2,
+      onSelect: handleShare,
+    },
+  ];
+  const playlistMetaItems = [
+    `${data.track_count} track${data.track_count !== 1 ? "s" : ""}`,
+    data.total_duration > 0 ? formatTotalDuration(data.total_duration) : null,
+    `${data.follower_count} follower${data.follower_count !== 1 ? "s" : ""}`,
+    data.category,
+  ];
 
-      <div className="flex flex-col gap-6 md:flex-row">
-        <div className="w-[220px] max-w-full shrink-0">
-          <EditorialPlaylistArtwork
-            title={editorialLabel.title}
-            kicker={editorialLabel.kicker}
+  return (
+    <div className="-mx-4 -mt-4 sm:-mx-6 sm:-mt-6">
+      <PlaylistHeroSection
+        title={data.name}
+        subtitle="Crate playlist"
+        description={data.description}
+        metaItems={playlistMetaItems}
+        badges={<OfflineBadge state={offlineState} />}
+        artwork={(className) => (
+          <PlaylistArtwork
+            name={data.name}
             coverDataUrl={data.cover_data_url}
             tracks={data.artwork_tracks}
-            variant="core"
-            className="aspect-square rounded-3xl shadow-2xl"
+            className={className}
           />
-        </div>
-
-        <div className="flex flex-col justify-end gap-3 text-left">
-          <div>
-            <div className="flex flex-wrap items-center gap-2">
-              <h1 className="text-3xl font-bold text-foreground">
-                {data.name}
-              </h1>
-              <OfflineBadge state={offlineState} />
-            </div>
-            {data.description ? (
-              <p className="mt-2 max-w-2xl text-sm leading-6 text-muted-foreground">
-                {data.description}
-              </p>
-            ) : null}
-          </div>
-          <div className="flex flex-wrap items-center gap-x-4 gap-y-1 text-xs text-muted-foreground">
-            <span>{data.track_count} tracks</span>
-            {data.total_duration > 0 ? (
-              <span>{formatTotalDuration(data.total_duration)}</span>
-            ) : null}
-            <span className="inline-flex items-center gap-1">
-              <Users size={12} />
-              {data.follower_count} follower
-              {data.follower_count !== 1 ? "s" : ""}
-            </span>
-            {data.category ? <span>{data.category}</span> : null}
-          </div>
-        </div>
-      </div>
-
-      <div className="flex flex-wrap items-center gap-3">
-        <button
-          onClick={handlePlay}
-          disabled={playerTracks.length === 0}
-          className="inline-flex items-center gap-2 rounded-full bg-primary px-5 py-2.5 text-sm font-medium text-primary-foreground hover:bg-primary/90 transition-colors disabled:opacity-50"
-        >
-          <Play size={16} fill="currentColor" />
-          Play
-        </button>
-        <button
-          onClick={handleShuffle}
-          disabled={playerTracks.length === 0}
-          className="inline-flex items-center gap-2 rounded-full border border-white/15 px-4 py-2.5 text-sm text-foreground hover:bg-white/5 transition-colors disabled:opacity-50"
-        >
-          <Shuffle size={15} />
-          Shuffle
-        </button>
-        <button
-          onClick={handlePlaylistRadio}
-          disabled={playerTracks.length === 0}
-          className="inline-flex items-center gap-2 rounded-full border border-white/15 px-4 py-2.5 text-sm text-foreground hover:bg-white/5 transition-colors disabled:opacity-50"
-        >
-          <Radio size={15} />
-          Playlist Radio
-        </button>
-        <button
-          onClick={handleToggleOffline}
-          disabled={!offlineSupported || data.is_smart || offlineBusy}
-          className={`inline-flex h-11 w-11 items-center justify-center rounded-full border text-sm transition-colors disabled:opacity-50 ${
-            offlineState === "ready"
-              ? "border-cyan-400/25 bg-cyan-400/10 text-cyan-200"
-              : offlineBusy
-                ? "border border-primary/25 bg-primary/10 text-primary"
-                : offlineState === "error"
-                  ? "border border-amber-400/25 bg-amber-400/10 text-amber-200"
-                  : "border-white/15 text-foreground hover:bg-white/5"
-          }`}
-          aria-label={
-            offlineState === "ready"
-              ? "Remove offline copy"
-              : "Make available offline"
-          }
-          title={offlineButtonLabel}
-        >
-          {offlineState === "ready" ? (
-            <ArrowDownToLineBold size={15} />
-          ) : offlineBusy ? (
-            <Loader2 size={15} className="animate-spin" />
-          ) : offlineState === "error" ? (
-            <AlertCircle size={15} />
-          ) : (
-            <ArrowDownToLine size={15} />
-          )}
-        </button>
-        <button
-          onClick={handleToggleFollow}
-          disabled={togglingFollow}
-          className={`inline-flex items-center gap-2 rounded-full border px-4 py-2.5 text-sm transition-colors ${
-            data.is_followed
-              ? "border-primary/30 bg-primary/15 text-primary"
-              : "border-white/15 text-foreground hover:bg-white/5"
-          }`}
-        >
-          {togglingFollow ? (
-            <Loader2 size={15} className="animate-spin" />
-          ) : data.is_followed ? (
-            <HeartBold size={15} className="animate-crate-icon-active-pulse" />
-          ) : (
-            <Heart size={15} />
-          )}
-          {data.is_followed ? "Following" : "Follow"}
-        </button>
-        <button
-          onClick={handleShare}
-          className="inline-flex items-center gap-2 rounded-full border border-white/15 px-4 py-2.5 text-sm text-foreground hover:bg-white/5 transition-colors"
-        >
-          <Share2 size={15} />
-          Share
-        </button>
-      </div>
-
-      {offlineStatusDetail ? (
-        <p className="text-xs text-muted-foreground">{offlineStatusDetail}</p>
-      ) : null}
-
-      <PlaylistTrackFilterBar
-        query={filterQuery}
-        onQueryChange={setFilterQuery}
-        totalCount={data.tracks.length}
-        filteredCount={filteredTracks.length}
+        )}
+        menuImageUrl={data.cover_data_url}
+        menuImageAlt={data.name}
+        onPlay={handlePlay}
+        onShuffle={handleShuffle}
+        playDisabled={playerTracks.length === 0}
+        shuffleDisabled={playerTracks.length === 0}
+        secondaryActions={secondaryActions}
+        menuItems={playlistMenuItems}
       />
 
-      {data.tracks.length === 0 ? (
-        <div className="flex items-center justify-center py-16">
-          <p className="text-sm text-muted-foreground">
-            This playlist has no tracks yet
-          </p>
-        </div>
-      ) : filteredTracks.length === 0 ? (
-        <div className="flex items-center justify-center py-16">
-          <p className="text-sm text-muted-foreground">
-            No tracks match this filter
-          </p>
-        </div>
-      ) : (
-        <CuratedTrackList
-          tracks={filteredTracks}
-          playlistOptions={playlistOptions}
-          onAddToPlaylist={handleAddTrackToPlaylist}
-          onCreatePlaylist={handleCreatePlaylistFromTrack}
-          onActionMenuOpen={ensurePlaylistOptionsLoaded}
-          onPlayTrack={handlePlayTrack}
+      <div className="mx-auto w-full max-w-[1480px] space-y-6 px-4 pb-8 sm:px-6">
+        {offlineStatusDetail ? (
+          <p className="text-xs text-muted-foreground">{offlineStatusDetail}</p>
+        ) : null}
+
+        <PlaylistTrackFilterBar
+          query={filterQuery}
+          onQueryChange={setFilterQuery}
+          totalCount={data.tracks.length}
+          filteredCount={filteredTracks.length}
         />
-      )}
+
+        {data.tracks.length === 0 ? (
+          <div className="flex items-center justify-center py-16">
+            <p className="text-sm text-muted-foreground">
+              This playlist has no tracks yet
+            </p>
+          </div>
+        ) : filteredTracks.length === 0 ? (
+          <div className="flex items-center justify-center py-16">
+            <p className="text-sm text-muted-foreground">
+              No tracks match this filter
+            </p>
+          </div>
+        ) : (
+          <CuratedTrackList
+            tracks={filteredTracks}
+            playlistOptions={playlistOptions}
+            onAddToPlaylist={handleAddTrackToPlaylist}
+            onCreatePlaylist={handleCreatePlaylistFromTrack}
+            onActionMenuOpen={ensurePlaylistOptionsLoaded}
+            onPlayTrack={handlePlayTrack}
+          />
+        )}
+      </div>
     </div>
   );
 }

--- a/app/listen/src/pages/Explore.test.tsx
+++ b/app/listen/src/pages/Explore.test.tsx
@@ -1,8 +1,9 @@
-import { fireEvent, screen } from "@testing-library/react";
+import { fireEvent, screen, waitFor, within } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { useApi } from "@/hooks/use-api";
 import { startShapedRadio } from "@/lib/radio";
+import { SHARE_REQUEST_EVENT, type SharePayload } from "@/lib/social-share";
 import { renderWithListenProviders } from "@/test/render-with-listen-providers";
 
 import { Explore } from "./Explore";
@@ -117,6 +118,72 @@ describe("Explore", () => {
     expect(screen.queryByText("12 artists indexed")).toBeNull();
   });
 
+  it("opens genre detail using backend-provided genre slug", () => {
+    vi.mocked(useApi).mockImplementation((url: string | null) => {
+      if (url === "/api/browse/explore-page") {
+        return {
+          data: {
+            playlists: [],
+            moods: [],
+            filters: {
+              genres: [
+                {
+                  name: "Punk/Hardcore",
+                  slug: "punk-hardcore",
+                  count: 4,
+                  top_artists: ["Converge"],
+                  cover_url:
+                    "/api/genres/punk-hardcore/cover?size=640&format=webp",
+                },
+              ],
+              decades: [],
+              formats: [],
+              moods: [],
+            },
+          },
+          loading: false,
+          error: null,
+          refetch: vi.fn(),
+        };
+      }
+
+      if (url === "/api/genres/punk-hardcore?view=genre-detail-v5") {
+        return {
+          data: {
+            id: 1,
+            name: "Punk/Hardcore",
+            slug: "punk-hardcore",
+            artist_count: 1,
+            album_count: 1,
+            track_count: 1,
+            artists: [],
+            albums: [],
+            shows: [],
+          },
+          loading: false,
+          error: null,
+          refetch: vi.fn(),
+        };
+      }
+
+      return { data: null, loading: false, error: null, refetch: vi.fn() };
+    });
+
+    renderWithListenProviders(<Explore />, {
+      route: "/explore",
+      path: "/explore",
+    });
+
+    fireEvent.click(
+      screen.getByText("Punk/Hardcore").closest("button") as HTMLElement,
+    );
+
+    expect(
+      screen.getByRole("heading", { level: 1, name: "Punk/Hardcore" }),
+    ).toBeInTheDocument();
+    expect(screen.queryByText("Genre not found.")).toBeNull();
+  });
+
   it("renders a public genre hero with cover, description, and stats", () => {
     vi.mocked(useApi).mockImplementation((url: string | null) => {
       if (url === "/api/browse/explore-page") {
@@ -229,6 +296,103 @@ describe("Explore", () => {
     expect(screen.getByText("Circolo Magnolia")).toBeInTheDocument();
   });
 
+  it("hides the inline secondary genre action row on mobile", () => {
+    mockGenreDetail();
+
+    renderWithListenProviders(<Explore />, {
+      route: "/explore?genre=hardcore",
+      path: "/explore",
+    });
+
+    expect(
+      screen.queryByRole("group", { name: "Secondary genre actions" }),
+    ).toBeNull();
+    expect(screen.queryByRole("button", { name: "Share genre" })).toBeNull();
+    expect(screen.getByTestId("genre-mobile-hero-menu")).toBeInTheDocument();
+  });
+
+  it("groups public genre actions into primary pills and secondary icon labels", () => {
+    viewportState.isDesktop = true;
+    mockGenreDetail({
+      shows: [
+        {
+          id: 10,
+          type: "show",
+          date: "2030-07-03",
+          artist: "Converge",
+          artist_id: 1,
+          artist_slug: "converge",
+          title: "Circolo Magnolia",
+          subtitle: "Segrate, Italy",
+          cover_url: null,
+          status: "onsale",
+          venue: "Circolo Magnolia",
+          city: "Segrate",
+          country: "Italy",
+          genres: ["hardcore"],
+          is_upcoming: true,
+        },
+      ],
+    });
+
+    renderWithListenProviders(<Explore />, {
+      route: "/explore?genre=hardcore",
+      path: "/explore",
+    });
+
+    const primary = screen.getByRole("group", {
+      name: "Primary genre actions",
+    });
+    expect(
+      within(primary).getByRole("button", { name: "Play genre radio" }),
+    ).toHaveTextContent("Play");
+    expect(
+      within(primary).getByRole("button", {
+        name: "Open next genre show in Radar",
+      }),
+    ).toHaveTextContent("Next show");
+
+    const secondary = screen.getByRole("group", {
+      name: "Secondary genre actions",
+    });
+    expect(
+      within(secondary).getByRole("button", { name: "Share genre" }),
+    ).toHaveTextContent("Share");
+    expect(
+      within(secondary).getByRole("button", { name: "More" }),
+    ).toHaveTextContent("More");
+  });
+
+  it("opens the shared share sheet for public genres", () => {
+    viewportState.isDesktop = true;
+    mockGenreDetail();
+    let sharePayload: SharePayload | null = null;
+    const onShare = (event: Event) => {
+      sharePayload = (event as CustomEvent<SharePayload>).detail;
+    };
+    window.addEventListener(SHARE_REQUEST_EVENT, onShare);
+
+    try {
+      renderWithListenProviders(<Explore />, {
+        route: "/explore?genre=hardcore",
+        path: "/explore",
+      });
+
+      fireEvent.click(screen.getByRole("button", { name: "Share genre" }));
+
+      expect(sharePayload).toMatchObject({
+        kind: "genre",
+        title: "hardcore",
+        subtitle: "Genre",
+        imageUrl:
+          "/api/genres/hardcore/cover?size=1280&format=webp&hero=genre-detail-v5",
+        url: expect.stringContaining("/explore?genre=hardcore"),
+      });
+    } finally {
+      window.removeEventListener(SHARE_REQUEST_EVENT, onShare);
+    }
+  });
+
   it("falls back to the canonical genre cover when cached detail has no cover url", () => {
     mockGenreDetail({ coverUrl: null });
 
@@ -243,7 +407,79 @@ describe("Explore", () => {
     );
   });
 
-  it("starts seeded radio from the canonical genre slug", () => {
+  it("falls back to the canonical genre cover when hero image fails to load", async () => {
+    mockGenreDetail();
+
+    renderWithListenProviders(<Explore />, {
+      route: "/explore?genre=hardcore",
+      path: "/explore",
+    });
+
+    const heroImage = screen.getByAltText("hardcore genre cover");
+
+    expect(heroImage).toHaveAttribute(
+      "src",
+      "/api/genres/hardcore/cover?size=1280&format=webp&hero=genre-detail-v5",
+    );
+
+    fireEvent.error(heroImage);
+
+    await waitFor(() => {
+      expect(screen.getByAltText("hardcore genre cover")).toHaveAttribute(
+        "src",
+        "/api/genres/hardcore-punk/cover?size=1280&format=webp&hero=genre-detail-v5",
+      );
+    });
+  });
+
+  it("falls back to top artist photo when genre hero candidates fail", async () => {
+    mockGenreDetail({
+      coverUrl: null,
+      artists: [
+        {
+          artist_id: 111,
+          artist_name: "Less Popular",
+          artist_slug: "less-popular",
+          album_count: 3,
+          track_count: 6,
+          has_photo: true,
+          listeners: 120,
+        },
+        {
+          artist_id: 222,
+          artist_name: "Most Popular",
+          artist_slug: "most-popular",
+          album_count: 5,
+          track_count: 9,
+          has_photo: true,
+          listeners: 999,
+        },
+      ],
+    });
+
+    renderWithListenProviders(<Explore />, {
+      route: "/explore?genre=hardcore",
+      path: "/explore",
+    });
+
+    const heroImage = screen.getByAltText("hardcore genre cover");
+
+    expect(heroImage).toHaveAttribute(
+      "src",
+      "/api/genres/hardcore-punk/cover?size=1280&format=webp&hero=genre-detail-v5",
+    );
+
+    fireEvent.error(heroImage);
+
+    await waitFor(() => {
+      expect(screen.getByAltText("hardcore genre cover")).toHaveAttribute(
+        "src",
+        "/api/artists/222/photo?size=1280&format=webp&hero=genre-detail-v5",
+      );
+    });
+  });
+
+  it("starts seeded radio from the canonical genre slug", async () => {
     const playAll = vi.fn();
     vi.mocked(startShapedRadio).mockResolvedValue({
       sessionId: "radio-1",
@@ -280,6 +516,9 @@ describe("Explore", () => {
       "genre",
       "hardcore-punk",
     );
+    await waitFor(() => {
+      expect(playAll).toHaveBeenCalled();
+    });
   });
 
   it("limits public genre artists and albums on mobile", () => {
@@ -294,6 +533,71 @@ describe("Explore", () => {
     expect(screen.queryByText("Genre Artist 13")).toBeNull();
     expect(screen.getByText("Genre Album 12")).toBeInTheDocument();
     expect(screen.queryByText("Genre Album 13")).toBeNull();
+  });
+
+  it("limits public related genres on mobile", () => {
+    mockGenreDetail({
+      relatedGenres: Array.from({ length: 8 }, (_, index) => ({
+        slug: `related-${index + 1}`,
+        page_slug: `related-${index + 1}`,
+        name: `Related Genre ${index + 1}`,
+        relation_type: "related",
+        relation_label: "Related",
+        artist_count: 8 - index,
+        album_count: 2,
+      })),
+    });
+
+    renderWithListenProviders(<Explore />, {
+      route: "/explore?genre=hardcore",
+      path: "/explore",
+    });
+
+    expect(screen.getByText("Related Genre 6")).toBeInTheDocument();
+    expect(screen.queryByText("Related Genre 7")).toBeNull();
+  });
+
+  it("falls back related genre mini-card artwork through page genre, canonical genre, and top artist photo", () => {
+    mockGenreDetail({
+      relatedGenres: [
+        {
+          slug: "post-hardcore",
+          page_slug: "post-hardcore-scene",
+          name: "Post-hardcore",
+          relation_type: "related",
+          relation_label: "Related",
+          artist_count: 8,
+          album_count: 20,
+          cover_url: null,
+          top_artist_photo_url: "/api/artists/42/photo?size=640&format=webp",
+        },
+      ],
+    });
+
+    renderWithListenProviders(<Explore />, {
+      route: "/explore?genre=hardcore",
+      path: "/explore",
+    });
+
+    const card = screen.getByRole("button", { name: /Post-hardcore/i });
+    const image = card.querySelector("img");
+
+    expect(image).toHaveAttribute(
+      "src",
+      "/api/genres/post-hardcore-scene/cover?size=640&format=webp",
+    );
+
+    fireEvent.error(image!);
+    expect(card.querySelector("img")).toHaveAttribute(
+      "src",
+      "/api/genres/post-hardcore/cover?size=640&format=webp",
+    );
+
+    fireEvent.error(card.querySelector("img")!);
+    expect(card.querySelector("img")).toHaveAttribute(
+      "src",
+      "/api/artists/42/photo?size=640&format=webp",
+    );
   });
 
   it("keeps the full public genre grid on desktop", () => {
@@ -313,6 +617,16 @@ describe("Explore", () => {
 function mockGenreDetail(
   overrides: {
     coverUrl?: string | null;
+    artists?: Array<{
+      artist_id: number;
+      artist_name: string;
+      artist_slug?: string;
+      album_count: number;
+      track_count: number;
+      has_photo: boolean;
+      listeners: number | null;
+    }>;
+    relatedGenres?: Array<Record<string, unknown>>;
     shows?: Array<Record<string, unknown>>;
   } = {},
 ) {
@@ -350,18 +664,29 @@ function mockGenreDetail(
           artist_count: 13,
           album_count: 13,
           track_count: 39,
+          related_genres: overrides.relatedGenres || [],
           artists: Array.from({ length: 13 }, (_, index) => ({
             artist_id: index + 1,
             artist_name: `Genre Artist ${index + 1}`,
             artist_slug: `genre-artist-${index + 1}`,
             album_count: index + 1,
+            track_count: index + 1,
+            has_photo: false,
+            listeners: 0,
           })),
+          ...(overrides.artists
+            ? {
+                artists: overrides.artists,
+              }
+            : {}),
           albums: Array.from({ length: 13 }, (_, index) => ({
             album_id: index + 1,
             album_slug: `genre-album-${index + 1}`,
             artist: "Genre Artist 1",
             name: `Genre Album ${index + 1}`,
             year: 2020 + index,
+            track_count: 1,
+            has_cover: true,
           })),
           shows: overrides.shows || [],
         },

--- a/app/listen/src/pages/Explore.tsx
+++ b/app/listen/src/pages/Explore.tsx
@@ -18,7 +18,7 @@ import {
   type SystemPlaylist,
 } from "@/components/explore/explore-model";
 import { useApi } from "@/hooks/use-api";
-import { api } from "@/lib/api";
+import { api, resolveMaybeApiAssetUrl } from "@/lib/api";
 import { albumCoverApiUrl } from "@/lib/library-routes";
 import { toPlayableTrack } from "@/lib/playable-track";
 import { PlaylistCard } from "@/components/playlists/PlaylistCard";
@@ -288,6 +288,10 @@ function GenreExplorer({
   const topGenres = [...genres].sort((a, b) => b.count - a.count).slice(0, 12);
   if (!topGenres.length) return null;
 
+  function getGenreSlug(genre: (typeof topGenres)[number]) {
+    return genre.slug?.trim() || genre.name.toLowerCase().replace(/\s+/g, "-");
+  }
+
   return (
     <section className="space-y-4">
       <ExploreSectionHeader
@@ -296,6 +300,7 @@ function GenreExplorer({
       />
       <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-4">
         {topGenres.slice(0, 8).map((genre, index) => {
+          const resolvedCoverUrl = resolveMaybeApiAssetUrl(genre.cover_url);
           const detail =
             genre.description ||
             (genre.top_artists?.length
@@ -304,14 +309,14 @@ function GenreExplorer({
 
           return (
             <button
-              key={genre.name}
+              key={genre.slug || genre.name}
               type="button"
-              onClick={() => onOpen(genre.name)}
+              onClick={() => onOpen(getGenreSlug(genre))}
               className="group relative min-h-36 overflow-hidden rounded-3xl border border-white/10 bg-white/[0.035] p-4 text-left transition hover:border-primary/30 hover:bg-white/[0.06]"
             >
-              {genre.cover_url ? (
+              {resolvedCoverUrl ? (
                 <img
-                  src={genre.cover_url}
+                  src={resolvedCoverUrl}
                   alt=""
                   aria-hidden="true"
                   loading="lazy"
@@ -321,7 +326,7 @@ function GenreExplorer({
               <div
                 className="absolute inset-0 opacity-80"
                 style={{
-                  background: genre.cover_url
+                  background: resolvedCoverUrl
                     ? "linear-gradient(180deg, rgba(3,6,10,0.16) 0%, rgba(3,6,10,0.82) 100%)"
                     : `radial-gradient(circle at ${
                         20 + (index % 4) * 18

--- a/app/listen/src/pages/Home.test.tsx
+++ b/app/listen/src/pages/Home.test.tsx
@@ -1,0 +1,134 @@
+import { screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { useApi } from "@/hooks/use-api";
+import type { HomeDiscoveryPayload } from "@/components/home/home-model";
+import { renderWithListenProviders } from "@/test/render-with-listen-providers";
+
+import { Home } from "./Home";
+
+const viewportState = vi.hoisted(() => ({ isDesktop: false }));
+
+vi.mock("@crate/ui/lib/use-breakpoint", () => ({
+  useIsDesktop: () => viewportState.isDesktop,
+}));
+
+vi.mock("@/hooks/use-api", () => ({
+  useApi: vi.fn(),
+}));
+
+vi.mock("@/lib/api", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/api")>("@/lib/api");
+  return {
+    ...actual,
+    api: vi.fn(),
+    apiSseUrl: vi.fn((path: string) => path),
+  };
+});
+
+vi.mock("@/contexts/ArtistFollowsContext", () => ({
+  useArtistFollows: () => ({
+    isFollowing: vi.fn(() => false),
+    toggleArtistFollow: vi.fn(async () => true),
+  }),
+}));
+
+vi.mock("@/contexts/SavedAlbumsContext", () => ({
+  useSavedAlbums: () => ({
+    isSaved: vi.fn(() => false),
+    toggleAlbumSaved: vi.fn(async () => false),
+  }),
+}));
+
+class MockEventSource {
+  onopen: (() => void) | null = null;
+  onmessage: ((event: MessageEvent) => void) | null = null;
+  onerror: (() => void) | null = null;
+
+  constructor(public readonly url: string) {}
+
+  addEventListener = vi.fn();
+  close = vi.fn();
+}
+
+function homeDiscoveryPayload(): HomeDiscoveryPayload {
+  return {
+    snapshot: {
+      scope: "home",
+      subject_key: "user:1",
+      version: 1,
+      stale: false,
+      generation_ms: 1,
+    },
+    hero: [
+      {
+        id: 7,
+        slug: "converge",
+        name: "Converge",
+        genres: ["Hardcore"],
+        listeners: 639_200,
+        scrobbles: 52_600_000,
+        album_count: 9,
+        track_count: 118,
+        bio: "Converge are a Massachusetts hardcore band.",
+      },
+    ],
+    recently_played: [],
+    custom_mixes: [],
+    suggested_albums: [],
+    recommended_tracks: [],
+    radio_stations: [],
+    favorite_artists: [],
+    essentials: [],
+    recent_global_artists: [],
+    upcoming: {
+      items: [],
+      insights: [],
+      summary: {
+        followed_artists: 0,
+        show_count: 0,
+        release_count: 0,
+        attending_count: 0,
+        insight_count: 0,
+      },
+    },
+    replay: {
+      window: "month:2026-06",
+      title: "Crate DNA",
+      subtitle: "June 2026",
+      track_count: 0,
+      minutes_listened: 0,
+      items: [],
+    },
+  };
+}
+
+describe("Home", () => {
+  beforeEach(() => {
+    viewportState.isDesktop = false;
+    vi.stubGlobal("EventSource", MockEventSource);
+    vi.mocked(useApi).mockReturnValue({
+      data: homeDiscoveryPayload(),
+      loading: false,
+      error: null,
+      refetch: vi.fn(),
+    });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.clearAllMocks();
+  });
+
+  it("uses the taste hero on mobile instead of the old quick action buttons", () => {
+    renderWithListenProviders(<Home />);
+
+    expect(
+      screen.getByRole("heading", { name: "Converge" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: /Play Radio/i }),
+    ).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /^DNA$/i })).toBeNull();
+  });
+});

--- a/app/listen/src/pages/Home.tsx
+++ b/app/listen/src/pages/Home.tsx
@@ -7,7 +7,6 @@ import {
   useState,
 } from "react";
 import { useNavigate } from "react-router";
-import { Radio as RadioIcon, RotateCcw } from "@crate/ui/icons";
 import { toast } from "sonner";
 
 import { fetchArtistTopTracks } from "@/components/actions/shared";
@@ -17,7 +16,6 @@ import {
   FavoriteArtistsSection,
   HomeTasteHero,
   openRecentItemPath,
-  RadioStationsSection,
   RecentlyPlayedSection,
   RecommendedTracksSection,
   SuggestedAlbumsSection,
@@ -38,7 +36,6 @@ import type {
   HomeGeneratedPlaylistDetail,
   HomeGeneratedPlaylistSummary,
   HomeHeroArtist,
-  HomeRadioStation,
   HomeRecommendedTrack,
   HomeSectionId,
   HomeUpcomingInsight,
@@ -53,12 +50,7 @@ import { useApi } from "@/hooks/use-api";
 import { usePullToRefresh } from "@/hooks/use-pull-to-refresh";
 import { AUTH_TOKEN_EVENT, api, apiSseUrl } from "@/lib/api";
 import { fetchPlayableSetlist } from "@/lib/upcoming";
-import {
-  fetchAlbumRadio,
-  fetchArtistRadio,
-  fetchHomePlaylistRadio,
-  startShapedRadio,
-} from "@/lib/radio";
+import { fetchHomePlaylistRadio } from "@/lib/radio";
 import { albumCoverApiUrl, artistPagePath } from "@/lib/library-routes";
 import { toPlayableTrack } from "@/lib/playable-track";
 import {
@@ -116,7 +108,6 @@ export function Home() {
   const { play, playAll } = usePlayerActions();
   const { isFollowing, toggleArtistFollow } = useArtistFollows();
   const isDesktop = useIsDesktop();
-  const [startingDiscoveryRadio, setStartingDiscoveryRadio] = useState(false);
   const [dismissedHeroKeys, setDismissedHeroKeys] = useState<Set<string>>(
     () => new Set(),
   );
@@ -505,46 +496,6 @@ export function Home() {
     }
   }
 
-  async function playRadioStation(station: HomeRadioStation) {
-    try {
-      if (
-        station.type === "artist" &&
-        station.artist_id != null &&
-        station.artist_name
-      ) {
-        const radio = await fetchArtistRadio(
-          station.artist_id,
-          station.artist_name,
-          50,
-        );
-        if (!radio.tracks.length) {
-          toast.info("Artist radio is not available yet");
-          return;
-        }
-        playAll(radio.tracks, 0, radio.source);
-        return;
-      }
-      if (
-        station.type === "album" &&
-        station.album_id != null &&
-        station.artist_name
-      ) {
-        const radio = await fetchAlbumRadio({
-          albumId: station.album_id,
-          artistName: station.artist_name,
-          albumName: station.album_name || station.title,
-        });
-        if (!radio.tracks.length) {
-          toast.info("Album radio is not available yet");
-          return;
-        }
-        playAll(radio.tracks, 0, radio.source);
-      }
-    } catch {
-      toast.error("Failed to start radio");
-    }
-  }
-
   async function acknowledgeInsight(insight: HomeUpcomingInsight) {
     try {
       await api(`/api/me/shows/${insight.show_id}/reminders`, "POST", {
@@ -630,23 +581,6 @@ export function Home() {
     );
   }
 
-  async function startDiscoveryRadio() {
-    if (startingDiscoveryRadio) return;
-    setStartingDiscoveryRadio(true);
-    try {
-      const result = await startShapedRadio("discovery");
-      if (!result?.tracks.length) {
-        toast.info("Discovery Radio needs a bit more listening history");
-        return;
-      }
-      playAll(result.tracks, 0, result.source);
-    } catch {
-      toast.error("Failed to start Discovery Radio");
-    } finally {
-      setStartingDiscoveryRadio(false);
-    }
-  }
-
   if (!currentDiscovery) {
     return <CrateLoader label="Loading home." />;
   }
@@ -665,61 +599,34 @@ export function Home() {
           </p>
         </div>
 
-        {!isDesktop ? (
-          <div className="grid grid-cols-2 gap-3">
-            <button
-              type="button"
-              onClick={() => void startDiscoveryRadio()}
-              disabled={startingDiscoveryRadio}
-              className="flex min-h-14 touch-manipulation items-center gap-3 rounded-2xl border border-primary/25 bg-primary/12 px-4 text-left text-sm font-semibold text-foreground shadow-[0_0_28px_rgba(34,211,238,0.08)] transition active:scale-[0.98] disabled:opacity-60"
-            >
-              <span className="flex h-9 w-9 shrink-0 items-center justify-center rounded-full bg-primary text-black">
-                <RadioIcon size={18} />
-              </span>
-              Play Radio
-            </button>
-            <button
-              type="button"
-              onClick={playReplayMix}
-              disabled={!replay?.items?.length}
-              className="flex min-h-14 touch-manipulation items-center gap-3 rounded-2xl border border-white/10 bg-white/[0.04] px-4 text-left text-sm font-semibold text-foreground transition active:scale-[0.98] disabled:opacity-45"
-            >
-              <span className="flex h-9 w-9 shrink-0 items-center justify-center rounded-full bg-white/8 text-primary">
-                <RotateCcw size={18} />
-              </span>
-              DNA
-            </button>
-          </div>
-        ) : (
-          <HomeTasteHero
-            heroes={visibleHeroes}
-            isFollowing={isFollowing}
-            onOpenArtist={(artist) => {
-              void recordHeroRecommendationAction(artist, "opened");
-              navigate(
-                artistPagePath({
-                  artistId: artist.id,
-                  artistSlug: artist.slug,
-                  artistName: artist.name,
-                }),
-              );
-            }}
-            onPlay={(artist) => void playHeroArtist(artist)}
-            onToggleFollow={(artist) => void toggleHeroFollow(artist)}
-            onInfo={(artist) => {
-              void recordHeroRecommendationAction(artist, "opened");
-              navigate(
-                artistPagePath({
-                  artistId: artist.id,
-                  artistSlug: artist.slug,
-                  artistName: artist.name,
-                }),
-              );
-            }}
-            onDismiss={(artist) => void dismissHeroArtist(artist)}
-            onExpose={(artist) => void recordHeroExposure(artist)}
-          />
-        )}
+        <HomeTasteHero
+          heroes={visibleHeroes}
+          isFollowing={isFollowing}
+          onOpenArtist={(artist) => {
+            void recordHeroRecommendationAction(artist, "opened");
+            navigate(
+              artistPagePath({
+                artistId: artist.id,
+                artistSlug: artist.slug,
+                artistName: artist.name,
+              }),
+            );
+          }}
+          onPlay={(artist) => void playHeroArtist(artist)}
+          onToggleFollow={(artist) => void toggleHeroFollow(artist)}
+          onInfo={(artist) => {
+            void recordHeroRecommendationAction(artist, "opened");
+            navigate(
+              artistPagePath({
+                artistId: artist.id,
+                artistSlug: artist.slug,
+                artistName: artist.name,
+              }),
+            );
+          }}
+          onDismiss={(artist) => void dismissHeroArtist(artist)}
+          onExpose={(artist) => void recordHeroExposure(artist)}
+        />
       </div>
 
       <RecentlyPlayedSection
@@ -745,14 +652,6 @@ export function Home() {
       {isDesktop ? (
         <RecommendedTracksSection
           tracks={recommendedTracks}
-          onViewAll={openHomeSection}
-        />
-      ) : null}
-
-      {isDesktop ? (
-        <RadioStationsSection
-          stations={currentDiscovery?.radio_stations || []}
-          onPlayStation={(station) => void playRadioStation(station)}
           onViewAll={openHomeSection}
         />
       ) : null}

--- a/app/listen/src/pages/HomePlaylist.tsx
+++ b/app/listen/src/pages/HomePlaylist.tsx
@@ -1,14 +1,7 @@
 import { useDeferredValue, useMemo, useState } from "react";
-import { useNavigate, useParams } from "react-router";
-import {
-  ArrowLeft,
-  Loader2,
-  Play,
-  Radio,
-  Share2,
-  Shuffle,
-  Sparkles,
-} from "@crate/ui/icons";
+import { useParams } from "react-router";
+import { Play, Radio, Share2, Shuffle, Sparkles } from "@crate/ui/icons";
+import type { ContextMenuEntry } from "@crate/ui/domain/actions";
 import { toast } from "sonner";
 
 import { TrackRow, type TrackRowData } from "@/components/cards/TrackRow";
@@ -17,9 +10,14 @@ import { MixArtwork } from "@/components/home/MixArtwork";
 import type { HomeGeneratedPlaylistDetail } from "@/components/home/home-model";
 import { PlaylistArtwork } from "@/components/playlists/PlaylistArtwork";
 import {
+  PlaylistHeroSection,
+  type PlaylistHeroSecondaryAction,
+} from "@/components/playlists/PlaylistHeroSection";
+import {
   PlaylistTrackFilterBar,
   filterPlaylistTracks,
 } from "@/components/playlists/PlaylistTrackFilterBar";
+import { CrateLoader } from "@/components/ui/CrateLoader";
 import { usePlayerActions, type Track } from "@/contexts/PlayerContext";
 import { usePlaylistComposer } from "@/contexts/PlaylistComposerContext";
 import { useApi } from "@/hooks/use-api";
@@ -66,7 +64,6 @@ export function newArrivalsWindowLabel(
 }
 
 export function HomePlaylist() {
-  const navigate = useNavigate();
   const { playlistId } = useParams<{ playlistId: string }>();
   const { playAll } = usePlayerActions();
   const { openCreatePlaylist } = usePlaylistComposer();
@@ -197,11 +194,7 @@ export function HomePlaylist() {
   }
 
   if (loading) {
-    return (
-      <div className="flex items-center justify-center py-24">
-        <Loader2 size={24} className="animate-spin text-primary" />
-      </div>
-    );
+    return <CrateLoader label="Loading playlist." />;
   }
 
   if (!data) {
@@ -212,132 +205,137 @@ export function HomePlaylist() {
     );
   }
 
+  const secondaryActions: PlaylistHeroSecondaryAction[] = [
+    {
+      key: "radio",
+      label: "Radio",
+      ariaLabel: "Playlist Radio",
+      icon: Radio,
+      disabled: playerTracks.length === 0,
+      onClick: () => void handleRadio(),
+    },
+    {
+      key: "share",
+      label: "Share",
+      ariaLabel: "Share",
+      icon: Share2,
+      onClick: () => void handleShare(),
+    },
+  ];
+  const playlistMenuItems: ContextMenuEntry[] = [
+    {
+      key: "play",
+      label: "Play playlist",
+      icon: Play,
+      disabled: playerTracks.length === 0,
+      onSelect: handlePlay,
+    },
+    {
+      key: "shuffle",
+      label: "Shuffle playlist",
+      icon: Shuffle,
+      disabled: playerTracks.length === 0,
+      onSelect: handleShuffle,
+    },
+    {
+      key: "radio",
+      label: "Start playlist radio",
+      icon: Radio,
+      disabled: playerTracks.length === 0,
+      onSelect: handleRadio,
+    },
+    {
+      type: "divider",
+      key: "home-playlist-share-divider",
+    },
+    {
+      key: "share",
+      label: "Share playlist",
+      icon: Share2,
+      onSelect: handleShare,
+    },
+  ];
+  const playlistMetaItems = [
+    `${data.track_count} track${data.track_count !== 1 ? "s" : ""}`,
+    data.total_duration > 0 ? formatTotalDuration(data.total_duration) : null,
+    releaseWindowLabel,
+    "Generated for you",
+  ];
+  const renderArtwork = (className: string) =>
+    data.kind === "core" ? (
+      <CoreTracksArtwork item={data} className={className} />
+    ) : data.kind === "mix" ? (
+      <MixArtwork item={data} className={className} />
+    ) : (
+      <PlaylistArtwork
+        name={data.name}
+        tracks={data.artwork_tracks}
+        className={className}
+      />
+    );
+
   return (
-    <div className="space-y-6">
-      <button
-        onClick={() => navigate(-1)}
-        className="inline-flex items-center gap-2 text-sm text-muted-foreground transition-colors hover:text-foreground"
-      >
-        <ArrowLeft size={16} />
-        Back
-      </button>
-
-      <div className="flex flex-col gap-6 md:flex-row">
-        <div className="w-[220px] max-w-full shrink-0">
-          {data.kind === "core" ? (
-            <CoreTracksArtwork
-              item={data}
-              className="aspect-square rounded-3xl shadow-2xl"
-            />
-          ) : data.kind === "mix" ? (
-            <MixArtwork
-              item={data}
-              className="aspect-square rounded-3xl shadow-2xl"
-            />
-          ) : (
-            <PlaylistArtwork
-              name={data.name}
-              tracks={data.artwork_tracks}
-              className="aspect-square rounded-3xl shadow-2xl"
-            />
-          )}
-        </div>
-
-        <div className="flex flex-col justify-end gap-3 text-left">
-          <div className="inline-flex w-fit items-center gap-2 rounded-full border border-primary/25 bg-primary/10 px-3 py-1 text-[11px] font-medium uppercase tracking-wider text-primary">
+    <div className="-mx-4 -mt-4 sm:-mx-6 sm:-mt-6">
+      <PlaylistHeroSection
+        title={data.name}
+        subtitle="Generated playlist"
+        description={data.description}
+        metaItems={playlistMetaItems}
+        badges={
+          <span className="inline-flex w-fit items-center gap-2 rounded-full border border-primary/25 bg-primary/10 px-3 py-1 text-[11px] font-medium uppercase tracking-wider text-primary">
             <Sparkles size={12} />
             {data.badge}
-          </div>
-          <div>
-            <h1 className="text-3xl font-bold text-foreground">{data.name}</h1>
-            {data.description ? (
-              <p className="mt-2 max-w-2xl text-sm leading-6 text-muted-foreground">
-                {data.description}
-              </p>
-            ) : null}
-          </div>
-          <div className="flex flex-wrap items-center gap-x-4 gap-y-1 text-xs text-muted-foreground">
-            <span>{data.track_count} tracks</span>
-            {data.total_duration > 0 ? (
-              <span>{formatTotalDuration(data.total_duration)}</span>
-            ) : null}
-            {releaseWindowLabel ? <span>{releaseWindowLabel}</span> : null}
-            <span>Generated for you</span>
-          </div>
-        </div>
-      </div>
-
-      <div className="flex flex-wrap items-center gap-3">
-        <button
-          onClick={handlePlay}
-          disabled={playerTracks.length === 0}
-          className="inline-flex items-center gap-2 rounded-full bg-primary px-5 py-2.5 text-sm font-medium text-primary-foreground transition-colors hover:bg-primary/90 disabled:opacity-50"
-        >
-          <Play size={16} fill="currentColor" />
-          Play
-        </button>
-        <button
-          onClick={handleShuffle}
-          disabled={playerTracks.length === 0}
-          className="inline-flex items-center gap-2 rounded-full border border-white/15 px-4 py-2.5 text-sm text-foreground transition-colors hover:bg-white/5 disabled:opacity-50"
-        >
-          <Shuffle size={15} />
-          Shuffle
-        </button>
-        <button
-          onClick={handleShare}
-          className="inline-flex items-center gap-2 rounded-full border border-white/15 px-4 py-2.5 text-sm text-foreground transition-colors hover:bg-white/5"
-        >
-          <Share2 size={15} />
-          Share
-        </button>
-        <button
-          onClick={handleRadio}
-          disabled={playerTracks.length === 0}
-          className="inline-flex items-center gap-2 rounded-full border border-white/15 px-4 py-2.5 text-sm text-foreground transition-colors hover:bg-white/5 disabled:opacity-50"
-        >
-          <Radio size={15} />
-          Playlist Radio
-        </button>
-      </div>
-
-      <PlaylistTrackFilterBar
-        query={filterQuery}
-        onQueryChange={setFilterQuery}
-        totalCount={data.tracks.length}
-        filteredCount={filteredTracks.length}
+          </span>
+        }
+        artwork={renderArtwork}
+        onPlay={handlePlay}
+        onShuffle={handleShuffle}
+        playDisabled={playerTracks.length === 0}
+        shuffleDisabled={playerTracks.length === 0}
+        secondaryActions={secondaryActions}
+        menuItems={playlistMenuItems}
       />
 
-      {data.tracks.length === 0 ? (
-        <div className="flex items-center justify-center py-16">
-          <p className="text-sm text-muted-foreground">
-            This playlist has no tracks yet
-          </p>
-        </div>
-      ) : filteredTracks.length === 0 ? (
-        <div className="flex items-center justify-center py-16">
-          <p className="text-sm text-muted-foreground">
-            No tracks match this filter
-          </p>
-        </div>
-      ) : (
-        <div className="space-y-1">
-          {trackRows.map((row, index) => (
-            <TrackRow
-              key={row.id ?? `${row.path}-${index}`}
-              track={row}
-              index={index + 1}
-              showArtist
-              showAlbum
-              playlistOptions={playlistOptions}
-              onAddToPlaylist={handleAddTrackToPlaylist}
-              onCreatePlaylist={handleCreatePlaylistFromTrack}
-              onActionMenuOpen={ensurePlaylistOptionsLoaded}
-              queueTracks={trackRows}
-            />
-          ))}
-        </div>
-      )}
+      <div className="mx-auto w-full max-w-[1480px] space-y-6 px-4 pb-8 sm:px-6">
+        <PlaylistTrackFilterBar
+          query={filterQuery}
+          onQueryChange={setFilterQuery}
+          totalCount={data.tracks.length}
+          filteredCount={filteredTracks.length}
+        />
+
+        {data.tracks.length === 0 ? (
+          <div className="flex items-center justify-center py-16">
+            <p className="text-sm text-muted-foreground">
+              This playlist has no tracks yet
+            </p>
+          </div>
+        ) : filteredTracks.length === 0 ? (
+          <div className="flex items-center justify-center py-16">
+            <p className="text-sm text-muted-foreground">
+              No tracks match this filter
+            </p>
+          </div>
+        ) : (
+          <div className="space-y-1">
+            {trackRows.map((row, index) => (
+              <TrackRow
+                key={row.id ?? `${row.path}-${index}`}
+                track={row}
+                index={index + 1}
+                showCoverThumb
+                showArtist
+                showAlbum
+                playlistOptions={playlistOptions}
+                onAddToPlaylist={handleAddTrackToPlaylist}
+                onCreatePlaylist={handleCreatePlaylistFromTrack}
+                onActionMenuOpen={ensurePlaylistOptionsLoaded}
+                queueTracks={trackRows}
+              />
+            ))}
+          </div>
+        )}
+      </div>
     </div>
   );
 }

--- a/app/listen/src/pages/HomeSection.tsx
+++ b/app/listen/src/pages/HomeSection.tsx
@@ -1,11 +1,12 @@
 import { useMemo } from "react";
 import { useNavigate, useParams } from "react-router";
-import { ArrowLeft, Loader2 } from "@crate/ui/icons";
+import { ArrowLeft } from "@crate/ui/icons";
 import { toast } from "sonner";
 
 import { AlbumCard } from "@/components/cards/AlbumCard";
 import { ArtistCard } from "@/components/cards/ArtistCard";
 import { TrackRow, type TrackRowData } from "@/components/cards/TrackRow";
+import { CrateLoader } from "@/components/ui/CrateLoader";
 import {
   CoreTracksPlaylistCard,
   CustomMixCard,
@@ -172,11 +173,7 @@ export function HomeSection() {
   }
 
   if (loading) {
-    return (
-      <div className="flex items-center justify-center py-24">
-        <Loader2 size={24} className="animate-spin text-primary" />
-      </div>
-    );
+    return <CrateLoader label="Loading section." />;
   }
 
   if (!data) {

--- a/app/listen/src/pages/Library.tsx
+++ b/app/listen/src/pages/Library.tsx
@@ -46,7 +46,7 @@ import {
 } from "@crate/ui/primitives/AppModal";
 import { type PlaylistArtworkTrack } from "@/components/playlists/PlaylistArtwork";
 import { usePlayerActions, type Track } from "@/contexts/PlayerContext";
-import { api, apiAssetUrl } from "@/lib/api";
+import { api, apiAssetUrl, resolveMaybeApiAssetUrl } from "@/lib/api";
 import { contributionSourceLabel } from "@/lib/contributions";
 import { formatTotalDuration } from "@/lib/utils";
 import { albumCoverApiUrl } from "@/lib/library-routes";
@@ -960,61 +960,65 @@ function BandcampTab() {
         </div>
       ) : (
         <div className="grid gap-3">
-          {purchases.map((item) => (
-            <article
-              key={`${item.id}-${item.item_url}`}
-              className="flex items-center gap-3 rounded-2xl border border-white/8 bg-white/[0.03] p-3"
-            >
-              <div className="flex h-16 w-16 shrink-0 items-center justify-center overflow-hidden rounded-xl border border-white/8 bg-white/6">
-                {item.cover_url ? (
-                  <img
-                    src={item.cover_url}
-                    alt=""
-                    loading="lazy"
-                    className="h-full w-full object-cover"
-                  />
-                ) : (
-                  <BandcampLogo size={22} className="text-primary/70" />
-                )}
-              </div>
-              <div className="min-w-0 flex-1">
-                <h3 className="truncate text-sm font-black text-foreground">
-                  {bandcampItemTitle(item)}
-                </h3>
-                <p className="truncate text-xs text-muted-foreground">
-                  {item.artist_name || "Bandcamp"}
-                </p>
-              </div>
-              {item.latest_import_status === "completed" ? (
-                <span className="rounded-full border border-emerald-400/25 bg-emerald-400/10 px-3 py-1 text-xs font-bold text-emerald-300">
-                  Imported
-                </span>
-              ) : item.downloadable ? (
-                <button
-                  type="button"
-                  disabled={busyItemId === item.id}
-                  onClick={() => void importItem(item)}
-                  className="inline-flex min-h-10 items-center gap-2 rounded-full bg-primary px-3 text-xs font-black text-black disabled:opacity-50"
-                >
-                  {busyItemId === item.id ? (
-                    <Loader2 size={14} className="animate-spin" />
+          {purchases.map((item) => {
+            const coverUrl = resolveMaybeApiAssetUrl(item.cover_url);
+
+            return (
+              <article
+                key={`${item.id}-${item.item_url}`}
+                className="flex items-center gap-3 rounded-2xl border border-white/8 bg-white/[0.03] p-3"
+              >
+                <div className="flex h-16 w-16 shrink-0 items-center justify-center overflow-hidden rounded-xl border border-white/8 bg-white/6">
+                  {coverUrl ? (
+                    <img
+                      src={coverUrl}
+                      alt=""
+                      loading="lazy"
+                      className="h-full w-full object-cover"
+                    />
                   ) : (
-                    <Download size={14} />
+                    <BandcampLogo size={22} className="text-primary/70" />
                   )}
-                  Import
-                </button>
-              ) : null}
-              {item.item_url ? (
-                <button
-                  type="button"
-                  onClick={() => window.open(item.item_url || "", "_blank")}
-                  className="inline-flex min-h-10 items-center rounded-full border border-white/10 px-3 text-xs font-bold text-muted-foreground"
-                >
-                  <ExternalLink size={14} />
-                </button>
-              ) : null}
-            </article>
-          ))}
+                </div>
+                <div className="min-w-0 flex-1">
+                  <h3 className="truncate text-sm font-black text-foreground">
+                    {bandcampItemTitle(item)}
+                  </h3>
+                  <p className="truncate text-xs text-muted-foreground">
+                    {item.artist_name || "Bandcamp"}
+                  </p>
+                </div>
+                {item.latest_import_status === "completed" ? (
+                  <span className="rounded-full border border-emerald-400/25 bg-emerald-400/10 px-3 py-1 text-xs font-bold text-emerald-300">
+                    Imported
+                  </span>
+                ) : item.downloadable ? (
+                  <button
+                    type="button"
+                    disabled={busyItemId === item.id}
+                    onClick={() => void importItem(item)}
+                    className="inline-flex min-h-10 items-center gap-2 rounded-full bg-primary px-3 text-xs font-black text-black disabled:opacity-50"
+                  >
+                    {busyItemId === item.id ? (
+                      <Loader2 size={14} className="animate-spin" />
+                    ) : (
+                      <Download size={14} />
+                    )}
+                    Import
+                  </button>
+                ) : null}
+                {item.item_url ? (
+                  <button
+                    type="button"
+                    onClick={() => window.open(item.item_url || "", "_blank")}
+                    className="inline-flex min-h-10 items-center rounded-full border border-white/10 px-3 text-xs font-bold text-muted-foreground"
+                  >
+                    <ExternalLink size={14} />
+                  </button>
+                ) : null}
+              </article>
+            );
+          })}
         </div>
       )}
 

--- a/app/listen/src/pages/Login.tsx
+++ b/app/listen/src/pages/Login.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState, type FormEvent } from "react";
 import { Link, Navigate, useNavigate, useSearchParams } from "react-router";
 import { OAuthButtons } from "@/components/auth/OAuthButtons";
+import { CrateLoader } from "@/components/ui/CrateLoader";
 import { api, ApiError, setAuthTokens } from "@/lib/api";
 import { useAuth } from "@/contexts/AuthContext";
 import { isTauriRuntime } from "@/lib/platform";
@@ -44,11 +45,7 @@ export function Login() {
   }, []);
 
   if (authLoading) {
-    return (
-      <div className="flex min-h-screen items-center justify-center bg-app-surface px-4">
-        <div className="h-6 w-6 animate-spin rounded-full border-2 border-cyan-400 border-t-transparent" />
-      </div>
-    );
+    return <CrateLoader variant="screen" label="Loading Crate." />;
   }
 
   if (user) {

--- a/app/listen/src/pages/PathDetail.tsx
+++ b/app/listen/src/pages/PathDetail.tsx
@@ -12,6 +12,7 @@ import { toast } from "sonner";
 
 import { useApi } from "@/hooks/use-api";
 import { api } from "@/lib/api";
+import { CrateLoader } from "@/components/ui/CrateLoader";
 import { usePlayerActions, type Track } from "@/contexts/PlayerContext";
 import { albumCoverApiUrl } from "@/lib/library-routes";
 import { toPlayableTrack } from "@/lib/playable-track";
@@ -120,11 +121,7 @@ export function PathDetail() {
   }, []);
 
   if (loading || !path) {
-    return (
-      <div className="flex items-center justify-center py-20">
-        <Loader2 size={20} className="animate-spin text-primary" />
-      </div>
-    );
+    return <CrateLoader label="Loading music path." />;
   }
 
   const nodeCount = path.tracks.length;

--- a/app/listen/src/pages/Playlist.tsx
+++ b/app/listen/src/pages/Playlist.tsx
@@ -17,15 +17,21 @@ import {
   Copy,
   UserMinus,
 } from "@crate/ui/icons";
+import type { ContextMenuEntry } from "@crate/ui/domain/actions";
 import { toast } from "sonner";
 import { useApi } from "@/hooks/use-api";
 import { useLazyPlaylistOptions } from "@/hooks/use-lazy-playlist-options";
-import { api } from "@/lib/api";
+import { api, resolveMaybeApiAssetUrl } from "@/lib/api";
 import { TrackRow, type TrackRowData } from "@/components/cards/TrackRow";
+import { CrateLoader } from "@/components/ui/CrateLoader";
 import {
   PlaylistArtwork,
   type PlaylistArtworkTrack,
 } from "@/components/playlists/PlaylistArtwork";
+import {
+  PlaylistHeroSection,
+  type PlaylistHeroSecondaryAction,
+} from "@/components/playlists/PlaylistHeroSection";
 import {
   PlaylistTrackFilterBar,
   filterPlaylistTracks,
@@ -303,7 +309,7 @@ export function Playlist() {
       kind: "playlist",
       title: data.name,
       subtitle: data.description,
-      imageUrl: data.cover_data_url,
+      imageUrl: resolveMaybeApiAssetUrl(data.cover_data_url),
       url: publicShareUrl(`/playlist/${data.id}`),
     });
   }
@@ -491,11 +497,7 @@ export function Playlist() {
   }
 
   if (loading) {
-    return (
-      <div className="flex items-center justify-center py-16">
-        <Loader2 size={24} className="text-primary animate-spin" />
-      </div>
-    );
+    return <CrateLoader label="Loading playlist." />;
   }
 
   if (!data) {
@@ -506,196 +508,251 @@ export function Playlist() {
     );
   }
 
+  const playlistArtworkTracks = data.artwork_tracks ?? data.tracks;
+  const playlistMetaItems = [
+    `${data.track_count} track${data.track_count !== 1 ? "s" : ""}`,
+    data.total_duration > 0 ? formatTotalDuration(data.total_duration) : null,
+  ];
+  const offlineIcon =
+    offlineState === "ready"
+      ? ArrowDownToLineBold
+      : offlineBusy
+        ? Loader2
+        : offlineState === "error"
+          ? AlertCircle
+          : ArrowDownToLine;
+  const secondaryActions: PlaylistHeroSecondaryAction[] = [
+    {
+      key: "radio",
+      label: "Radio",
+      ariaLabel: "Playlist Radio",
+      icon: Radio,
+      disabled: playerTracks.length === 0,
+      onClick: () => void handlePlaylistRadio(),
+    },
+    {
+      key: "offline",
+      label: "Offline",
+      ariaLabel:
+        offlineState === "ready"
+          ? "Remove offline copy"
+          : "Make available offline",
+      icon: offlineIcon,
+      iconClassName: offlineBusy ? "animate-spin" : undefined,
+      className:
+        offlineState === "ready"
+          ? "text-cyan-200 drop-shadow-[0_0_8px_rgba(34,211,238,0.28)]"
+          : offlineBusy
+            ? "text-primary"
+            : offlineState === "error"
+              ? "text-amber-300/90"
+              : undefined,
+      disabled: !offlineSupported || data.is_smart || offlineBusy,
+      title: offlineButtonLabel,
+      onClick: () => void handleToggleOffline(),
+    },
+    ...(data.is_collaborative
+      ? [
+          {
+            key: "collaborators",
+            label: "Collabs",
+            ariaLabel: "Collaborators",
+            icon: Users,
+            onClick: () => setMembersOpen(true),
+          } satisfies PlaylistHeroSecondaryAction,
+        ]
+      : []),
+    {
+      key: "edit",
+      label: "Edit",
+      ariaLabel: "Edit",
+      icon: Pencil,
+      onClick: () => setEditorOpen(true),
+    },
+    {
+      key: "share",
+      label: "Share",
+      ariaLabel: "Share",
+      icon: Share2,
+      onClick: () => void handleShare(),
+    },
+  ];
+  const playlistMenuItems: ContextMenuEntry[] = [
+    {
+      key: "play",
+      label: "Play playlist",
+      icon: Play,
+      disabled: playerTracks.length === 0,
+      onSelect: handlePlay,
+    },
+    {
+      key: "shuffle",
+      label: "Shuffle playlist",
+      icon: Shuffle,
+      disabled: playerTracks.length === 0,
+      onSelect: handleShuffle,
+    },
+    {
+      key: "radio",
+      label: "Start playlist radio",
+      icon: Radio,
+      disabled: playerTracks.length === 0,
+      onSelect: handlePlaylistRadio,
+    },
+    {
+      type: "divider",
+      key: "playlist-state-divider",
+    },
+    {
+      key: "offline",
+      label: offlineButtonLabel,
+      icon: offlineIcon,
+      active: offlineState === "ready",
+      disabled: !offlineSupported || data.is_smart || offlineBusy,
+      onSelect: handleToggleOffline,
+    },
+    ...(data.is_collaborative
+      ? [
+          {
+            key: "collaborators",
+            label: "Collaborators",
+            icon: Users,
+            onSelect: () => setMembersOpen(true),
+          } satisfies ContextMenuEntry,
+        ]
+      : []),
+    {
+      key: "edit",
+      label: "Edit playlist",
+      icon: Pencil,
+      onSelect: () => setEditorOpen(true),
+    },
+    ...(data.is_smart
+      ? [
+          {
+            key: "regenerate",
+            label: "Regenerate playlist",
+            icon: RefreshCw,
+            onSelect: handleRegenerate,
+          } satisfies ContextMenuEntry,
+        ]
+      : []),
+    {
+      key: "share",
+      label: "Share playlist",
+      icon: Share2,
+      onSelect: handleShare,
+    },
+    {
+      type: "divider",
+      key: "playlist-danger-divider",
+    },
+    {
+      key: "delete",
+      label: "Delete playlist",
+      icon: Trash2,
+      danger: true,
+      onSelect: () => setDeleteOpen(true),
+    },
+  ];
+
   return (
-    <div className="space-y-6">
-      <div className="rounded-3xl border border-white/10 bg-white/5 p-5 sm:p-6">
-        <div className="flex flex-col gap-5 sm:flex-row sm:items-end">
+    <div className="-mx-4 -mt-4 sm:-mx-6 sm:-mt-6">
+      <PlaylistHeroSection
+        title={data.name}
+        subtitle={
+          data.visibility === "public" ? "Public playlist" : "Private playlist"
+        }
+        description={data.description}
+        metaItems={playlistMetaItems}
+        badges={
+          <>
+            <OfflineBadge state={offlineState} />
+            {data.is_smart ? (
+              <span className="inline-flex items-center rounded-md border border-primary/30 px-1.5 py-0 text-[10px] font-medium text-primary">
+                <Sparkles size={10} className="mr-0.5" />
+                Smart
+              </span>
+            ) : null}
+            <span className="inline-flex items-center rounded-md border border-white/10 px-1.5 py-0 text-[10px] font-medium text-white/60">
+              {data.visibility === "public" ? "Public" : "Private"}
+            </span>
+            {data.is_collaborative ? (
+              <span className="inline-flex items-center rounded-md border border-cyan-400/20 bg-cyan-400/10 px-1.5 py-0 text-[10px] font-medium text-cyan-300">
+                Collaborative
+              </span>
+            ) : null}
+          </>
+        }
+        artwork={(className) => (
           <PlaylistArtwork
             name={data.name}
             coverDataUrl={data.cover_data_url}
-            tracks={data.tracks}
-            className="w-40 h-40 sm:w-48 sm:h-48 rounded-2xl shadow-2xl flex-shrink-0"
+            tracks={playlistArtworkTracks}
+            className={className}
           />
-          <div className="min-w-0">
-            <div className="flex items-center gap-2 mb-1">
-              <h1 className="text-2xl font-bold text-foreground truncate">
-                {data.name}
-              </h1>
-              <OfflineBadge state={offlineState} />
-              {data.is_smart && (
-                <span className="inline-flex items-center rounded-md border border-primary/30 text-primary text-[10px] px-1.5 py-0 font-medium">
-                  <Sparkles size={10} className="mr-0.5" />
-                  Smart
-                </span>
-              )}
-              <span className="inline-flex items-center rounded-md border border-white/10 px-1.5 py-0 text-[10px] font-medium text-white/60">
-                {data.visibility === "public" ? "Public" : "Private"}
-              </span>
-              {data.is_collaborative ? (
-                <span className="inline-flex items-center rounded-md border border-cyan-400/20 bg-cyan-400/10 px-1.5 py-0 text-[10px] font-medium text-cyan-300">
-                  Collaborative
-                </span>
-              ) : null}
-            </div>
-            {data.description && (
-              <p className="text-sm text-muted-foreground mb-2">
-                {data.description}
-              </p>
-            )}
-            <div className="text-xs text-muted-foreground">
-              {data.track_count} track{data.track_count !== 1 ? "s" : ""}
-              {data.total_duration > 0 &&
-                ` · ${formatTotalDuration(data.total_duration)}`}
-            </div>
-          </div>
-        </div>
-
-        <div className="flex flex-wrap items-center gap-2 mt-4">
-          <button
-            onClick={handlePlay}
-            disabled={playerTracks.length === 0}
-            className="flex items-center gap-2 rounded-lg bg-primary px-5 py-2.5 text-sm font-medium text-primary-foreground hover:bg-primary/90 transition-colors disabled:opacity-50"
-          >
-            <Play size={16} fill="currentColor" />
-            Play
-          </button>
-          <button
-            onClick={handleShuffle}
-            disabled={playerTracks.length === 0}
-            className="flex items-center gap-2 rounded-lg border border-white/20 px-5 py-2.5 text-sm font-medium text-foreground hover:bg-white/10 transition-colors disabled:opacity-50"
-          >
-            <Shuffle size={16} />
-            Shuffle
-          </button>
-          <button
-            onClick={handlePlaylistRadio}
-            disabled={playerTracks.length === 0}
-            className="flex items-center gap-2 rounded-lg border border-white/20 px-5 py-2.5 text-sm font-medium text-foreground hover:bg-white/10 transition-colors disabled:opacity-50"
-          >
-            <Radio size={16} />
-            Playlist Radio
-          </button>
-          <button
-            onClick={handleToggleOffline}
-            disabled={!offlineSupported || data.is_smart || offlineBusy}
-            className={`flex h-11 w-11 items-center justify-center rounded-full border transition-colors disabled:opacity-50 ${
-              offlineState === "ready"
-                ? "border border-cyan-400/25 bg-cyan-400/10 text-cyan-200"
-                : offlineBusy
-                  ? "border border-primary/25 bg-primary/10 text-primary"
-                  : offlineState === "error"
-                    ? "border border-amber-400/25 bg-amber-400/10 text-amber-200"
-                    : "border-white/20 text-foreground hover:bg-white/10"
-            }`}
-            aria-label={
-              offlineState === "ready"
-                ? "Remove offline copy"
-                : "Make available offline"
-            }
-            title={offlineButtonLabel}
-          >
-            {offlineState === "ready" ? (
-              <ArrowDownToLineBold size={16} />
-            ) : offlineBusy ? (
-              <Loader2 size={16} className="animate-spin" />
-            ) : offlineState === "error" ? (
-              <AlertCircle size={16} />
-            ) : (
-              <ArrowDownToLine size={16} />
-            )}
-          </button>
-          {data.is_collaborative ? (
-            <button
-              onClick={() => setMembersOpen(true)}
-              className="flex items-center gap-2 rounded-lg border border-white/20 px-4 py-2.5 text-sm font-medium text-foreground hover:bg-white/10 transition-colors"
-            >
-              <Users size={16} />
-              Collaborators
-            </button>
-          ) : null}
-          <button
-            onClick={() => setEditorOpen(true)}
-            className="flex items-center gap-2 rounded-lg border border-white/20 px-4 py-2.5 text-sm font-medium text-foreground hover:bg-white/10 transition-colors"
-          >
-            <Pencil size={16} />
-            Edit
-          </button>
-          <button
-            onClick={handleShare}
-            className="flex items-center gap-2 rounded-lg border border-white/20 px-4 py-2.5 text-sm font-medium text-foreground hover:bg-white/10 transition-colors"
-          >
-            <Share2 size={16} />
-            Share
-          </button>
-          <button
-            onClick={() => setDeleteOpen(true)}
-            className="flex items-center gap-2 rounded-lg border border-red-500/25 px-4 py-2.5 text-sm font-medium text-red-300 hover:bg-red-500/10 transition-colors"
-          >
-            <Trash2 size={16} />
-            Delete
-          </button>
-          {data.is_smart && (
-            <button
-              onClick={handleRegenerate}
-              className="flex items-center gap-2 rounded-lg border border-white/20 px-4 py-2.5 text-sm font-medium text-foreground hover:bg-white/10 transition-colors"
-            >
-              <RefreshCw size={16} />
-              Regenerate
-            </button>
-          )}
-        </div>
-
-        {offlineStatusDetail ? (
-          <p className="mt-3 text-xs text-muted-foreground">
-            {offlineStatusDetail}
-          </p>
-        ) : null}
-      </div>
-
-      <PlaylistTrackFilterBar
-        query={filterQuery}
-        onQueryChange={setFilterQuery}
-        totalCount={data.tracks.length}
-        filteredCount={filteredTracks.length}
+        )}
+        menuImageUrl={data.cover_data_url}
+        menuImageAlt={data.name}
+        onPlay={handlePlay}
+        onShuffle={handleShuffle}
+        playDisabled={playerTracks.length === 0}
+        shuffleDisabled={playerTracks.length === 0}
+        secondaryActions={secondaryActions}
+        menuItems={playlistMenuItems}
       />
 
-      {/* Track list */}
-      {data.tracks.length === 0 ? (
-        <div className="flex items-center justify-center py-16">
-          <p className="text-sm text-muted-foreground">
-            This playlist has no tracks yet
-          </p>
-        </div>
-      ) : filteredTracks.length === 0 ? (
-        <div className="flex items-center justify-center py-16">
-          <p className="text-sm text-muted-foreground">
-            No tracks match this filter
-          </p>
-        </div>
-      ) : (
-        <WindowVirtualList
-          items={filteredTracks}
-          estimateSize={72}
-          itemKey={(t) => t.id ?? `${t.track_path}-${t.position}`}
-          renderItem={(t, i) => (
-            <TrackRow
-              track={toTrackRowData({
-                ...t,
-                id: t.track_id ?? t.track_path ?? t.title,
-                library_track_id: t.track_id,
-              })}
-              index={i + 1}
-              showArtist
-              showAlbum
-              playlistOptions={destinationPlaylistOptions}
-              onAddToPlaylist={handleAddTrackToPlaylist}
-              onCreatePlaylist={handleCreatePlaylistFromTrack}
-              onActionMenuOpen={ensurePlaylistOptionsLoaded}
-              onPlayOverride={() => handlePlayTrack(t.id)}
-            />
-          )}
+      <div className="mx-auto w-full max-w-[1480px] space-y-6 px-4 pb-8 sm:px-6">
+        {offlineStatusDetail ? (
+          <p className="text-xs text-muted-foreground">{offlineStatusDetail}</p>
+        ) : null}
+
+        <PlaylistTrackFilterBar
+          query={filterQuery}
+          onQueryChange={setFilterQuery}
+          totalCount={data.tracks.length}
+          filteredCount={filteredTracks.length}
         />
-      )}
+
+        {/* Track list */}
+        {data.tracks.length === 0 ? (
+          <div className="flex items-center justify-center py-16">
+            <p className="text-sm text-muted-foreground">
+              This playlist has no tracks yet
+            </p>
+          </div>
+        ) : filteredTracks.length === 0 ? (
+          <div className="flex items-center justify-center py-16">
+            <p className="text-sm text-muted-foreground">
+              No tracks match this filter
+            </p>
+          </div>
+        ) : (
+          <WindowVirtualList
+            items={filteredTracks}
+            estimateSize={72}
+            itemKey={(t) => t.id ?? `${t.track_path}-${t.position}`}
+            renderItem={(t, i) => (
+              <TrackRow
+                track={toTrackRowData({
+                  ...t,
+                  id: t.track_id ?? t.track_path ?? t.title,
+                  library_track_id: t.track_id,
+                })}
+                index={i + 1}
+                showCoverThumb
+                showArtist
+                showAlbum
+                playlistOptions={destinationPlaylistOptions}
+                onAddToPlaylist={handleAddTrackToPlaylist}
+                onCreatePlaylist={handleCreatePlaylistFromTrack}
+                onActionMenuOpen={ensurePlaylistOptionsLoaded}
+                onPlayOverride={() => handlePlayTrack(t.id)}
+              />
+            )}
+          />
+        )}
+      </div>
 
       <PlaylistCreateModal
         open={editorOpen}

--- a/app/listen/src/pages/PlaylistPages.test.tsx
+++ b/app/listen/src/pages/PlaylistPages.test.tsx
@@ -1,0 +1,223 @@
+import type { ReactNode } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { screen } from "@testing-library/react";
+
+import { renderWithListenProviders } from "@/test/render-with-listen-providers";
+import { useApi } from "@/hooks/use-api";
+import { Playlist } from "./Playlist";
+import { CuratedPlaylist } from "./CuratedPlaylist";
+import { HomePlaylist } from "./HomePlaylist";
+
+const trackRowProps = vi.hoisted(() => [] as Array<Record<string, unknown>>);
+
+vi.mock("@/hooks/use-api", () => ({
+  useApi: vi.fn(),
+}));
+
+vi.mock("@/hooks/use-lazy-playlist-options", () => ({
+  useLazyPlaylistOptions: () => ({
+    playlistOptions: [],
+    ensurePlaylistOptionsLoaded: vi.fn(),
+  }),
+}));
+
+vi.mock("@/contexts/PlaylistComposerContext", () => ({
+  usePlaylistComposer: () => ({
+    openCreatePlaylist: vi.fn(),
+  }),
+}));
+
+vi.mock("@/components/ui/WindowVirtualList", () => ({
+  WindowVirtualList: <T,>({
+    items,
+    renderItem,
+  }: {
+    items: T[];
+    renderItem: (item: T, index: number) => ReactNode;
+  }) => <div>{items.map((item, index) => renderItem(item, index))}</div>,
+}));
+
+vi.mock("@/components/cards/TrackRow", () => ({
+  TrackRow: (props: Record<string, unknown>) => {
+    trackRowProps.push(props);
+    const track = props.track as { title?: string };
+    return (
+      <div
+        data-testid="track-row"
+        data-show-cover-thumb={props.showCoverThumb ? "true" : "false"}
+      >
+        {track.title}
+      </div>
+    );
+  },
+}));
+
+vi.mock("@/components/playlists/PlaylistArtwork", () => ({
+  PlaylistArtwork: ({ name }: { name?: string }) => (
+    <div data-testid="plain-playlist-artwork">{name}</div>
+  ),
+}));
+
+vi.mock("@/components/playlists/EditorialPlaylistArtwork", () => ({
+  EditorialPlaylistArtwork: ({ title }: { title: string }) => (
+    <div data-testid="editorial-playlist-artwork">{title}</div>
+  ),
+  editorialPlaylistLabel: (name: string) => ({ title: name, kicker: "" }),
+}));
+
+vi.mock("@/components/playlists/PlaylistHeroSection", () => ({
+  PlaylistHeroSection: ({
+    title,
+    artwork,
+  }: {
+    title: string;
+    artwork: (className: string) => ReactNode;
+  }) => (
+    <section data-testid="playlist-hero">
+      <h1>{title}</h1>
+      {artwork("hero-artwork")}
+    </section>
+  ),
+}));
+
+vi.mock("sonner", () => ({
+  toast: {
+    error: vi.fn(),
+    info: vi.fn(),
+    success: vi.fn(),
+  },
+}));
+
+const playlistTrack = {
+  id: 1,
+  playlist_id: 42,
+  track_id: 10,
+  track_entity_uid: "track-10",
+  track_path: "Band/Album/Song.flac",
+  title: "Song",
+  artist: "Band",
+  artist_id: 7,
+  artist_entity_uid: "artist-7",
+  artist_slug: "band",
+  album: "Album",
+  album_id: 12,
+  album_entity_uid: "album-12",
+  album_slug: "album",
+  duration: 180,
+  position: 1,
+  added_at: "2026-06-01T00:00:00Z",
+};
+
+const basePlaylist = {
+  id: 42,
+  name: "Screamo",
+  description: "Raw nerves.",
+  cover_data_url: "/api/playlists/42/cover",
+  is_smart: false,
+  track_count: 1,
+  total_duration: 180,
+  artwork_tracks: [playlistTrack],
+  tracks: [playlistTrack],
+};
+
+const mockUseApi = vi.mocked(useApi);
+
+describe("playlist pages", () => {
+  beforeEach(() => {
+    trackRowProps.length = 0;
+    vi.clearAllMocks();
+    mockUseApi.mockImplementation((url: string | null) => {
+      if (url === "/api/playlists/42") {
+        return {
+          data: {
+            ...basePlaylist,
+            visibility: "public",
+            user_id: 1,
+            is_collaborative: false,
+            created_at: "2026-06-01T00:00:00Z",
+            updated_at: "2026-06-01T00:00:00Z",
+          },
+          loading: false,
+          error: null,
+          refetch: vi.fn(),
+        };
+      }
+      if (url === "/api/curation/playlists/42") {
+        return {
+          data: {
+            ...basePlaylist,
+            is_curated: true,
+            category: "editorial",
+            follower_count: 3,
+            is_followed: false,
+          },
+          loading: false,
+          error: null,
+          refetch: vi.fn(),
+        };
+      }
+      if (url === "/api/me/home/playlists/screamo?v=2") {
+        return {
+          data: {
+            id: "screamo",
+            name: "Screamo",
+            description: "Raw nerves.",
+            artwork_tracks: [playlistTrack],
+            artwork_artists: [],
+            track_count: 1,
+            total_duration: 180,
+            badge: "Editorial",
+            kind: "playlist",
+            tracks: [playlistTrack],
+          },
+          loading: false,
+          error: null,
+          refetch: vi.fn(),
+        };
+      }
+      return { data: null, loading: false, error: null, refetch: vi.fn() };
+    });
+  });
+
+  it("shows album cover thumbs in user playlist tracklists", () => {
+    renderWithListenProviders(<Playlist />, {
+      route: "/playlists/42",
+      path: "/playlists/:id",
+    });
+
+    expect(screen.getByTestId("track-row")).toHaveAttribute(
+      "data-show-cover-thumb",
+      "true",
+    );
+  });
+
+  it("shows album cover thumbs in generated playlist tracklists", () => {
+    renderWithListenProviders(<HomePlaylist />, {
+      route: "/home/playlist/screamo",
+      path: "/home/playlist/:playlistId",
+    });
+
+    expect(screen.getByTestId("track-row")).toHaveAttribute(
+      "data-show-cover-thumb",
+      "true",
+    );
+  });
+
+  it("keeps curated playlist hero artwork clean and moves text to the hero layout", () => {
+    renderWithListenProviders(<CuratedPlaylist />, {
+      route: "/playlists/curated/42",
+      path: "/playlists/curated/:id",
+    });
+
+    const hero = screen.getByTestId("playlist-hero");
+    expect(hero).toHaveTextContent("Screamo");
+    expect(
+      screen.queryByTestId("editorial-playlist-artwork"),
+    ).not.toBeInTheDocument();
+    expect(screen.getByTestId("plain-playlist-artwork")).toBeInTheDocument();
+    expect(screen.getByTestId("track-row")).toHaveAttribute(
+      "data-show-cover-thumb",
+      "true",
+    );
+  });
+});

--- a/app/listen/src/pages/Radio.test.tsx
+++ b/app/listen/src/pages/Radio.test.tsx
@@ -1,0 +1,118 @@
+import { fireEvent, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { api } from "@/lib/api";
+import { cacheClear } from "@/lib/cache";
+import { checkDiscoveryAvailable, startShapedRadio } from "@/lib/radio";
+import { renderWithListenProviders } from "@/test/render-with-listen-providers";
+
+import { RadioPage } from "./Radio";
+
+vi.mock("@/lib/api", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/api")>();
+  return {
+    ...actual,
+    api: vi.fn(),
+  };
+});
+
+vi.mock("@/lib/radio", () => ({
+  checkDiscoveryAvailable: vi.fn(),
+  startShapedRadio: vi.fn(),
+}));
+
+describe("RadioPage", () => {
+  beforeEach(() => {
+    cacheClear();
+    vi.mocked(api).mockReset();
+    vi.mocked(checkDiscoveryAvailable).mockResolvedValue(true);
+    vi.mocked(startShapedRadio).mockResolvedValue({
+      sessionId: "radio-session-1",
+      seedLabel: "hardcore",
+      tracks: [],
+      source: {
+        type: "radio",
+        name: "hardcore Radio",
+        radio: {
+          seedType: "genre",
+          seedId: "hardcore",
+          shapedSessionId: "radio-session-1",
+        },
+      },
+    });
+    vi.mocked(api).mockImplementation(async (url) => {
+      if (url === "/api/radio/stations") {
+        return {
+          artist_stations: [
+            {
+              type: "artist",
+              seed_type: "artist",
+              seed_value: "7",
+              seed_label: "Converge",
+              seed_subtitle: "Artist",
+              artist_id: 7,
+              artist_name: "Converge",
+              title: "Converge Radio",
+              subtitle: "",
+              play_count: 44,
+              minutes_listened: 180,
+            },
+          ],
+          genre_stations: [
+            {
+              type: "genre",
+              seed_type: "genre",
+              seed_value: "hardcore",
+              seed_label: "hardcore",
+              seed_subtitle: "Genre",
+              genre_slug: "hardcore",
+              genre_name: "hardcore",
+              cover_url: "/api/genres/hardcore/cover?size=640&format=webp",
+              title: "hardcore Radio",
+              subtitle: "",
+              play_count: 88,
+              minutes_listened: 320,
+            },
+          ],
+        };
+      }
+      if (url === "/api/genres") return [];
+      if (url.startsWith("/api/search")) return { artists: [], albums: [] };
+      throw new Error(`Unexpected API call: ${url}`);
+    });
+  });
+
+  it("renders personalized artist and genre station rails", async () => {
+    renderWithListenProviders(<RadioPage />, {
+      route: "/radio",
+      path: "/radio",
+    });
+
+    expect(await screen.findByText("Converge")).toBeInTheDocument();
+    expect(screen.getByText("Artist Stations")).toBeInTheDocument();
+    expect(screen.getByText("Genre Stations")).toBeInTheDocument();
+    expect(screen.getByText("hardcore")).toBeInTheDocument();
+    expect(screen.queryByText("Based on your heavy rotation")).toBeNull();
+  });
+
+  it("starts seeded genre radio from a genre station", async () => {
+    const playAll = vi.fn();
+
+    renderWithListenProviders(<RadioPage />, {
+      route: "/radio",
+      path: "/radio",
+      playerActions: { playAll },
+    });
+
+    fireEvent.click(await screen.findByRole("button", { name: /hardcore/i }));
+
+    await waitFor(() => {
+      expect(startShapedRadio).toHaveBeenCalledWith(
+        "seeded",
+        "genre",
+        "hardcore",
+      );
+    });
+    expect(playAll).toHaveBeenCalled();
+  });
+});

--- a/app/listen/src/pages/Radio.tsx
+++ b/app/listen/src/pages/Radio.tsx
@@ -2,6 +2,7 @@ import { useState, useCallback, useEffect } from "react";
 import {
   Loader2,
   Music,
+  Play,
   Radio as RadioIcon,
   Sparkles,
   ThumbsDown,
@@ -9,12 +10,44 @@ import {
 } from "@crate/ui/icons";
 import { toast } from "sonner";
 
-import { api } from "@/lib/api";
+import {
+  SectionHeader,
+  SectionLoading,
+  SectionRail,
+} from "@/components/home/HomeSections";
 import { usePlayerActions } from "@/contexts/PlayerContext";
+import { useApi } from "@/hooks/use-api";
+import { api, resolveMaybeApiAssetUrl } from "@/lib/api";
 import { albumCoverApiUrl, artistPhotoApiUrl } from "@/lib/library-routes";
 import { startShapedRadio, checkDiscoveryAvailable } from "@/lib/radio";
+import { cn } from "@/lib/utils";
 
 type EndpointType = "artist" | "genre" | "album" | "track";
+type StationSeedType = "artist" | "genre";
+
+interface PersonalizedRadioStation {
+  type: StationSeedType;
+  seed_type: StationSeedType;
+  seed_value: string;
+  seed_label: string;
+  seed_subtitle?: string | null;
+  title: string;
+  subtitle?: string | null;
+  play_count?: number;
+  minutes_listened?: number;
+  artist_id?: number | null;
+  artist_entity_uid?: string | null;
+  artist_slug?: string | null;
+  artist_name?: string | null;
+  genre_slug?: string | null;
+  genre_name?: string | null;
+  cover_url?: string | null;
+}
+
+interface PersonalizedRadioStationsResponse {
+  artist_stations: PersonalizedRadioStation[];
+  genre_stations: PersonalizedRadioStation[];
+}
 
 interface SearchResult {
   type: EndpointType;
@@ -23,8 +56,143 @@ interface SearchResult {
   imageUrl?: string;
 }
 
+function stationTypeLabel(station: PersonalizedRadioStation): string {
+  return station.seed_type === "genre" ? "Genre Radio" : "Artist Radio";
+}
+
+function stationLabel(station: PersonalizedRadioStation): string {
+  return (
+    station.seed_label ||
+    station.genre_name ||
+    station.artist_name ||
+    station.title.replace(/\s+Radio$/i, "")
+  );
+}
+
+function stationArtwork(station: PersonalizedRadioStation): string | null {
+  if (station.type === "genre") {
+    return resolveMaybeApiAssetUrl(station.cover_url) || null;
+  }
+  return (
+    artistPhotoApiUrl(
+      {
+        artistId: station.artist_id,
+        artistEntityUid: station.artist_entity_uid,
+        artistSlug: station.artist_slug,
+        artistName: station.artist_name || station.seed_label,
+      },
+      { size: 320 },
+    ) || null
+  );
+}
+
+function StationCard({
+  station,
+  disabled,
+  onStart,
+}: {
+  station: PersonalizedRadioStation;
+  disabled: boolean;
+  onStart: (station: PersonalizedRadioStation) => void;
+}) {
+  const label = stationLabel(station);
+  const imageUrl = stationArtwork(station);
+  const plays = station.play_count || 0;
+
+  return (
+    <button
+      type="button"
+      aria-label={`Start ${label} ${stationTypeLabel(station)}`}
+      disabled={disabled}
+      onClick={() => onStart(station)}
+      className="group relative aspect-square snap-start overflow-hidden rounded-xl border border-white/8 bg-white/[0.03] text-left shadow-[0_18px_70px_rgba(0,0,0,0.24)] transition duration-300 hover:border-primary/30 hover:shadow-[0_18px_80px_rgba(10,209,241,0.12)] disabled:cursor-not-allowed disabled:opacity-50"
+    >
+      {imageUrl ? (
+        <img
+          src={imageUrl}
+          alt=""
+          className="absolute inset-0 h-full w-full object-cover opacity-85 transition duration-500 group-hover:scale-[1.04] group-hover:opacity-100"
+          loading="lazy"
+        />
+      ) : (
+        <div
+          className={cn(
+            "absolute inset-0 bg-[radial-gradient(circle_at_30%_20%,rgba(10,209,241,0.24),transparent_34%),linear-gradient(145deg,rgba(255,255,255,0.08),rgba(255,255,255,0.01))]",
+            station.type === "genre" && "bg-primary/10",
+          )}
+        />
+      )}
+      <div className="absolute inset-0 bg-gradient-to-t from-black via-black/35 to-black/10" />
+      <div className="absolute inset-x-3 top-3 flex items-center justify-between gap-2">
+        <span className="rounded-full border border-white/12 bg-black/35 px-2.5 py-1 text-[10px] font-semibold uppercase tracking-[0.16em] text-white/65 backdrop-blur-md">
+          {stationTypeLabel(station)}
+        </span>
+        <span className="flex h-8 w-8 items-center justify-center rounded-full bg-primary text-black opacity-0 shadow-[0_0_24px_rgba(10,209,241,0.32)] transition duration-300 group-hover:opacity-100">
+          <Play size={14} className="translate-x-px" />
+        </span>
+      </div>
+      <div className="absolute inset-x-3 bottom-3">
+        <div className="line-clamp-2 text-base font-semibold leading-tight text-white">
+          {label}
+        </div>
+        {plays > 0 ? (
+          <div className="mt-1 text-xs text-white/52">{plays} plays</div>
+        ) : null}
+      </div>
+    </button>
+  );
+}
+
+function StationRail({
+  title,
+  subtitle,
+  stations,
+  loading,
+  disabled,
+  onStart,
+}: {
+  title: string;
+  subtitle: string;
+  stations: PersonalizedRadioStation[];
+  loading: boolean;
+  disabled: boolean;
+  onStart: (station: PersonalizedRadioStation) => void;
+}) {
+  if (loading) {
+    return (
+      <section className="space-y-4">
+        <SectionHeader title={title} subtitle={subtitle} />
+        <SectionLoading />
+      </section>
+    );
+  }
+
+  if (!stations.length) return null;
+
+  return (
+    <section className="space-y-4">
+      <SectionHeader title={title} subtitle={subtitle} />
+      <SectionRail fit="square-card">
+        {stations.map((station) => (
+          <StationCard
+            key={`${station.seed_type}-${station.seed_value}`}
+            station={station}
+            disabled={disabled}
+            onStart={onStart}
+          />
+        ))}
+      </SectionRail>
+    </section>
+  );
+}
+
 export function RadioPage() {
   const { playAll } = usePlayerActions();
+  const {
+    data: stationGroups,
+    loading: stationsLoading,
+    error: stationsError,
+  } = useApi<PersonalizedRadioStationsResponse>("/api/radio/stations");
   const [discoveryAvailable, setDiscoveryAvailable] = useState(false);
   const [starting, setStarting] = useState(false);
   const [activeSession, setActiveSession] = useState<string | null>(null);
@@ -41,6 +209,9 @@ export function RadioPage() {
   useEffect(() => {
     checkDiscoveryAvailable().then(setDiscoveryAvailable);
   }, []);
+
+  const artistStations = stationGroups?.artist_stations ?? [];
+  const genreStations = stationGroups?.genre_stations ?? [];
 
   const search = useCallback(async (q: string) => {
     if (q.length < 2) {
@@ -111,6 +282,29 @@ export function RadioPage() {
     }
   }, []);
 
+  const startStation = async (station: PersonalizedRadioStation) => {
+    setStarting(true);
+    const seedValue =
+      station.seed_value ||
+      station.genre_slug ||
+      (station.artist_id != null ? String(station.artist_id) : "");
+    const result = await startShapedRadio(
+      "seeded",
+      station.seed_type,
+      seedValue,
+    );
+    if (!result) {
+      toast.error("Could not start radio");
+      setStarting(false);
+      return;
+    }
+    setActiveSession(result.sessionId);
+    setActiveMode("seeded");
+    setSeedLabel(result.seedLabel || stationLabel(station));
+    playAll(result.tracks, 0, result.source);
+    setStarting(false);
+  };
+
   const startSeeded = async (seed: SearchResult) => {
     setStarting(true);
     setQuery("");
@@ -144,63 +338,83 @@ export function RadioPage() {
   };
 
   return (
-    <div className="animate-page-in space-y-6 px-4 py-6 sm:px-6">
-      {/* Header */}
-      <div className="flex items-center gap-3">
-        <RadioIcon size={22} className="text-primary" />
-        <div>
-          <h1 className="text-2xl font-bold text-foreground">Radio</h1>
-          <p className="text-[13px] text-white/40">
-            Infinite music, shaped by your taste
-          </p>
+    <div className="animate-page-in space-y-7 px-4 py-6 sm:px-6">
+      <div className="relative overflow-hidden rounded-2xl border border-white/8 bg-white/[0.03] p-5 shadow-[0_24px_90px_rgba(0,0,0,0.28)] sm:p-6">
+        <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_16%_18%,rgba(10,209,241,0.2),transparent_32%),linear-gradient(135deg,rgba(255,255,255,0.06),transparent_52%)]" />
+        <div className="relative flex flex-col gap-5 sm:flex-row sm:items-end sm:justify-between">
+          <div className="flex min-w-0 items-start gap-4">
+            <div className="flex h-14 w-14 shrink-0 items-center justify-center rounded-2xl bg-primary text-black shadow-[0_0_34px_rgba(10,209,241,0.32)]">
+              <RadioIcon size={24} />
+            </div>
+            <div className="min-w-0">
+              <h1 className="text-3xl font-bold leading-tight text-foreground">
+                Radio
+              </h1>
+              <p className="mt-1 max-w-2xl text-sm leading-relaxed text-white/52">
+                Start from the artists and scenes Crate already knows you come
+                back to.
+              </p>
+            </div>
+          </div>
+
+          <button
+            onClick={startDiscovery}
+            disabled={starting || !discoveryAvailable}
+            className={cn(
+              "group inline-flex min-h-12 items-center justify-center gap-3 rounded-full px-5 text-sm font-semibold text-black transition duration-300",
+              "bg-primary shadow-[0_0_28px_rgba(10,209,241,0.28)] hover:shadow-[0_0_38px_rgba(10,209,241,0.4)] disabled:opacity-40",
+            )}
+          >
+            {starting ? (
+              <Loader2 size={19} className="animate-spin" />
+            ) : (
+              <Sparkles size={19} />
+            )}
+            Discovery Radio
+          </button>
         </div>
       </div>
 
-      {/* Discovery Radio — always visible */}
-      <button
-        onClick={startDiscovery}
-        disabled={starting || !discoveryAvailable}
-        className={`group flex w-full items-center gap-4 rounded-2xl border p-5 text-left transition ${
-          activeMode === "discovery"
-            ? "border-primary/35 bg-gradient-to-r from-primary/15 via-primary/8 to-transparent"
-            : "border-primary/20 bg-gradient-to-r from-primary/10 via-primary/5 to-transparent hover:border-primary/35 hover:from-primary/15 disabled:opacity-40"
-        }`}
-      >
-        <div className="flex h-14 w-14 flex-shrink-0 items-center justify-center rounded-xl bg-primary/15 text-primary shadow-[0_0_20px_rgba(6,182,212,0.2)] transition group-hover:shadow-[0_0_30px_rgba(6,182,212,0.3)]">
-          {starting ? (
-            <Loader2 size={24} className="animate-spin" />
-          ) : activeMode === "discovery" ? (
-            <div className="h-3 w-3 animate-pulse rounded-full bg-primary shadow-[0_0_12px_rgba(6,182,212,0.6)]" />
-          ) : (
-            <Sparkles size={24} />
-          )}
-        </div>
-        <div>
+      {activeMode === "discovery" ? (
+        <div className="rounded-xl border border-primary/15 bg-primary/5 px-4 py-3">
           <div className="flex items-center gap-2">
-            <span className="text-base font-semibold text-foreground">
+            <div className="h-2 w-2 animate-pulse rounded-full bg-primary shadow-[0_0_8px_rgba(6,182,212,0.5)]" />
+            <span className="text-sm font-medium text-primary">
               Discovery Radio
             </span>
-            {activeMode === "discovery" && (
-              <span className="rounded-full border border-primary/30 bg-primary/10 px-2 py-0.5 text-[10px] font-medium text-primary">
-                playing
-              </span>
-            )}
-          </div>
-          <div className="mt-0.5 text-[13px] text-white/45">
-            {activeMode === "discovery"
-              ? "Use thumbs up/down in the player to shape the sound."
-              : discoveryAvailable
-                ? "Based on your likes, follows, and saved albums. Like or dislike tracks to shape the sound."
-                : "Follow an artist or save an album to unlock Discovery Radio."}
+            <span className="text-[11px] text-white/35">playing</span>
           </div>
         </div>
-      </button>
+      ) : null}
 
-      {/* Seeded Radio — search to start */}
-      <div className="rounded-2xl border border-white/8 bg-white/[0.02] p-5">
+      <StationRail
+        title="Artist Stations"
+        subtitle="Artist-led stations from your listening history and follows."
+        stations={artistStations}
+        loading={stationsLoading}
+        disabled={starting}
+        onStart={startStation}
+      />
+
+      <StationRail
+        title="Genre Stations"
+        subtitle="Scene-level stations shaped by the genres you actually play."
+        stations={genreStations}
+        loading={stationsLoading}
+        disabled={starting}
+        onStart={startStation}
+      />
+
+      {stationsError ? (
+        <div className="rounded-xl border border-white/8 bg-white/[0.02] px-4 py-3 text-sm text-white/45">
+          Could not load personalized stations.
+        </div>
+      ) : null}
+
+      <div className="rounded-2xl border border-white/8 bg-white/[0.03] p-5 shadow-[0_18px_70px_rgba(0,0,0,0.22)]">
         <div className="mb-4 flex items-center gap-2 text-sm font-semibold text-foreground">
           <RadioIcon size={16} className="text-primary" />
-          Start a radio station
+          Start from anything
         </div>
 
         <input
@@ -211,7 +425,7 @@ export function RadioPage() {
             void search(e.target.value);
           }}
           placeholder="Search an artist, genre, or album to seed the radio..."
-          className="h-11 w-full rounded-xl border border-white/10 bg-black/30 px-4 text-sm text-foreground placeholder:text-white/25 focus:border-primary/30 focus:outline-none"
+          className="h-12 w-full rounded-xl border border-white/10 bg-black/30 px-4 text-sm text-foreground placeholder:text-white/25 focus:border-primary/35 focus:outline-none"
         />
 
         {searching && (
@@ -272,27 +486,6 @@ export function RadioPage() {
           </div>
         </div>
       )}
-
-      {/* How it works */}
-      <div className="rounded-xl border border-white/6 bg-white/[0.01] p-5">
-        <div className="mb-3 text-[11px] font-semibold uppercase tracking-wider text-white/30">
-          How it works
-        </div>
-        <div className="space-y-3 text-[13px] leading-relaxed text-white/45">
-          <p>
-            Radio uses bliss similarity vectors, artist connections, and genre
-            overlap to find tracks that naturally flow from your seed. No fixed
-            playlist — the queue generates endlessly.
-          </p>
-          <p>
-            When you <strong className="text-white/60">like</strong> a track,
-            the radio shifts toward that sound. When you{" "}
-            <strong className="text-white/60">dislike</strong>, it steers away.
-            The more feedback you give, the more the radio learns what you want
-            to hear in this session.
-          </p>
-        </div>
-      </div>
     </div>
   );
 }

--- a/app/listen/src/pages/Register.tsx
+++ b/app/listen/src/pages/Register.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect } from "react";
 import { Link, Navigate, useNavigate, useSearchParams } from "react-router";
-import { Loader2 } from "@crate/ui/icons";
 import { OAuthButtons } from "@/components/auth/OAuthButtons";
+import { CrateLoader } from "@/components/ui/CrateLoader";
 import { api, ApiError, setAuthTokens } from "@/lib/api";
 import { useAuth } from "@/contexts/AuthContext";
 
@@ -24,11 +24,7 @@ export function Register() {
   }, []);
 
   if (authLoading) {
-    return (
-      <div className="flex min-h-screen items-center justify-center bg-app-surface px-4">
-        <Loader2 size={20} className="animate-spin text-primary" />
-      </div>
-    );
+    return <CrateLoader variant="screen" label="Loading Crate." />;
   }
 
   if (user) {

--- a/app/listen/src/pages/SearchResults.tsx
+++ b/app/listen/src/pages/SearchResults.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useMemo } from "react";
 import { useSearchParams } from "react-router";
-import { Loader2, Play, Search } from "@crate/ui/icons";
+import { Play, Search } from "@crate/ui/icons";
 import { api, ApiError } from "@/lib/api";
 import { albumCoverApiUrl } from "@/lib/library-routes";
 import { toPlayableTrack } from "@/lib/playable-track";
@@ -8,6 +8,7 @@ import { toTrackRowData } from "@/lib/track-row-data";
 import { ArtistCard } from "@/components/cards/ArtistCard";
 import { AlbumCard } from "@/components/cards/AlbumCard";
 import { TrackRow } from "@/components/cards/TrackRow";
+import { CrateLoader } from "@/components/ui/CrateLoader";
 import { usePlayerActions, type Track } from "@/contexts/PlayerContext";
 
 interface SearchData {
@@ -110,12 +111,7 @@ export function SearchResults() {
 
   if (!query)
     return <p className="text-muted-foreground">Enter a search term</p>;
-  if (loading && !data)
-    return (
-      <div className="flex justify-center py-12">
-        <Loader2 className="h-5 w-5 animate-spin text-primary" />
-      </div>
-    );
+  if (loading && !data) return <CrateLoader label="Loading search results." />;
   if (searchError)
     return (
       <div className="space-y-8">

--- a/app/listen/src/pages/Stats.tsx
+++ b/app/listen/src/pages/Stats.tsx
@@ -4,12 +4,12 @@ import {
   Activity,
   BarChart3,
   CalendarDays,
-  Compass,
   Disc3,
   Flame,
   Music2,
   Play,
   Repeat2,
+  Search,
   Users,
 } from "@crate/ui/icons";
 import { Link, useLocation, useParams, useSearchParams } from "react-router";
@@ -279,7 +279,7 @@ export function Stats() {
               }
             />
             <SignalCard
-              icon={Compass}
+              icon={Search}
               label={topDiscovery ? "Discovery" : "Gravity"}
               title={
                 topDiscovery?.artist_name ||

--- a/app/listen/src/pages/UserProfile.tsx
+++ b/app/listen/src/pages/UserProfile.tsx
@@ -17,7 +17,8 @@ import { useAuth } from "@/contexts/AuthContext";
 import { useApi } from "@/hooks/use-api";
 import { useUserAvatarUrl } from "@/hooks/use-user-avatar-url";
 import { UserProfileLink } from "@/components/social/UserProfileLink";
-import { api } from "@/lib/api";
+import { CrateLoader } from "@/components/ui/CrateLoader";
+import { api, resolveMaybeApiAssetUrl } from "@/lib/api";
 import { contributionSourceLabel } from "@/lib/contributions";
 import { albumCoverApiUrl, albumPagePath } from "@/lib/library-routes";
 import { formatTotalDuration } from "@/lib/utils";
@@ -303,11 +304,7 @@ export function UserProfile() {
   }
 
   if (loading) {
-    return (
-      <div className="flex items-center justify-center py-16">
-        <Loader2 size={22} className="animate-spin text-primary" />
-      </div>
-    );
+    return <CrateLoader label="Loading profile." />;
   }
 
   if (!data) {
@@ -592,42 +589,50 @@ export function UserProfile() {
                   No public playlists yet.
                 </div>
               ) : (
-                data.public_playlists.map((playlist) => (
-                  <Link
-                    key={playlist.id}
-                    to={`/playlist/${playlist.id}`}
-                    className="flex items-center gap-4 rounded-2xl border border-white/10 bg-white/[0.02] px-4 py-3 hover:bg-white/[0.05] transition-colors"
-                  >
-                    {playlist.cover_data_url ? (
-                      <img
-                        src={playlist.cover_data_url}
-                        alt={playlist.name}
-                        className="h-14 w-14 rounded-xl object-cover"
-                      />
-                    ) : (
-                      <div className="h-14 w-14 rounded-xl bg-white/5 flex items-center justify-center text-lg font-semibold text-white/40">
-                        {playlist.name.charAt(0).toUpperCase()}
-                      </div>
-                    )}
-                    <div className="min-w-0 flex-1">
-                      <div className="truncate text-sm font-medium text-foreground">
-                        {playlist.name}
-                      </div>
-                      <div className="mt-1 text-xs text-muted-foreground">
-                        {playlist.track_count} tracks
-                        {playlist.total_duration > 0
-                          ? ` · ${formatTotalDuration(playlist.total_duration)}`
-                          : ""}
-                        {playlist.is_collaborative ? " · Collaborative" : ""}
-                      </div>
-                      {playlist.description ? (
-                        <div className="mt-1 truncate text-xs text-muted-foreground">
-                          {playlist.description}
+                data.public_playlists.map((playlist) => {
+                  const coverUrl = resolveMaybeApiAssetUrl(
+                    playlist.cover_data_url,
+                  );
+
+                  return (
+                    <Link
+                      key={playlist.id}
+                      to={`/playlist/${playlist.id}`}
+                      className="flex items-center gap-4 rounded-2xl border border-white/10 bg-white/[0.02] px-4 py-3 hover:bg-white/[0.05] transition-colors"
+                    >
+                      {coverUrl ? (
+                        <img
+                          src={coverUrl}
+                          alt={playlist.name}
+                          className="h-14 w-14 rounded-xl object-cover"
+                        />
+                      ) : (
+                        <div className="h-14 w-14 rounded-xl bg-white/5 flex items-center justify-center text-lg font-semibold text-white/40">
+                          {playlist.name.charAt(0).toUpperCase()}
                         </div>
-                      ) : null}
-                    </div>
-                  </Link>
-                ))
+                      )}
+                      <div className="min-w-0 flex-1">
+                        <div className="truncate text-sm font-medium text-foreground">
+                          {playlist.name}
+                        </div>
+                        <div className="mt-1 text-xs text-muted-foreground">
+                          {playlist.track_count} tracks
+                          {playlist.total_duration > 0
+                            ? ` · ${formatTotalDuration(
+                                playlist.total_duration,
+                              )}`
+                            : ""}
+                          {playlist.is_collaborative ? " · Collaborative" : ""}
+                        </div>
+                        {playlist.description ? (
+                          <div className="mt-1 truncate text-xs text-muted-foreground">
+                            {playlist.description}
+                          </div>
+                        ) : null}
+                      </div>
+                    </Link>
+                  );
+                })
               )}
             </div>
           </div>

--- a/app/readplane/internal/catalog/genre.go
+++ b/app/readplane/internal/catalog/genre.go
@@ -3,10 +3,325 @@ package catalog
 import (
 	"context"
 	"math"
+	"net/url"
+	"sort"
+	"strconv"
 	"strings"
 
 	"github.com/thecrateapp/crate/app/readplane/internal/postgres"
 )
+
+const (
+	minGenreMembershipScore  = 0.45
+	artistAlbumFallbackScore = 0.70
+	relatedGenreLimit        = 24
+)
+
+var genreRelationLabels = map[string]string{
+	"child":         "Subgenre",
+	"sibling":       "Sibling",
+	"related":       "Related",
+	"influenced_by": "Influenced by",
+	"influences":    "Influences",
+	"fusion":        "Fusion",
+}
+
+var genreRelationPriority = map[string]int64{
+	"child":         60,
+	"related":       50,
+	"sibling":       40,
+	"influenced_by": 30,
+	"influences":    20,
+	"fusion":        10,
+}
+
+func genreMembershipTier(score float64) string {
+	switch {
+	case score >= 0.90:
+		return "core"
+	case score >= 0.70:
+		return "strong"
+	case score >= minGenreMembershipScore:
+		return "adjacent"
+	default:
+		return "weak"
+	}
+}
+
+func visibleGenreMembership(score float64) bool {
+	return score >= minGenreMembershipScore
+}
+
+func annotateGenreMembershipRows(rows []map[string]any) {
+	for _, row := range rows {
+		score := floatValue(row["membership_score"])
+		row["membership_score"] = score
+		row["membership_tier"] = genreMembershipTier(score)
+	}
+}
+
+func buildRelatedGenrePayloads(rows []map[string]any, relations map[string]string, limit int) []map[string]any {
+	items := []map[string]any{}
+	for _, row := range rows {
+		slug := strings.TrimSpace(stringValue(row["slug"]))
+		if slug == "" {
+			continue
+		}
+		relationType := strings.TrimSpace(stringValue(row["relation_type"]))
+		if relationType == "" && relations != nil {
+			relationType = strings.TrimSpace(relations[slug])
+		}
+		relationLabel, ok := genreRelationLabels[relationType]
+		if !ok {
+			continue
+		}
+		artistCount := intValue(row["artist_count"])
+		albumCount := intValue(row["album_count"])
+		contentScore := artistCount*3 + albumCount
+		if contentScore <= 0 {
+			continue
+		}
+		coverURL := stringValue(row["cover_url"])
+		if coverURL == "" && (stringValue(row["canonical_cover_path"]) != "" || stringValue(row["cover_path"]) != "") {
+			coverURL = genreCoverPublicURL(slug)
+		}
+		topArtistID := intValue(row["top_artist_id"])
+		topArtistPhotoURL := stringValue(row["top_artist_photo_url"])
+		if topArtistPhotoURL == "" && topArtistID > 0 {
+			topArtistPhotoURL = artistPhotoPublicURL(topArtistID)
+		}
+		items = append(items, map[string]any{
+			"slug":                 slug,
+			"name":                 firstNonEmpty(stringValue(row["page_name"]), stringValue(row["name"]), strings.ReplaceAll(slug, "-", " ")),
+			"page_slug":            firstNonEmpty(stringValue(row["page_slug"]), slug),
+			"relation_type":        relationType,
+			"relation_label":       relationLabel,
+			"description":          firstNonEmpty(stringValue(row["description"]), stringValue(row["external_description"])),
+			"artist_count":         artistCount,
+			"album_count":          albumCount,
+			"content_score":        contentScore,
+			"cover_url":            nilIfEmpty(coverURL),
+			"top_artist_id":        nilIfZero(topArtistID),
+			"top_artist_slug":      nilIfEmpty(stringValue(row["top_artist_slug"])),
+			"top_artist_name":      nilIfEmpty(stringValue(row["top_artist_name"])),
+			"top_artist_photo_url": nilIfEmpty(topArtistPhotoURL),
+		})
+	}
+	sort.SliceStable(items, func(i, j int) bool {
+		left := items[i]
+		right := items[j]
+		if intValue(left["content_score"]) != intValue(right["content_score"]) {
+			return intValue(left["content_score"]) > intValue(right["content_score"])
+		}
+		if genreRelationPriority[stringValue(left["relation_type"])] != genreRelationPriority[stringValue(right["relation_type"])] {
+			return genreRelationPriority[stringValue(left["relation_type"])] > genreRelationPriority[stringValue(right["relation_type"])]
+		}
+		if intValue(left["artist_count"]) != intValue(right["artist_count"]) {
+			return intValue(left["artist_count"]) > intValue(right["artist_count"])
+		}
+		if intValue(left["album_count"]) != intValue(right["album_count"]) {
+			return intValue(left["album_count"]) > intValue(right["album_count"])
+		}
+		return stringValue(left["name"]) < stringValue(right["name"])
+	})
+	if limit > 0 && len(items) > limit {
+		items = items[:limit]
+	}
+	return items
+}
+
+func nilIfEmpty(value string) any {
+	if strings.TrimSpace(value) == "" {
+		return nil
+	}
+	return value
+}
+
+func nilIfZero(value int64) any {
+	if value <= 0 {
+		return nil
+	}
+	return value
+}
+
+func (s *Store) relatedGenres(ctx context.Context, canonicalSlug string, limit int) ([]map[string]any, error) {
+	slug := strings.TrimSpace(canonicalSlug)
+	if slug == "" {
+		return []map[string]any{}, nil
+	}
+	queryCtx, cancel := postgres.WithTimeout(ctx, s.queryTimeout)
+	defer cancel()
+	rows, err := rowsToMaps(s.pool.Query(queryCtx, `
+		WITH target AS (
+			SELECT id, slug
+			FROM genre_taxonomy_nodes
+			WHERE slug = $1
+			LIMIT 1
+		),
+		parent_ids AS (
+			SELECT e.target_genre_id AS parent_id
+			FROM genre_taxonomy_edges e
+			JOIN target t ON t.id = e.source_genre_id
+			WHERE e.relation_type = 'parent'
+		),
+		raw_relations AS (
+			SELECT child.slug, 'child'::TEXT AS relation_type
+			FROM genre_taxonomy_edges e
+			JOIN target t ON t.id = e.target_genre_id
+			JOIN genre_taxonomy_nodes child ON child.id = e.source_genre_id
+			WHERE e.relation_type = 'parent'
+
+			UNION ALL
+
+			SELECT sibling.slug, 'sibling'::TEXT AS relation_type
+			FROM parent_ids p
+			JOIN genre_taxonomy_edges e
+			  ON e.target_genre_id = p.parent_id
+			 AND e.relation_type = 'parent'
+			JOIN target t ON true
+			JOIN genre_taxonomy_nodes sibling ON sibling.id = e.source_genre_id
+			WHERE sibling.id != t.id
+
+			UNION ALL
+
+			SELECT related.slug, 'related'::TEXT AS relation_type
+			FROM genre_taxonomy_edges e
+			JOIN target t ON t.id = e.source_genre_id
+			JOIN genre_taxonomy_nodes related ON related.id = e.target_genre_id
+			WHERE e.relation_type = 'related'
+
+			UNION ALL
+
+			SELECT related.slug, 'related'::TEXT AS relation_type
+			FROM genre_taxonomy_edges e
+			JOIN target t ON t.id = e.target_genre_id
+			JOIN genre_taxonomy_nodes related ON related.id = e.source_genre_id
+			WHERE e.relation_type = 'related'
+
+			UNION ALL
+
+			SELECT influenced.slug, 'influenced_by'::TEXT AS relation_type
+			FROM genre_taxonomy_edges e
+			JOIN target t ON t.id = e.source_genre_id
+			JOIN genre_taxonomy_nodes influenced ON influenced.id = e.target_genre_id
+			WHERE e.relation_type = 'influenced_by'
+
+			UNION ALL
+
+			SELECT influenced.slug, 'influences'::TEXT AS relation_type
+			FROM genre_taxonomy_edges e
+			JOIN target t ON t.id = e.target_genre_id
+			JOIN genre_taxonomy_nodes influenced ON influenced.id = e.source_genre_id
+			WHERE e.relation_type = 'influenced_by'
+
+			UNION ALL
+
+			SELECT fusion.slug, 'fusion'::TEXT AS relation_type
+			FROM genre_taxonomy_edges e
+			JOIN target t ON t.id = e.target_genre_id
+			JOIN genre_taxonomy_nodes fusion ON fusion.id = e.source_genre_id
+			WHERE e.relation_type = 'fusion_of'
+		),
+		ranked_relations AS (
+			SELECT
+				slug,
+				relation_type,
+				ROW_NUMBER() OVER (
+					PARTITION BY slug
+					ORDER BY
+						CASE relation_type
+							WHEN 'child' THEN 60
+							WHEN 'related' THEN 50
+							WHEN 'sibling' THEN 40
+							WHEN 'influenced_by' THEN 30
+							WHEN 'influences' THEN 20
+							WHEN 'fusion' THEN 10
+							ELSE 0
+						END DESC,
+						slug ASC
+				) AS relation_rank
+			FROM raw_relations
+			WHERE slug != $1
+		),
+		candidate_relations AS (
+			SELECT slug, relation_type
+			FROM ranked_relations
+			WHERE relation_rank = 1
+		)
+		SELECT
+			n.slug,
+			n.name,
+			n.description,
+			n.external_description,
+			n.cover_path AS canonical_cover_path,
+			c.relation_type,
+			COUNT(DISTINCT ag.artist_name)::BIGINT AS artist_count,
+			COUNT(DISTINCT alg.album_id)::BIGINT AS album_count,
+			page.page_slug,
+			page.page_name,
+			top_artist.top_artist_id,
+			top_artist.top_artist_slug,
+			top_artist.top_artist_name
+		FROM candidate_relations c
+		JOIN genre_taxonomy_nodes n ON n.slug = c.slug
+		LEFT JOIN genre_taxonomy_aliases gta ON gta.genre_id = n.id
+		LEFT JOIN genres g ON g.slug = gta.alias_slug
+		LEFT JOIN artist_genres ag ON ag.genre_id = g.id
+		LEFT JOIN album_genres alg ON alg.genre_id = g.id
+		LEFT JOIN LATERAL (
+			SELECT
+				gp.slug AS page_slug,
+				gp.name AS page_name
+			FROM genre_taxonomy_aliases gta_page
+			JOIN genres gp ON gp.slug = gta_page.alias_slug
+			LEFT JOIN artist_genres ag_page ON ag_page.genre_id = gp.id
+			LEFT JOIN album_genres alg_page ON alg_page.genre_id = gp.id
+			WHERE gta_page.genre_id = n.id
+			GROUP BY gp.id, gp.slug, gp.name
+			ORDER BY
+				COUNT(DISTINCT ag_page.artist_name) DESC,
+				COUNT(DISTINCT alg_page.album_id) DESC,
+				gp.slug ASC
+			LIMIT 1
+		) page ON true
+		LEFT JOIN LATERAL (
+			SELECT
+				la.id AS top_artist_id,
+				la.slug AS top_artist_slug,
+				la.name AS top_artist_name
+			FROM genre_taxonomy_aliases gta_artist
+			JOIN genres ga ON ga.slug = gta_artist.alias_slug
+			JOIN artist_genres ag_top ON ag_top.genre_id = ga.id
+			JOIN library_artists la ON la.name = ag_top.artist_name
+			WHERE gta_artist.genre_id = n.id
+			  AND COALESCE(la.has_photo, 0) <> 0
+			ORDER BY
+				ag_top.weight DESC NULLS LAST,
+				la.listeners DESC NULLS LAST,
+				la.album_count DESC NULLS LAST,
+				la.name ASC
+			LIMIT 1
+		) top_artist ON true
+		GROUP BY
+			n.id,
+			n.slug,
+			n.name,
+			n.description,
+			n.external_description,
+			n.cover_path,
+			c.relation_type,
+			page.page_slug,
+			page.page_name,
+			top_artist.top_artist_id,
+			top_artist.top_artist_slug,
+			top_artist.top_artist_name
+	`, slug))
+	if err != nil {
+		return nil, err
+	}
+	return buildRelatedGenrePayloads(rows, nil, limit), nil
+}
+
 func (s *Store) genreTaxonomyContext(ctx context.Context, canonicalSlug string) (any, any, error) {
 	queryCtx, cancel := postgres.WithTimeout(ctx, s.queryTimeout)
 	defer cancel()
@@ -179,6 +494,7 @@ func buildGenreProfile(rows []map[string]any, limit int) []map[string]any {
 
 func annotateGenreSummary(row map[string]any, includeEQ bool) {
 	canonicalSlug := strings.TrimSpace(stringValue(row["canonical_slug"]))
+	canonicalCoverPath := strings.TrimSpace(stringValue(row["canonical_cover_path"]))
 	mapped := canonicalSlug != ""
 	row["mapped"] = mapped
 
@@ -200,11 +516,17 @@ func annotateGenreSummary(row map[string]any, includeEQ bool) {
 			row["top_level_description"] = stringValue(row["canonical_description"])
 		}
 		row["description"] = stringValue(row["canonical_description"])
+		if canonicalCoverPath != "" {
+			row["cover_url"] = genreCoverPublicURL(canonicalSlug)
+		} else {
+			row["cover_url"] = nil
+		}
 	} else {
 		row["top_level_slug"] = nil
 		row["top_level_name"] = nil
 		row["top_level_description"] = nil
 		row["description"] = nil
+		row["cover_url"] = nil
 		row["external_description"] = nil
 		row["external_description_source"] = nil
 		row["musicbrainz_mbid"] = nil
@@ -233,6 +555,16 @@ func annotateGenreSummary(row map[string]any, includeEQ bool) {
 	delete(row, "preset_source")
 	delete(row, "preset_slug")
 	delete(row, "preset_name")
+	delete(row, "canonical_cover_path")
+}
+
+func genreCoverPublicURL(slug string) string {
+	encodedSlug := url.PathEscape(strings.ToLower(strings.TrimSpace(slug)))
+	return "/api/genres/" + encodedSlug + "/cover?size=640&format=webp"
+}
+
+func artistPhotoPublicURL(artistID int64) string {
+	return "/api/artists/" + strconv.FormatInt(artistID, 10) + "/photo?size=640&format=webp"
 }
 
 func shouldUseStaticTopLevel(canonicalSlug string, currentTopLevelSlug string) bool {

--- a/app/readplane/internal/catalog/genre_membership_test.go
+++ b/app/readplane/internal/catalog/genre_membership_test.go
@@ -1,0 +1,136 @@
+package catalog
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGenreMembershipTier(t *testing.T) {
+	tests := []struct {
+		name    string
+		score   float64
+		tier    string
+		visible bool
+	}{
+		{name: "core", score: 0.90, tier: "core", visible: true},
+		{name: "strong", score: 0.70, tier: "strong", visible: true},
+		{name: "adjacent", score: 0.45, tier: "adjacent", visible: true},
+		{name: "weak", score: 0.44, tier: "weak", visible: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.tier, genreMembershipTier(tt.score))
+			assert.Equal(t, tt.visible, visibleGenreMembership(tt.score))
+		})
+	}
+}
+
+func TestAnnotateGenreSummaryAddsCoverURLForMappedGenre(t *testing.T) {
+	row := map[string]any{
+		"canonical_slug":        "hardcore",
+		"canonical_name":        "Hardcore",
+		"canonical_description": "Fast, direct, and physical.",
+		"canonical_cover_path":  "hardcore.webp",
+	}
+
+	annotateGenreSummary(row, false)
+
+	assert.Equal(t, true, row["mapped"])
+	assert.Equal(t, "Fast, direct, and physical.", row["description"])
+	assert.Equal(
+		t,
+		"/api/genres/hardcore/cover?size=640&format=webp",
+		row["cover_url"],
+	)
+	assert.NotContains(t, row, "canonical_cover_path")
+}
+
+func TestAnnotateGenreSummaryClearsCoverURLForUnmappedGenre(t *testing.T) {
+	row := map[string]any{
+		"canonical_slug":       "",
+		"canonical_cover_path": "raw.webp",
+	}
+
+	annotateGenreSummary(row, false)
+
+	assert.Equal(t, false, row["mapped"])
+	assert.Nil(t, row["cover_url"])
+	assert.NotContains(t, row, "canonical_cover_path")
+}
+
+func TestGenreShowPayload(t *testing.T) {
+	payload := genreShowPayload(map[string]any{
+		"id":                int64(42),
+		"date":              "2026-08-12",
+		"local_time":        "20:30:00",
+		"artist_name":       "Converge",
+		"artist_id":         int64(7),
+		"artist_slug":       "converge",
+		"venue":             "Sala Test",
+		"city":              "Madrid",
+		"country":           "Spain",
+		"tickets_url":       "https://tickets.example/show",
+		"url":               "https://example/show",
+		"artist_genres":     []any{"hardcore", "metalcore", "mathcore", "extra"},
+		"distance_km":       float64(12.4),
+		"lastfm_url":        "https://last.fm/event",
+		"lastfm_attendance": int64(120),
+	})
+
+	assert.Equal(t, int64(42), payload["id"])
+	assert.Equal(t, "show", payload["type"])
+	assert.Equal(t, "2026-08-12", payload["date"])
+	assert.Equal(t, "20:30:00", payload["time"])
+	assert.Equal(t, "Converge", payload["artist"])
+	assert.Equal(t, "Sala Test", payload["title"])
+	assert.Equal(t, "Madrid, Spain", payload["subtitle"])
+	assert.Equal(t, "https://tickets.example/show", payload["url"])
+	assert.Equal(t, []string{"hardcore", "metalcore", "mathcore"}, payload["genres"])
+	assert.Equal(t, true, payload["is_upcoming"])
+}
+
+func TestBuildRelatedGenrePayloadsRanksLibraryContent(t *testing.T) {
+	rows := []map[string]any{
+		{
+			"slug":                 "metalcore",
+			"page_slug":            "metalcore",
+			"page_name":            "metalcore",
+			"description":          "metallic hardcore pressure.",
+			"artist_count":         int64(3),
+			"album_count":          int64(22),
+			"canonical_cover_path": "metalcore.webp",
+		},
+		{
+			"slug":          "post-hardcore",
+			"page_slug":     "post-hardcore",
+			"page_name":     "post-hardcore",
+			"artist_count":  int64(5),
+			"album_count":   int64(19),
+			"top_artist_id": int64(42),
+		},
+		{
+			"slug":         "empty-scene",
+			"page_slug":    "empty-scene",
+			"page_name":    "empty scene",
+			"artist_count": int64(0),
+			"album_count":  int64(0),
+		},
+	}
+	relations := map[string]string{
+		"metalcore":     "related",
+		"post-hardcore": "related",
+		"empty-scene":   "child",
+	}
+
+	payloads := buildRelatedGenrePayloads(rows, relations, 12)
+
+	assert.Len(t, payloads, 2)
+	assert.Equal(t, "post-hardcore", payloads[0]["slug"])
+	assert.Equal(t, "Related", payloads[0]["relation_label"])
+	assert.Equal(t, int64(34), payloads[0]["content_score"])
+	assert.Equal(t, "/api/artists/42/photo?size=640&format=webp", payloads[0]["top_artist_photo_url"])
+	assert.Equal(t, "metalcore", payloads[1]["slug"])
+	assert.Equal(t, "/api/genres/metalcore/cover?size=640&format=webp", payloads[1]["cover_url"])
+}

--- a/app/readplane/internal/catalog/store.go
+++ b/app/readplane/internal/catalog/store.go
@@ -368,6 +368,7 @@ func (s *Store) Genres(ctx context.Context) ([]map[string]any, error) {
 			tn.description AS canonical_description,
 			tn.external_description,
 			tn.external_description_source,
+			tn.cover_path AS canonical_cover_path,
 			tn.musicbrainz_mbid,
 			tn.wikidata_entity_id,
 			tn.wikidata_url,
@@ -391,6 +392,7 @@ func (s *Store) Genres(ctx context.Context) ([]map[string]any, error) {
 			tn.description,
 			tn.external_description,
 			tn.external_description_source,
+			tn.cover_path,
 			tn.musicbrainz_mbid,
 			tn.wikidata_entity_id,
 			tn.wikidata_url,
@@ -409,8 +411,8 @@ func (s *Store) Genres(ctx context.Context) ([]map[string]any, error) {
 	return rows, nil
 }
 
-// GenreDetail returns a single genre summary with its artists and albums.
-func (s *Store) GenreDetail(ctx context.Context, slug string) (map[string]any, error) {
+// GenreDetail returns a single genre summary with its artists, albums, and user-local shows.
+func (s *Store) GenreDetail(ctx context.Context, slug string, userID int64) (map[string]any, error) {
 	summary, err := s.genreSummaryBySlug(ctx, slug)
 	if err != nil {
 		return nil, err
@@ -423,15 +425,18 @@ func (s *Store) GenreDetail(ctx context.Context, slug string) (map[string]any, e
 	defer cancel()
 
 	artists, err := rowsToMaps(s.pool.Query(queryCtx, `
-		WITH ranked_artist_genres AS (
+		WITH target_genres AS (
+			SELECT $1::BIGINT AS id
+		),
+		artist_memberships AS (
 			SELECT
-				ag.*,
-				ROW_NUMBER() OVER (
-					PARTITION BY ag.artist_name
-					ORDER BY ag.weight DESC NULLS LAST, g.name ASC
-				) AS genre_rank
+				ag.artist_name,
+				ag.genre_id,
+				ag.weight::DOUBLE PRECISION AS weight,
+				ag.weight::DOUBLE PRECISION AS membership_score,
+				ag.source
 			FROM artist_genres ag
-			JOIN genres g ON g.id = ag.genre_id
+			WHERE ag.genre_id IN (SELECT id FROM target_genres)
 		)
 		SELECT
 			ag.artist_name,
@@ -443,56 +448,115 @@ func (s *Store) GenreDetail(ctx context.Context, slug string) (map[string]any, e
 			la.track_count,
 			la.has_photo,
 			la.spotify_popularity,
-			la.listeners
-		FROM ranked_artist_genres ag
+			la.listeners,
+			ag.membership_score
+		FROM artist_memberships ag
 		JOIN library_artists la ON ag.artist_name = la.name
-		WHERE ag.genre_rank = 1
-		  AND ag.genre_id = $1
-		ORDER BY ag.weight DESC, la.listeners DESC NULLS LAST
-	`, genreID))
+		WHERE ag.membership_score >= $2
+		ORDER BY
+			CASE
+				WHEN ag.membership_score >= 0.90 THEN 3
+				WHEN ag.membership_score >= 0.70 THEN 2
+				WHEN ag.membership_score >= $2 THEN 1
+				ELSE 0
+			END DESC,
+			ag.weight DESC NULLS LAST,
+			la.listeners DESC NULLS LAST,
+			la.spotify_popularity DESC NULLS LAST,
+			la.album_count DESC NULLS LAST,
+			ag.artist_name ASC
+	`, genreID, minGenreMembershipScore))
 	if err != nil {
 		return nil, err
 	}
+	annotateGenreMembershipRows(artists)
 	albums, err := rowsToMaps(s.pool.Query(queryCtx, `
-		WITH ranked_artist_genres AS (
-			SELECT
-				ag.*,
-				ROW_NUMBER() OVER (
-					PARTITION BY ag.artist_name
-					ORDER BY ag.weight DESC NULLS LAST, g.name ASC
-				) AS genre_rank
-			FROM artist_genres ag
-			JOIN genres g ON g.id = ag.genre_id
+		WITH target_genres AS (
+			SELECT $1::BIGINT AS id
 		),
-		primary_artists AS (
-			SELECT artist_name, weight
-			FROM ranked_artist_genres
-			WHERE genre_rank = 1
-			  AND genre_id = $1
+		artist_memberships AS (
+			SELECT
+				ag.artist_name,
+				ag.genre_id,
+				ag.weight::DOUBLE PRECISION AS weight,
+				ag.weight::DOUBLE PRECISION AS membership_score,
+				ag.source
+			FROM artist_genres ag
+			WHERE ag.genre_id IN (SELECT id FROM target_genres)
 		),
 		album_genre_weights AS (
-			SELECT album_id, MAX(weight) AS weight
+			SELECT album_id, MAX(weight)::DOUBLE PRECISION AS weight
 			FROM album_genres
-			WHERE genre_id = $1
+			WHERE genre_id IN (SELECT id FROM target_genres)
 			GROUP BY album_id
-		)
-		SELECT DISTINCT ON (a.id)
-			a.id AS album_id,
-			a.slug AS album_slug,
-			a.artist,
-			ar.id AS artist_id,
-			ar.slug AS artist_slug,
-			a.name,
-			a.year,
+		),
+		album_memberships AS (
+			SELECT
+				a.id AS album_id,
+				a.slug AS album_slug,
+				a.artist,
+				ar.id AS artist_id,
+				ar.slug AS artist_slug,
+				a.name,
+				a.year,
 				a.track_count,
 				a.has_cover,
-				COALESCE(alg.weight, pa.weight, 0.5) AS weight
+				a.popularity,
+				a.lastfm_playcount,
+				ar.listeners,
+				ar.spotify_popularity,
+				GREATEST(
+					COALESCE(alg.weight, 0.0),
+					COALESCE(pa.membership_score, 0.0) * $3
+				)::DOUBLE PRECISION AS membership_score,
+				(alg.album_id IS NOT NULL) AS direct_genre_match
 			FROM library_albums a
-			JOIN primary_artists pa ON pa.artist_name = a.artist
+			LEFT JOIN artist_memberships pa ON pa.artist_name = a.artist
 			LEFT JOIN library_artists ar ON ar.name = a.artist
 			LEFT JOIN album_genre_weights alg ON alg.album_id = a.id
-			ORDER BY a.id, a.year DESC NULLS LAST
-		`, genreID))
+			WHERE alg.album_id IS NOT NULL
+			   OR pa.membership_score >= $2
+		)
+		SELECT
+			album_id,
+			album_slug,
+			artist,
+			artist_id,
+			artist_slug,
+			name,
+			year,
+			track_count,
+			has_cover,
+			membership_score AS weight,
+			membership_score,
+			direct_genre_match
+		FROM album_memberships
+		WHERE membership_score >= $2
+		ORDER BY
+			CASE
+				WHEN membership_score >= 0.90 THEN 3
+				WHEN membership_score >= 0.70 THEN 2
+				WHEN membership_score >= $2 THEN 1
+				ELSE 0
+			END DESC,
+			direct_genre_match DESC,
+			membership_score DESC NULLS LAST,
+			COALESCE(popularity, 0) DESC NULLS LAST,
+			COALESCE(lastfm_playcount, 0) DESC NULLS LAST,
+			listeners DESC NULLS LAST,
+			spotify_popularity DESC NULLS LAST,
+			year DESC NULLS LAST,
+			name ASC
+		`, genreID, minGenreMembershipScore, artistAlbumFallbackScore))
+	if err != nil {
+		return nil, err
+	}
+	annotateGenreMembershipRows(albums)
+	shows, err := s.genreUpcomingShows(ctx, genreID, userID, 5)
+	if err != nil {
+		return nil, err
+	}
+	relatedGenres, err := s.relatedGenres(ctx, stringValue(summary["canonical_slug"]), relatedGenreLimit)
 	if err != nil {
 		return nil, err
 	}
@@ -505,8 +569,224 @@ func (s *Store) GenreDetail(ctx context.Context, slug string) (map[string]any, e
 	summary["track_count"] = trackTotal
 	summary["artists"] = artists
 	summary["albums"] = albums
+	summary["shows"] = shows
+	summary["related_genres"] = relatedGenres
 	return summary, nil
 }
+
+type genreShowLocation struct {
+	latitude  float64
+	longitude float64
+	radiusKm  int64
+}
+
+func (s *Store) genreUpcomingShows(ctx context.Context, genreID int64, userID int64, limit int) ([]map[string]any, error) {
+	if limit <= 0 {
+		return []map[string]any{}, nil
+	}
+	location, ok, err := s.genreShowLocation(ctx, userID)
+	if err != nil || !ok {
+		return []map[string]any{}, err
+	}
+	delta := float64(location.radiusKm) / 111.0
+	queryCtx, cancel := postgres.WithTimeout(ctx, s.queryTimeout)
+	defer cancel()
+	rows, err := rowsToMaps(s.pool.Query(queryCtx, `
+		WITH target_genres AS (
+			SELECT $1::BIGINT AS id
+		),
+		artist_memberships AS (
+			SELECT
+				ag.artist_name,
+				ag.genre_id,
+				ag.weight::DOUBLE PRECISION AS membership_score
+			FROM artist_genres ag
+			WHERE ag.genre_id IN (SELECT id FROM target_genres)
+		),
+		genre_artists AS (
+			SELECT artist_name, membership_score
+			FROM artist_memberships
+			WHERE membership_score >= $2
+		),
+		candidate_shows AS (
+			SELECT
+				s.*,
+				la.id AS artist_id,
+				la.slug AS artist_slug,
+				CASE WHEN s.latitude IS NOT NULL AND s.longitude IS NOT NULL THEN
+					6371 * acos(
+						LEAST(1.0, GREATEST(-1.0,
+							cos(radians($3)) * cos(radians(s.latitude))
+							* cos(radians(s.longitude) - radians($4))
+							+ sin(radians($3)) * sin(radians(s.latitude))
+						))
+					)
+				ELSE NULL END AS distance_km,
+				ROW_NUMBER() OVER (
+					PARTITION BY s.artist_name
+					ORDER BY s.date ASC, s.local_time ASC NULLS LAST, s.id ASC
+				) AS artist_show_rank,
+				ARRAY(
+					SELECT g2.name
+					FROM artist_genres ag2
+					JOIN genres g2 ON g2.id = ag2.genre_id
+					WHERE ag2.artist_name = s.artist_name
+					ORDER BY ag2.weight DESC, g2.name ASC
+					LIMIT 3
+				) AS artist_genres
+			FROM shows s
+			JOIN genre_artists pa ON pa.artist_name = s.artist_name
+			LEFT JOIN library_artists la ON la.name = s.artist_name
+			WHERE s.date >= CURRENT_DATE
+			  AND COALESCE(s.status, '') != 'cancelled'
+			  AND s.latitude IS NOT NULL
+			  AND s.longitude IS NOT NULL
+			  AND s.latitude BETWEEN $5 AND $6
+			  AND s.longitude BETWEEN $7 AND $8
+		)
+		SELECT
+			id,
+			artist_name,
+			artist_id,
+			artist_slug,
+			date::TEXT AS date,
+			local_time::TEXT AS local_time,
+			venue,
+			address_line1,
+			city,
+			region,
+			postal_code,
+			country,
+			country_code,
+			latitude,
+			longitude,
+			url,
+			image_url,
+			lineup,
+			status,
+			source,
+			lastfm_attendance,
+			lastfm_url,
+			tickets_url,
+			artist_genres,
+			distance_km
+		FROM candidate_shows
+		WHERE artist_show_rank = 1
+		  AND distance_km <= $9
+		ORDER BY date ASC, local_time ASC NULLS LAST, id ASC
+		LIMIT $10
+	`, genreID, minGenreMembershipScore, location.latitude, location.longitude, location.latitude-delta, location.latitude+delta, location.longitude-delta*1.5, location.longitude+delta*1.5, location.radiusKm, limit))
+	if err != nil {
+		return nil, err
+	}
+	shows := make([]map[string]any, 0, len(rows))
+	for _, row := range rows {
+		shows = append(shows, genreShowPayload(row))
+	}
+	return shows, nil
+}
+
+func (s *Store) genreShowLocation(ctx context.Context, userID int64) (genreShowLocation, bool, error) {
+	queryCtx, cancel := postgres.WithTimeout(ctx, s.queryTimeout)
+	defer cancel()
+	rows, err := rowsToMaps(s.pool.Query(queryCtx, `
+		SELECT
+			latitude::DOUBLE PRECISION AS latitude,
+			longitude::DOUBLE PRECISION AS longitude,
+			COALESCE(show_radius_km, 60)::INTEGER AS show_radius_km,
+			COALESCE(show_location_mode, 'fixed') AS show_location_mode
+		FROM users
+		WHERE id = $1
+		LIMIT 1
+	`, userID))
+	if err != nil {
+		return genreShowLocation{}, false, err
+	}
+	if len(rows) == 0 {
+		return genreShowLocation{}, false, nil
+	}
+	row := rows[0]
+	if row["latitude"] == nil || row["longitude"] == nil {
+		return genreShowLocation{}, false, nil
+	}
+	if strings.EqualFold(strings.TrimSpace(stringValue(row["show_location_mode"])), "near_me") {
+		return genreShowLocation{}, false, nil
+	}
+	radiusKm := intValue(row["show_radius_km"])
+	if radiusKm <= 0 {
+		radiusKm = 60
+	}
+	return genreShowLocation{
+		latitude:  floatValue(row["latitude"]),
+		longitude: floatValue(row["longitude"]),
+		radiusKm:  radiusKm,
+	}, true, nil
+}
+
+func genreShowPayload(row map[string]any) map[string]any {
+	city := stringValue(row["city"])
+	country := stringValue(row["country"])
+	return map[string]any{
+		"id":                row["id"],
+		"type":              "show",
+		"date":              stringValue(row["date"]),
+		"time":              row["local_time"],
+		"artist":            stringValue(row["artist_name"]),
+		"artist_id":         row["artist_id"],
+		"artist_slug":       row["artist_slug"],
+		"title":             stringValue(row["venue"]),
+		"subtitle":          strings.Join(nonEmptyStrings(city, country), ", "),
+		"cover_url":         row["image_url"],
+		"status":            firstNonEmpty(stringValue(row["status"]), "onsale"),
+		"is_upcoming":       true,
+		"url":               firstNonEmpty(stringValue(row["tickets_url"]), stringValue(row["url"]), stringValue(row["lastfm_url"])),
+		"venue":             row["venue"],
+		"address_line1":     row["address_line1"],
+		"city":              row["city"],
+		"region":            row["region"],
+		"postal_code":       row["postal_code"],
+		"country":           row["country"],
+		"country_code":      row["country_code"],
+		"latitude":          row["latitude"],
+		"longitude":         row["longitude"],
+		"lineup":            row["lineup"],
+		"genres":            genreShowGenres(row["artist_genres"]),
+		"source":            row["source"],
+		"lastfm_attendance": row["lastfm_attendance"],
+		"lastfm_url":        row["lastfm_url"],
+		"tickets_url":       row["tickets_url"],
+		"distance_km":       row["distance_km"],
+	}
+}
+
+func genreShowGenres(value any) []string {
+	switch typed := value.(type) {
+	case []string:
+		if len(typed) > 3 {
+			return typed[:3]
+		}
+		return typed
+	case []any:
+		items := anyStrings(typed)
+		if len(items) > 3 {
+			return items[:3]
+		}
+		return items
+	default:
+		return []string{}
+	}
+}
+
+func nonEmptyStrings(values ...string) []string {
+	items := make([]string, 0, len(values))
+	for _, value := range values {
+		if strings.TrimSpace(value) != "" {
+			items = append(items, value)
+		}
+	}
+	return items
+}
+
 func (s *Store) genreSummaryBySlug(ctx context.Context, slug string) (map[string]any, error) {
 	queryCtx, cancel := postgres.WithTimeout(ctx, s.queryTimeout)
 	defer cancel()
@@ -523,6 +803,7 @@ func (s *Store) genreSummaryBySlug(ctx context.Context, slug string) (map[string
 			tn.description AS canonical_description,
 			tn.external_description,
 			tn.external_description_source,
+			tn.cover_path AS canonical_cover_path,
 			tn.musicbrainz_mbid,
 			tn.wikidata_entity_id,
 			tn.wikidata_url,
@@ -553,6 +834,7 @@ func (s *Store) genreSummaryBySlug(ctx context.Context, slug string) (map[string
 			tn.description,
 			tn.external_description,
 			tn.external_description_source,
+			tn.cover_path,
 			tn.musicbrainz_mbid,
 			tn.wikidata_entity_id,
 			tn.wikidata_url,

--- a/app/readplane/internal/routes/catalog.go
+++ b/app/readplane/internal/routes/catalog.go
@@ -130,10 +130,11 @@ func (s *Server) genresRoute(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if len(parts) == 1 && !isReservedGenreRoute(parts[0]) {
-		if !s.requireCatalogAuth(w, r) {
+		user, ok := s.requireCatalogUser(w, r)
+		if !ok {
 			return
 		}
-		payload, err := s.catalog.GenreDetail(r.Context(), parts[0])
+		payload, err := s.catalog.GenreDetail(r.Context(), parts[0], user.ID)
 		s.writeCatalogPayload(w, r, payload, err, "Genre unavailable", "Genre not found")
 		return
 	}

--- a/app/shared/ui/domain/actions/ContextMenu.test.tsx
+++ b/app/shared/ui/domain/actions/ContextMenu.test.tsx
@@ -119,6 +119,58 @@ describe("ContextMenu", () => {
     expect(screen.getByText("El Cielo")).toBeInTheDocument();
   });
 
+  it("hides a broken media header image instead of showing browser broken-image chrome", () => {
+    render(
+      <ContextMenu
+        header={header}
+        items={actions()}
+        menuRef={createRef<HTMLDivElement>()}
+        onClose={vi.fn()}
+        open
+        position={{ x: 12, y: 12 }}
+      />,
+    );
+
+    const image = screen.getByRole("img", { name: "El Cielo cover" });
+    fireEvent.error(image);
+
+    expect(
+      screen.queryByRole("img", { name: "El Cielo cover" }),
+    ).not.toBeInTheDocument();
+    expect(screen.getByText("El Cielo")).toBeInTheDocument();
+  });
+
+  it("retries the media header image when imageUrl changes", () => {
+    const { rerender } = render(
+      <ContextMenu
+        header={header}
+        items={actions()}
+        menuRef={createRef<HTMLDivElement>()}
+        onClose={vi.fn()}
+        open
+        position={{ x: 12, y: 12 }}
+      />,
+    );
+
+    fireEvent.error(screen.getByRole("img", { name: "El Cielo cover" }));
+
+    rerender(
+      <ContextMenu
+        header={{ ...header, imageUrl: "/cover-2.jpg" }}
+        items={actions()}
+        menuRef={createRef<HTMLDivElement>()}
+        onClose={vi.fn()}
+        open
+        position={{ x: 12, y: 12 }}
+      />,
+    );
+
+    expect(screen.getByRole("img", { name: "El Cielo cover" })).toHaveAttribute(
+      "src",
+      "/cover-2.jpg",
+    );
+  });
+
   it("uses the mobile sheet on non-desktop", () => {
     isDesktop = false;
 

--- a/app/shared/ui/domain/actions/ContextMenu.tsx
+++ b/app/shared/ui/domain/actions/ContextMenu.tsx
@@ -2,6 +2,8 @@ import {
   type CSSProperties,
   type ReactNode,
   type MouseEvent as ReactMouseEvent,
+  useEffect,
+  useState,
 } from "react";
 import { createPortal } from "react-dom";
 import {
@@ -103,8 +105,14 @@ function ContextMenuMediaHeaderView({
   header: ContextMenuMediaHeader;
 }) {
   const FallbackIcon = header.fallbackIcon;
+  const [imageFailed, setImageFailed] = useState(false);
+  const showImage = Boolean(header.imageUrl) && !imageFailed;
   const imageShape =
     header.imageShape === "circle" ? "rounded-full" : "rounded-lg";
+
+  useEffect(() => {
+    setImageFailed(false);
+  }, [header.imageUrl]);
 
   return (
     <div className="flex items-center gap-3 border-b border-white/10 px-4 py-4">
@@ -114,14 +122,17 @@ function ContextMenuMediaHeaderView({
           imageShape,
         )}
       >
-        {header.imageUrl ? (
+        {showImage ? (
           <img
-            src={header.imageUrl}
+            src={header.imageUrl || ""}
             alt={header.imageAlt ?? header.title}
             width={48}
             height={48}
             loading="lazy"
-            onError={header.imageOnError}
+            onError={() => {
+              setImageFailed(true);
+              header.imageOnError?.();
+            }}
             className="h-full w-full object-cover"
           />
         ) : FallbackIcon ? (

--- a/app/shared/ui/tokens/animations.css
+++ b/app/shared/ui/tokens/animations.css
@@ -348,13 +348,31 @@
   animation: cratePlayCorePulse 2.55s cubic-bezier(0.4, 0, 0.2, 1) infinite;
 }
 
+@keyframes crateLoaderDotBounce {
+  0%,
+  100% {
+    opacity: 0.42;
+    transform: translateY(0);
+  }
+  42% {
+    opacity: 1;
+    transform: translateY(-2px);
+  }
+}
+
+.animate-crate-loader-dot-bounce {
+  animation: crateLoaderDotBounce 1.05s ease-in-out infinite;
+  display: inline-block;
+}
+
 @media (prefers-reduced-motion: reduce) {
   .animate-discovery-logo-pulse,
   .animate-discovery-logo-glow,
   .animate-crate-icon-active-pulse,
   .animate-crate-play-aura-pulse,
   .animate-crate-play-rim-pulse,
-  .animate-crate-play-core-pulse {
+  .animate-crate-play-core-pulse,
+  .animate-crate-loader-dot-bounce {
     animation: none;
   }
 }

--- a/app/tests/test_bliss_queries.py
+++ b/app/tests/test_bliss_queries.py
@@ -133,6 +133,14 @@ def _set_bliss_embedding(track_id: int, vector: list[float]) -> None:
         )
 
 
+def _quarantine_album(album_id: int) -> None:
+    with transaction_scope() as session:
+        session.execute(
+            text("UPDATE library_albums SET quarantined_at = NOW() WHERE id = :id"),
+            {"id": album_id},
+        )
+
+
 def _get_bliss_embedding_distance(track_a_id: int, track_b_id: int) -> float:
     with read_scope() as session:
         return session.execute(
@@ -374,6 +382,83 @@ class TestBlissTrackLookup:
 
         assert len(result) == 1
         assert result[0]["path"] == p1
+
+    def test_track_lookup_excludes_hidden_and_quarantined_tracks(self, pg_db):
+        from crate.db.queries.bliss_track_lookup import (
+            get_same_artist_tracks,
+            get_seed_tracks_by_paths,
+            get_track_with_artist,
+        )
+
+        _insert_artist(pg_db, "Lookup Clean")
+        clean_album_id = _insert_album(
+            pg_db,
+            "Lookup Clean",
+            "Lookup Clean Album",
+            "/music/Lookup Clean/Lookup Clean Album",
+        )
+        hidden_album_id = _insert_album(
+            pg_db,
+            "Lookup Clean",
+            "Lookup Hidden Album",
+            "/music/.crate-trash/Lookup Hidden Album",
+        )
+        quarantine_album_id = _insert_album(
+            pg_db,
+            "Lookup Clean",
+            "Lookup Quarantine Album",
+            "/music/Lookup Clean/Lookup Quarantine Album",
+        )
+        clean_path = "/music/Lookup Clean/Lookup Clean Album/01-clean.flac"
+        hidden_path = "/music/.crate-trash/Lookup Hidden Album/01-hidden.flac"
+        quarantine_path = (
+            "/music/Lookup Clean/Lookup Quarantine Album/01-quarantine.flac"
+        )
+        _insert_track(
+            pg_db,
+            clean_album_id,
+            "Lookup Clean",
+            "Lookup Clean Album",
+            "Lookup Clean Track",
+            clean_path,
+        )
+        _insert_track(
+            pg_db,
+            hidden_album_id,
+            "Lookup Clean",
+            "Lookup Hidden Album",
+            "Lookup Hidden Track",
+            hidden_path,
+        )
+        _insert_track(
+            pg_db,
+            quarantine_album_id,
+            "Lookup Clean",
+            "Lookup Quarantine Album",
+            "Lookup Quarantine Track",
+            quarantine_path,
+        )
+        _quarantine_album(quarantine_album_id)
+
+        with read_scope() as session:
+            artist_id = session.execute(
+                text("SELECT id FROM library_artists WHERE LOWER(name) = LOWER(:n)"),
+                {"n": "Lookup Clean"},
+            ).scalar()
+
+        seeds = get_seed_tracks_by_paths(
+            seed_paths=[clean_path, hidden_path, quarantine_path]
+        )
+        same_artist = get_same_artist_tracks(
+            artist_id=artist_id,
+            artist_name="",
+            exclude_path="/missing.flac",
+            limit=10,
+        )
+
+        assert get_track_with_artist(track_path=hidden_path) is None
+        assert {row["path"] for row in seeds} == {clean_path}
+        assert {row["path"] for row in same_artist} == {clean_path}
 
 
 # ── bliss_storage ────────────────────────────────────────────────────
@@ -853,6 +938,73 @@ class TestBlissSimilarityCandidates:
         assert t1 in ids
 
     @pytest.mark.skipif(not PGVECTOR, reason="pgvector extension not available")
+    def test_get_bliss_candidates_excludes_hidden_and_quarantined_tracks(self, pg_db):
+        from crate.db.queries.bliss_similarity_candidates import get_bliss_candidates
+
+        _insert_artist(pg_db, "Playable Artist")
+        playable_album_id = _insert_album(
+            pg_db,
+            "Playable Artist",
+            "Playable Album",
+            "/music/Playable Artist/Playable Album",
+        )
+        playable_track_id = _insert_track(
+            pg_db,
+            playable_album_id,
+            "Playable Artist",
+            "Playable Album",
+            "Playable",
+            "/music/Playable Artist/Playable Album/01 - Playable.flac",
+        )
+        _set_bliss_embedding(playable_track_id, make_vec(0.2))
+
+        _insert_artist(pg_db, ".crate-trash")
+        hidden_album_id = _insert_album(
+            pg_db,
+            ".crate-trash",
+            ".crate-trash",
+            "/music/.crate-trash/Hidden Album",
+        )
+        hidden_track_id = _insert_track(
+            pg_db,
+            hidden_album_id,
+            ".crate-trash",
+            ".crate-trash",
+            "Hidden",
+            "/music/.crate-trash/Hidden Album/01 - Hidden.flac",
+        )
+        _set_bliss_embedding(hidden_track_id, make_vec_near(0.0))
+
+        _insert_artist(pg_db, "Quarantine Artist")
+        quarantine_album_id = _insert_album(
+            pg_db,
+            "Quarantine Artist",
+            "Quarantine Album",
+            "/music/Quarantine Artist/Quarantine Album",
+        )
+        quarantine_track_id = _insert_track(
+            pg_db,
+            quarantine_album_id,
+            "Quarantine Artist",
+            "Quarantine Album",
+            "Quarantined",
+            "/music/Quarantine Artist/Quarantine Album/01 - Quarantined.flac",
+        )
+        _set_bliss_embedding(quarantine_track_id, make_vec_near(0.0))
+        _quarantine_album(quarantine_album_id)
+
+        result = get_bliss_candidates(
+            bliss_vector=make_vec(0.0),
+            exclude_path="",
+            limit=10,
+        )
+
+        ids = {row["track_id"] for row in result}
+        assert playable_track_id in ids
+        assert hidden_track_id not in ids
+        assert quarantine_track_id not in ids
+
+    @pytest.mark.skipif(not PGVECTOR, reason="pgvector extension not available")
     def test_get_bliss_candidates_respects_limit(self, pg_db):
         from crate.db.queries.bliss_similarity_candidates import get_bliss_candidates
 
@@ -976,6 +1128,92 @@ class TestBlissSimilarityCandidates:
 
         assert len(result) <= 3
 
+    def test_get_recommend_without_bliss_excludes_hidden_and_quarantined_tracks(
+        self, pg_db
+    ):
+        from crate.db.queries.bliss_similarity_candidates import (
+            get_recommend_without_bliss_candidates,
+        )
+
+        _insert_artist(pg_db, "Fallback Playable")
+        playable_album_id = _insert_album(
+            pg_db,
+            "Fallback Playable",
+            "Fallback Album",
+            "/music/Fallback Playable/Fallback Album",
+        )
+        seed_path = "/music/Fallback Playable/Fallback Album/01 - Seed.flac"
+        playable_path = "/music/Fallback Playable/Fallback Album/02 - Keep.flac"
+        _insert_track(
+            pg_db,
+            playable_album_id,
+            "Fallback Playable",
+            "Fallback Album",
+            "Seed",
+            seed_path,
+            bpm=120.0,
+        )
+        _insert_track(
+            pg_db,
+            playable_album_id,
+            "Fallback Playable",
+            "Fallback Album",
+            "Keep",
+            playable_path,
+            bpm=125.0,
+        )
+
+        _insert_artist(pg_db, ".crate-trash")
+        hidden_album_id = _insert_album(
+            pg_db,
+            ".crate-trash",
+            ".crate-trash",
+            "/music/.crate-trash/Fallback Hidden",
+        )
+        hidden_path = "/music/.crate-trash/Fallback Hidden/01 - Hidden.flac"
+        _insert_track(
+            pg_db,
+            hidden_album_id,
+            ".crate-trash",
+            ".crate-trash",
+            "Hidden Fallback",
+            hidden_path,
+            bpm=130.0,
+        )
+
+        _insert_artist(pg_db, "Fallback Quarantine")
+        quarantine_album_id = _insert_album(
+            pg_db,
+            "Fallback Quarantine",
+            "Fallback Quarantine Album",
+            "/music/Fallback Quarantine/Fallback Quarantine Album",
+        )
+        quarantine_path = (
+            "/music/Fallback Quarantine/Fallback Quarantine Album/01 - Skip.flac"
+        )
+        _insert_track(
+            pg_db,
+            quarantine_album_id,
+            "Fallback Quarantine",
+            "Fallback Quarantine Album",
+            "Skip",
+            quarantine_path,
+            bpm=135.0,
+        )
+        _quarantine_album(quarantine_album_id)
+
+        result = get_recommend_without_bliss_candidates(
+            seed_paths=[seed_path],
+            similar_artist_names=["fallback playable", ".crate-trash"],
+            artist_pick_limit=5,
+            row_limit=10,
+        )
+
+        paths = {row["path"] for row in result}
+        assert playable_path in paths
+        assert hidden_path not in paths
+        assert quarantine_path not in paths
+
     @pytest.mark.skipif(not PGVECTOR, reason="pgvector extension not available")
     def test_get_multi_seed_bliss_candidates(self, pg_db):
         from crate.db.queries.bliss_similarity_candidates import (
@@ -1034,6 +1272,88 @@ class TestBlissSimilarityCandidates:
         seed_paths_found = {r["seed_path"] for r in result}
         assert seed_a_path in seed_paths_found
         assert seed_b_path in seed_paths_found
+
+    @pytest.mark.skipif(not PGVECTOR, reason="pgvector extension not available")
+    def test_get_multi_seed_bliss_excludes_hidden_and_quarantined_tracks(self, pg_db):
+        from crate.db.queries.bliss_similarity_candidates import (
+            get_multi_seed_bliss_candidates,
+        )
+
+        _insert_artist(pg_db, "Multi Clean")
+        album_id = _insert_album(
+            pg_db,
+            "Multi Clean",
+            "Multi Clean Album",
+            "/music/Multi Clean/Multi Clean Album",
+        )
+        seed_path = "/music/Multi Clean/Multi Clean Album/01 - Seed.flac"
+        keep_path = "/music/Multi Clean/Multi Clean Album/02 - Keep.flac"
+        seed_id = _insert_track(
+            pg_db,
+            album_id,
+            "Multi Clean",
+            "Multi Clean Album",
+            "Seed",
+            seed_path,
+        )
+        keep_id = _insert_track(
+            pg_db,
+            album_id,
+            "Multi Clean",
+            "Multi Clean Album",
+            "Keep",
+            keep_path,
+        )
+        _set_bliss_embedding(seed_id, make_vec(0.0))
+        _set_bliss_embedding(keep_id, make_vec(0.1))
+
+        hidden_album_id = _insert_album(
+            pg_db,
+            ".crate-trash",
+            ".crate-trash",
+            "/music/.crate-trash/Multi Hidden",
+        )
+        hidden_path = "/music/.crate-trash/Multi Hidden/01 - Hidden.flac"
+        hidden_id = _insert_track(
+            pg_db,
+            hidden_album_id,
+            ".crate-trash",
+            ".crate-trash",
+            "Hidden Multi",
+            hidden_path,
+        )
+        _set_bliss_embedding(hidden_id, make_vec_near(0.0))
+
+        quarantine_album_id = _insert_album(
+            pg_db,
+            "Multi Quarantine",
+            "Multi Quarantine Album",
+            "/music/Multi Quarantine/Multi Quarantine Album",
+        )
+        quarantine_path = (
+            "/music/Multi Quarantine/Multi Quarantine Album/01 - Skip.flac"
+        )
+        quarantine_id = _insert_track(
+            pg_db,
+            quarantine_album_id,
+            "Multi Quarantine",
+            "Multi Quarantine Album",
+            "Skip",
+            quarantine_path,
+        )
+        _set_bliss_embedding(quarantine_id, make_vec_near(0.0))
+        _quarantine_album(quarantine_album_id)
+
+        result = get_multi_seed_bliss_candidates(
+            bliss_seed_paths=[seed_path],
+            all_seed_paths=[seed_path],
+            per_seed_limit=10,
+        )
+
+        paths = {row["path"] for row in result}
+        assert keep_path in paths
+        assert hidden_path not in paths
+        assert quarantine_path not in paths
 
     @pytest.mark.skipif(not PGVECTOR, reason="pgvector extension not available")
     def test_get_multi_seed_bliss_candidates_empty(self, pg_db):
@@ -1226,6 +1546,109 @@ class TestBlissRadioCandidates:
 
         assert len(result) == 1
         assert result[0]["track_id"] == tid
+
+    def test_radio_candidates_exclude_hidden_and_quarantined_tracks(self, pg_db):
+        from crate.db.queries.bliss_radio_candidates import (
+            get_album_tracks_for_radio,
+            get_playlist_tracks_for_radio,
+            get_similar_artist_tracks_for_radio,
+        )
+        from crate.db.repositories.playlists_create import create_playlist
+        from crate.db.repositories.playlists_tracks import add_playlist_tracks
+
+        _insert_artist(pg_db, "Radio Filter")
+        clean_album_id = _insert_album(
+            pg_db,
+            "Radio Filter",
+            "Radio Filter Album",
+            "/music/Radio Filter/Radio Filter Album",
+        )
+        hidden_album_id = _insert_album(
+            pg_db,
+            "Radio Filter",
+            "Radio Hidden Album",
+            "/music/.crate-trash/Radio Hidden Album",
+        )
+        quarantine_album_id = _insert_album(
+            pg_db,
+            "Radio Filter",
+            "Radio Quarantine Album",
+            "/music/Radio Filter/Radio Quarantine Album",
+        )
+        clean_path = "/music/Radio Filter/Radio Filter Album/01-clean.flac"
+        hidden_path = "/music/.crate-trash/Radio Hidden Album/01-hidden.flac"
+        quarantine_path = (
+            "/music/Radio Filter/Radio Quarantine Album/01-quarantine.flac"
+        )
+        _insert_track(
+            pg_db,
+            clean_album_id,
+            "Radio Filter",
+            "Radio Filter Album",
+            "Radio Clean Track",
+            clean_path,
+            bliss_vector=make_vec(0.1),
+        )
+        _insert_track(
+            pg_db,
+            hidden_album_id,
+            "Radio Filter",
+            "Radio Hidden Album",
+            "Radio Hidden Track",
+            hidden_path,
+            bliss_vector=make_vec(0.2),
+        )
+        _insert_track(
+            pg_db,
+            quarantine_album_id,
+            "Radio Filter",
+            "Radio Quarantine Album",
+            "Radio Quarantine Track",
+            quarantine_path,
+            bliss_vector=make_vec(0.3),
+        )
+        _quarantine_album(quarantine_album_id)
+
+        with read_scope() as session:
+            rows = (
+                session.execute(
+                    text(
+                        """
+                        SELECT id, path
+                        FROM library_tracks
+                        WHERE path = ANY(:paths)
+                        """
+                    ),
+                    {"paths": [clean_path, hidden_path, quarantine_path]},
+                )
+                .mappings()
+                .all()
+            )
+        ids_by_path = {row["path"]: row["id"] for row in rows}
+
+        playlist_id = create_playlist("Radio Filter Playlist")
+        add_playlist_tracks(
+            playlist_id,
+            [
+                {"track_id": ids_by_path[clean_path]},
+                {"track_id": ids_by_path[hidden_path]},
+                {"track_id": ids_by_path[quarantine_path]},
+            ],
+        )
+
+        similar_rows = get_similar_artist_tracks_for_radio(
+            similar_artist_keys=["radio filter"],
+            limit=10,
+        )
+        playlist_rows = get_playlist_tracks_for_radio(playlist_id=playlist_id)
+
+        assert {row["path"] for row in similar_rows} == {clean_path}
+        assert {
+            row["path"] for row in get_album_tracks_for_radio(album_id=clean_album_id)
+        } == {clean_path}
+        assert get_album_tracks_for_radio(album_id=hidden_album_id) == []
+        assert get_album_tracks_for_radio(album_id=quarantine_album_id) == []
+        assert {row["path"] for row in playlist_rows} == {clean_path}
 
 
 # ── bliss_artist_profiles ────────────────────────────────────────────

--- a/app/tests/test_browse_queries.py
+++ b/app/tests/test_browse_queries.py
@@ -138,10 +138,37 @@ def test_browse_filter_genres_include_editorial_metadata(pg_db):
     assert mathcore["description"] == (
         "Angular hardcore, odd meters and controlled chaos."
     )
+    assert mathcore["slug"] == "mathcore"
     assert mathcore["top_artists"] == ["Converge", "Botch"]
     assert mathcore["cover_url"] == (
         f"/api/artists/{converge_id}/background?size=640&format=webp"
     )
+
+
+def test_browse_filter_genres_orders_top_artists_by_genre_weight(pg_db):
+    from crate.db.queries.browse_artist_filters import get_browse_filter_genres
+
+    pg_db.upsert_artist({"name": "Evenly Split 1", "listeners": 1000})
+    pg_db.upsert_artist({"name": "Evenly Split 2", "listeners": 1000})
+    pg_db.upsert_artist({"name": "Weak Split Artist", "listeners": 999999})
+    pg_db.set_artist_genres(
+        "Evenly Split 1",
+        [("mathcore", 0.5, "test"), ("shoegaze", 1.0, "test")],
+    )
+    pg_db.set_artist_genres(
+        "Evenly Split 2",
+        [("mathcore", 0.9, "test")],
+    )
+    pg_db.set_artist_genres(
+        "Weak Split Artist",
+        [("mathcore", 0.3, "test")],
+    )
+
+    rows = get_browse_filter_genres()
+    mathcore = next(row for row in rows if row["name"] == "mathcore")
+
+    assert mathcore["top_artists"] == ["Evenly Split 2", "Evenly Split 1"]
+    assert mathcore["count"] == 2
 
 
 def test_browse_filter_genres_prefers_manual_taxonomy_cover(pg_db):
@@ -179,6 +206,7 @@ def test_browse_filter_genres_prefers_manual_taxonomy_cover(pg_db):
     rows = get_browse_filter_genres()
     screamo = next(row for row in rows if row["name"] == "screamo")
 
+    assert screamo["slug"] == "screamo"
     assert screamo["cover_url"] == "/api/genres/screamo/cover?size=640&format=webp"
 
 

--- a/app/tests/test_genres_queries.py
+++ b/app/tests/test_genres_queries.py
@@ -243,14 +243,21 @@ class TestGenresLibraryDetail:
         assert len(result["artists"]) >= 1
         assert result["artists"][0]["artist_name"] == "Detail Artist"
 
-    def test_get_genre_detail_only_includes_primary_genre_artists(self, pg_db):
+    def test_get_genre_detail_includes_all_genre_artists_by_weight_then_popularity(
+        self, pg_db
+    ):
         from crate.db.queries.genres_library_detail import get_genre_detail
 
         self._setup_genre_library_data(pg_db)
         pg_db.upsert_artist({"name": "Secondary Detail Artist", "listeners": 999999})
+        pg_db.upsert_artist({"name": "Weak Detail Artist", "listeners": 9999999})
         pg_db.set_artist_genres(
             "Secondary Detail Artist",
             [("experimental", 1.0, "test"), ("post-punk", 0.5, "test")],
+        )
+        pg_db.set_artist_genres(
+            "Weak Detail Artist",
+            [("experimental", 1.0, "test"), ("post-punk", 0.3, "test")],
         )
         pg_db.upsert_album(
             {
@@ -263,19 +270,244 @@ class TestGenresLibraryDetail:
                 "formats": ["flac"],
             }
         )
+        pg_db.upsert_album(
+            {
+                "artist": "Weak Detail Artist",
+                "name": "Weak Detail Album",
+                "path": "/music/Weak Detail Artist/Weak Detail Album",
+                "track_count": 7,
+                "total_size": 1000,
+                "total_duration": 180.0,
+                "formats": ["flac"],
+            }
+        )
 
         result = get_genre_detail("post-punk")
 
         assert result is not None
-        assert "Detail Artist" in [artist["artist_name"] for artist in result["artists"]]
-        assert "Secondary Detail Artist" not in [
-            artist["artist_name"] for artist in result["artists"]
-        ]
-        assert "Secondary Detail Album" not in [
-            album["name"] for album in result["albums"]
-        ]
+        artist_names = [artist["artist_name"] for artist in result["artists"]]
+        assert "Detail Artist" in artist_names
+        assert "Weak Detail Artist" not in artist_names
+        assert result["artists"][0]["artist_name"] == "Detail Artist"
+        assert result["artists"][1]["artist_name"] == "Secondary Detail Artist"
+        assert (
+            result["artists"][0]["membership_score"]
+            > result["artists"][1]["membership_score"]
+        )
+        assert result["artists"][0]["membership_tier"] == "core"
+        assert result["artists"][1]["membership_tier"] == "adjacent"
+        album_names = [album["name"] for album in result["albums"]]
+        assert "Secondary Detail Album" not in album_names
+        assert "Weak Detail Album" not in album_names
         assert result["artist_count"] == len(result["artists"])
         assert result["album_count"] == len(result["albums"])
+
+    def test_get_genre_albums_use_album_membership_before_artist_fallback(self, pg_db):
+        from crate.db.queries.genres_library_detail import get_genre_detail
+        from crate.db.tx import transaction_scope
+        from sqlalchemy import text
+
+        self._setup_genre_library_data(pg_db)
+        pg_db.upsert_artist({"name": "Indirect Popular Artist", "listeners": 999999})
+        pg_db.set_artist_genres(
+            "Indirect Popular Artist",
+            [("post-punk", 0.9, "test")],
+        )
+        indirect_album_id = pg_db.upsert_album(
+            {
+                "artist": "Indirect Popular Artist",
+                "name": "Huge Indirect Album",
+                "path": "/music/Indirect Popular Artist/Huge Indirect Album",
+                "track_count": 10,
+                "total_size": 1000,
+                "total_duration": 180.0,
+                "formats": ["flac"],
+            }
+        )
+        pg_db.upsert_artist({"name": "Direct Album Artist", "listeners": 10})
+        pg_db.set_artist_genres(
+            "Direct Album Artist",
+            [("post-punk", 0.5, "test")],
+        )
+        direct_album_id = pg_db.upsert_album(
+            {
+                "artist": "Direct Album Artist",
+                "name": "Essential Direct Album",
+                "path": "/music/Direct Album Artist/Essential Direct Album",
+                "track_count": 10,
+                "total_size": 1000,
+                "total_duration": 180.0,
+                "formats": ["flac"],
+            }
+        )
+
+        with transaction_scope() as session:
+            genre_id = session.execute(
+                text("SELECT id FROM genres WHERE slug = 'post-punk'")
+            ).scalar_one()
+            session.execute(
+                text(
+                    """
+                    INSERT INTO album_genres (album_id, genre_id, weight, source)
+                    VALUES (:album_id, :genre_id, 0.95, 'test')
+                    """
+                ),
+                {"album_id": direct_album_id, "genre_id": genre_id},
+            )
+            session.execute(
+                text("UPDATE library_albums SET popularity = 100 WHERE id = :album_id"),
+                {"album_id": indirect_album_id},
+            )
+
+        result = get_genre_detail("post-punk")
+
+        assert result is not None
+        album_names = [album["name"] for album in result["albums"]]
+        assert album_names.index("Essential Direct Album") < album_names.index(
+            "Huge Indirect Album"
+        )
+        direct_album = next(
+            album
+            for album in result["albums"]
+            if album["name"] == "Essential Direct Album"
+        )
+        assert direct_album["direct_genre_match"] is True
+        assert direct_album["membership_tier"] == "core"
+        assert direct_album["membership_score"] == 0.95
+
+    def test_get_genre_albums_hide_weak_artist_fallback_without_direct_match(
+        self, pg_db
+    ):
+        from crate.db.queries.genres_library_detail import get_genre_detail
+        from crate.db.tx import transaction_scope
+        from sqlalchemy import text
+
+        self._setup_genre_library_data(pg_db)
+        pg_db.upsert_artist({"name": "Weak Album Artist", "listeners": 999999})
+        pg_db.set_artist_genres(
+            "Weak Album Artist",
+            [("experimental", 1.0, "test"), ("post-punk", 0.3, "test")],
+        )
+        weak_fallback_album_id = pg_db.upsert_album(
+            {
+                "artist": "Weak Album Artist",
+                "name": "Weak Fallback Album",
+                "path": "/music/Weak Album Artist/Weak Fallback Album",
+                "track_count": 8,
+                "total_size": 1000,
+                "total_duration": 180.0,
+                "formats": ["flac"],
+            }
+        )
+        weak_direct_album_id = pg_db.upsert_album(
+            {
+                "artist": "Weak Album Artist",
+                "name": "Weak Direct Album",
+                "path": "/music/Weak Album Artist/Weak Direct Album",
+                "track_count": 8,
+                "total_size": 1000,
+                "total_duration": 180.0,
+                "formats": ["flac"],
+            }
+        )
+
+        with transaction_scope() as session:
+            genre_id = session.execute(
+                text("SELECT id FROM genres WHERE slug = 'post-punk'")
+            ).scalar_one()
+            session.execute(
+                text(
+                    """
+                    INSERT INTO album_genres (album_id, genre_id, weight, source)
+                    VALUES (:album_id, :genre_id, 0.8, 'test')
+                    """
+                ),
+                {"album_id": weak_direct_album_id, "genre_id": genre_id},
+            )
+
+        result = get_genre_detail("post-punk")
+
+        assert result is not None
+        album_names = [album["name"] for album in result["albums"]]
+        assert "Weak Direct Album" in album_names
+        assert "Weak Fallback Album" not in album_names
+        assert weak_fallback_album_id is not None
+
+    def test_get_genre_albums_ordered_by_popularity_not_artist(self, pg_db):
+        from crate.db.queries.genres_library_detail import get_genre_detail
+        from crate.db.tx import transaction_scope
+        from sqlalchemy import text
+
+        self._setup_genre_library_data(pg_db)
+        pg_db.upsert_artist({"name": "Loud Listener Artist", "listeners": 999999})
+        pg_db.set_artist_genres(
+            "Loud Listener Artist",
+            [("post-punk", 0.9, "test")],
+        )
+        top_album_id = pg_db.upsert_album(
+            {
+                "artist": "Loud Listener Artist",
+                "name": "Single Loud Hit",
+                "path": "/music/Loud Listener Artist/Single Loud Hit",
+                "track_count": 4,
+                "total_size": 1000,
+                "total_duration": 180.0,
+                "formats": ["flac"],
+            }
+        )
+        low_album_a_id = pg_db.upsert_album(
+            {
+                "artist": "Detail Artist",
+                "name": "Hidden Gem A",
+                "path": "/music/Detail Artist/Hidden Gem A",
+                "track_count": 7,
+                "total_size": 1000,
+                "total_duration": 180.0,
+                "formats": ["flac"],
+            }
+        )
+        low_album_b_id = pg_db.upsert_album(
+            {
+                "artist": "Detail Artist",
+                "name": "Hidden Gem B",
+                "path": "/music/Detail Artist/Hidden Gem B",
+                "track_count": 5,
+                "total_size": 1000,
+                "total_duration": 180.0,
+                "formats": ["flac"],
+            }
+        )
+
+        with transaction_scope() as session:
+            session.execute(
+                text(
+                    "UPDATE library_albums SET popularity = :pop WHERE id = :album_id"
+                ),
+                {"pop": 20, "album_id": top_album_id},
+            )
+            session.execute(
+                text(
+                    "UPDATE library_albums SET popularity = :pop WHERE id = :album_id"
+                ),
+                {"pop": 100, "album_id": low_album_a_id},
+            )
+            session.execute(
+                text(
+                    "UPDATE library_albums SET popularity = :pop WHERE id = :album_id"
+                ),
+                {"pop": 90, "album_id": low_album_b_id},
+            )
+
+        result = get_genre_detail("post-punk")
+
+        assert result is not None
+        album_names = [album["name"] for album in result["albums"]]
+        assert album_names[:4] == [
+            "Detail Album",
+            "Hidden Gem A",
+            "Hidden Gem B",
+            "Single Loud Hit",
+        ]
 
     def test_get_genre_detail_uses_canonical_cover_for_alias(self, pg_db):
         from crate.db.queries.genres_library_detail import get_genre_detail
@@ -372,11 +604,48 @@ class TestGenresLibraryDetail:
         result = get_genre_detail("post-punk")
 
         assert result is not None
-        assert "Detail Artist" in [artist["artist_name"] for artist in result["artists"]]
+        assert "Detail Artist" in [
+            artist["artist_name"] for artist in result["artists"]
+        ]
         assert "Alias Primary Artist" not in [
             artist["artist_name"] for artist in result["artists"]
         ]
-        assert "Alias Primary Album" not in [album["name"] for album in result["albums"]]
+        assert "Alias Primary Album" not in [
+            album["name"] for album in result["albums"]
+        ]
+
+    def test_get_genre_detail_includes_related_genres_ranked_by_library_content(
+        self, pg_db
+    ):
+        from crate.db.queries.genres_library_detail import get_genre_detail
+
+        self._setup_genre_library_data(pg_db)
+        for index in range(3):
+            artist_name = f"Gothic Detail Artist {index}"
+            pg_db.upsert_artist(
+                {
+                    "name": artist_name,
+                    "has_photo": 1 if index == 0 else 0,
+                    "listeners": 1000 - index,
+                }
+            )
+            pg_db.set_artist_genres(artist_name, [("gothic-rock", 0.9, "test")])
+        pg_db.upsert_artist({"name": "New Wave Detail Artist"})
+        pg_db.set_artist_genres("New Wave Detail Artist", [("new-wave", 0.9, "test")])
+
+        result = get_genre_detail("post-punk")
+
+        assert result is not None
+        related = result["related_genres"]
+        assert related[0]["slug"] == "gothic-rock"
+        assert related[0]["relation_type"] == "related"
+        assert related[0]["artist_count"] >= 3
+        assert related[0]["top_artist_name"] == "Gothic Detail Artist 0"
+        assert related[0]["top_artist_photo_url"].startswith("/api/artists/")
+        assert related[0]["top_artist_photo_url"].endswith(
+            "/photo?size=640&format=webp"
+        )
+        assert "new-wave" in [genre["slug"] for genre in related]
 
     def test_get_genre_upcoming_shows_uses_primary_genre_and_location(self, pg_db):
         from crate.db.queries.genres_library_detail import get_genre_upcoming_shows
@@ -385,9 +654,14 @@ class TestGenresLibraryDetail:
 
         self._setup_genre_library_data(pg_db)
         pg_db.upsert_artist({"name": "Secondary Detail Artist", "listeners": 999999})
+        pg_db.upsert_artist({"name": "Weak Detail Artist", "listeners": 9999999})
         pg_db.set_artist_genres(
             "Secondary Detail Artist",
             [("experimental", 1.0, "test"), ("post-punk", 0.5, "test")],
+        )
+        pg_db.set_artist_genres(
+            "Weak Detail Artist",
+            [("experimental", 1.0, "test"), ("post-punk", 0.3, "test")],
         )
 
         with transaction_scope() as session:
@@ -412,6 +686,7 @@ class TestGenresLibraryDetail:
                         ('Detail Artist', 'Near Room', 'Berlin', 'Germany', 'DE', 52.520, 13.405, CURRENT_DATE + INTERVAL '7 days', 'onsale', 'lastfm', NOW(), NOW()),
                         ('Detail Artist', 'Later Room', 'Berlin', 'Germany', 'DE', 52.520, 13.405, CURRENT_DATE + INTERVAL '14 days', 'onsale', 'lastfm', NOW(), NOW()),
                         ('Secondary Detail Artist', 'Wrong Room', 'Berlin', 'Germany', 'DE', 52.520, 13.405, CURRENT_DATE + INTERVAL '8 days', 'onsale', 'lastfm', NOW(), NOW()),
+                        ('Weak Detail Artist', 'Weak Room', 'Berlin', 'Germany', 'DE', 52.520, 13.405, CURRENT_DATE + INTERVAL '9 days', 'onsale', 'lastfm', NOW(), NOW()),
                         ('Detail Artist', 'Far Room', 'Paris', 'France', 'FR', 48.8566, 2.3522, CURRENT_DATE + INTERVAL '6 days', 'onsale', 'lastfm', NOW(), NOW())
                     """
                 )
@@ -425,7 +700,10 @@ class TestGenresLibraryDetail:
             limit=5,
         )
 
-        assert [show["artist_name"] for show in shows] == ["Detail Artist"]
+        assert [show["artist_name"] for show in shows] == [
+            "Detail Artist",
+            "Secondary Detail Artist",
+        ]
         assert shows[0]["venue"] == "Near Room"
 
     def test_get_artists_with_tags_empty(self, pg_db):

--- a/app/tests/test_paths_queries.py
+++ b/app/tests/test_paths_queries.py
@@ -446,3 +446,147 @@ class TestPathsBlissCandidateQueries:
 
         rows = find_candidate_rows([0.1] * 20, set(), limit=10)
         assert rows == []
+
+    def test_candidate_queries_exclude_hidden_and_quarantined_tracks(self, pg_db):
+        from crate.db.queries.paths_bliss_candidate_queries import (
+            find_anchor_track_row,
+            find_candidate_rows,
+            find_seeded_radio_candidate_rows,
+        )
+        from crate.db.tx import transaction_scope
+        from sqlalchemy import text
+
+        pg_db.upsert_artist({"name": "Paths Clean"})
+        clean_album_id = pg_db.upsert_album(
+            {
+                "artist": "Paths Clean",
+                "name": "Paths Clean Album",
+                "path": "/music/Paths Clean/Paths Clean Album",
+                "track_count": 1,
+                "total_size": 1000,
+                "total_duration": 180.0,
+                "formats": ["flac"],
+            }
+        )
+        clean_path = "/music/Paths Clean/Paths Clean Album/01-clean.flac"
+        pg_db.upsert_track(
+            {
+                "album_id": clean_album_id,
+                "artist": "Paths Clean",
+                "album": "Paths Clean Album",
+                "filename": "01-clean.flac",
+                "title": "Paths Clean Track",
+                "path": clean_path,
+                "duration": 180.0,
+                "size": 1000,
+                "format": "flac",
+            }
+        )
+
+        pg_db.upsert_artist({"name": ".crate-trash"})
+        hidden_album_id = pg_db.upsert_album(
+            {
+                "artist": ".crate-trash",
+                "name": ".crate-trash",
+                "path": "/music/.crate-trash/Paths Hidden",
+                "track_count": 1,
+                "total_size": 1000,
+                "total_duration": 180.0,
+                "formats": ["flac"],
+            }
+        )
+        hidden_path = "/music/.crate-trash/Paths Hidden/01-hidden.flac"
+        pg_db.upsert_track(
+            {
+                "album_id": hidden_album_id,
+                "artist": ".crate-trash",
+                "album": ".crate-trash",
+                "filename": "01-hidden.flac",
+                "title": "Paths Hidden Track",
+                "path": hidden_path,
+                "duration": 180.0,
+                "size": 1000,
+                "format": "flac",
+            }
+        )
+
+        pg_db.upsert_artist({"name": "Paths Quarantine"})
+        quarantine_album_id = pg_db.upsert_album(
+            {
+                "artist": "Paths Quarantine",
+                "name": "Paths Quarantine Album",
+                "path": "/music/Paths Quarantine/Paths Quarantine Album",
+                "track_count": 1,
+                "total_size": 1000,
+                "total_duration": 180.0,
+                "formats": ["flac"],
+            }
+        )
+        quarantine_path = "/music/Paths Quarantine/Paths Quarantine Album/01-skip.flac"
+        pg_db.upsert_track(
+            {
+                "album_id": quarantine_album_id,
+                "artist": "Paths Quarantine",
+                "album": "Paths Quarantine Album",
+                "filename": "01-skip.flac",
+                "title": "Paths Quarantine Track",
+                "path": quarantine_path,
+                "duration": 180.0,
+                "size": 1000,
+                "format": "flac",
+            }
+        )
+
+        with transaction_scope() as session:
+            rows = (
+                session.execute(
+                    text(
+                        """
+                        SELECT id, path
+                        FROM library_tracks
+                        WHERE path = ANY(:paths)
+                        """
+                    ),
+                    {"paths": [clean_path, hidden_path, quarantine_path]},
+                )
+                .mappings()
+                .all()
+            )
+            ids_by_path = {row["path"]: row["id"] for row in rows}
+            session.execute(
+                text(
+                    "UPDATE library_tracks SET bliss_vector = :bv WHERE path = ANY(:paths)"
+                ),
+                {
+                    "bv": [0.2] * 20,
+                    "paths": [clean_path, hidden_path, quarantine_path],
+                },
+            )
+            session.execute(
+                text("UPDATE library_albums SET quarantined_at = NOW() WHERE id = :id"),
+                {"id": quarantine_album_id},
+            )
+
+        rows = find_candidate_rows([0.1] * 20, set(), limit=10)
+        seeded_rows = find_seeded_radio_candidate_rows(
+            [0.1] * 20,
+            set(),
+            seed_artists=["Paths Clean", ".crate-trash", "Paths Quarantine"],
+            limit=10,
+        )
+
+        row_ids = {row["id"] for row in rows}
+        seeded_ids = {row["id"] for row in seeded_rows}
+
+        assert ids_by_path[clean_path] in row_ids
+        assert ids_by_path[hidden_path] not in row_ids
+        assert ids_by_path[quarantine_path] not in row_ids
+        assert ids_by_path[clean_path] in seeded_ids
+        assert ids_by_path[hidden_path] not in seeded_ids
+        assert ids_by_path[quarantine_path] not in seeded_ids
+        assert (
+            find_anchor_track_row(
+                "track", str(ids_by_path[hidden_path]), [0.1] * 20, set()
+            )
+            is None
+        )

--- a/app/tests/test_radio_contracts.py
+++ b/app/tests/test_radio_contracts.py
@@ -4,6 +4,50 @@ from unittest.mock import patch
 
 
 class TestRadioApiContracts:
+    def test_radio_stations_returns_personalized_station_groups(self, test_app):
+        payload = {
+            "artist_stations": [
+                {
+                    "type": "artist",
+                    "seed_type": "artist",
+                    "seed_value": "7",
+                    "seed_label": "Converge",
+                    "seed_subtitle": "Artist",
+                    "artist_id": 7,
+                    "artist_name": "Converge",
+                    "title": "Converge Radio",
+                    "subtitle": "",
+                    "play_count": 44,
+                    "minutes_listened": 180,
+                }
+            ],
+            "genre_stations": [
+                {
+                    "type": "genre",
+                    "seed_type": "genre",
+                    "seed_value": "hardcore",
+                    "seed_label": "hardcore",
+                    "seed_subtitle": "Genre",
+                    "genre_slug": "hardcore",
+                    "genre_name": "hardcore",
+                    "cover_url": "/api/genres/hardcore/cover?size=640&format=webp",
+                    "title": "hardcore Radio",
+                    "subtitle": "",
+                    "play_count": 88,
+                    "minutes_listened": 320,
+                }
+            ],
+        }
+
+        with patch(
+            "crate.api.radio.get_user_radio_stations", return_value=payload
+        ) as get_stations:
+            resp = test_app.get("/api/radio/stations")
+
+        assert resp.status_code == 200
+        assert resp.json() == payload
+        get_stations.assert_called_once_with(1)
+
     def test_artist_radio_returns_session_and_tracks(self, test_app):
         tracks = [
             {

--- a/app/tests/test_radio_queries.py
+++ b/app/tests/test_radio_queries.py
@@ -231,6 +231,140 @@ class TestRadioLibraryQueries:
         result = get_track_bliss_vector(track_id)
         assert result == bliss_vec
 
+    def test_library_seed_queries_exclude_hidden_and_quarantined_tracks(
+        self, pg_db, monkeypatch
+    ):
+        from crate.db.queries import radio_library_queries
+        from crate.db.tx import transaction_scope
+        from sqlalchemy import text
+
+        pg_db.upsert_artist({"name": "Library Clean"})
+        clean_album_id = pg_db.upsert_album(
+            {
+                "artist": "Library Clean",
+                "name": "Library Clean Album",
+                "path": "/music/Library Clean/Library Clean Album",
+                "track_count": 1,
+                "total_size": 1000,
+                "total_duration": 180.0,
+                "formats": ["flac"],
+            }
+        )
+        clean_path = "/music/Library Clean/Library Clean Album/01-clean.flac"
+        pg_db.upsert_track(
+            {
+                "album_id": clean_album_id,
+                "artist": "Library Clean",
+                "album": "Library Clean Album",
+                "filename": "01-clean.flac",
+                "title": "Library Clean Track",
+                "path": clean_path,
+                "duration": 180.0,
+                "size": 1000,
+                "format": "flac",
+            }
+        )
+
+        pg_db.upsert_artist({"name": ".crate-trash"})
+        hidden_album_id = pg_db.upsert_album(
+            {
+                "artist": ".crate-trash",
+                "name": ".crate-trash",
+                "path": "/music/.crate-trash/Library Hidden",
+                "track_count": 1,
+                "total_size": 1000,
+                "total_duration": 180.0,
+                "formats": ["flac"],
+            }
+        )
+        hidden_path = "/music/.crate-trash/Library Hidden/01-hidden.flac"
+        pg_db.upsert_track(
+            {
+                "album_id": hidden_album_id,
+                "artist": ".crate-trash",
+                "album": ".crate-trash",
+                "filename": "01-hidden.flac",
+                "title": "Library Hidden Track",
+                "path": hidden_path,
+                "duration": 180.0,
+                "size": 1000,
+                "format": "flac",
+            }
+        )
+
+        pg_db.upsert_artist({"name": "Library Quarantine"})
+        quarantine_album_id = pg_db.upsert_album(
+            {
+                "artist": "Library Quarantine",
+                "name": "Library Quarantine Album",
+                "path": "/music/Library Quarantine/Library Quarantine Album",
+                "track_count": 1,
+                "total_size": 1000,
+                "total_duration": 180.0,
+                "formats": ["flac"],
+            }
+        )
+        quarantine_path = (
+            "/music/Library Quarantine/Library Quarantine Album/01-skip.flac"
+        )
+        pg_db.upsert_track(
+            {
+                "album_id": quarantine_album_id,
+                "artist": "Library Quarantine",
+                "album": "Library Quarantine Album",
+                "filename": "01-skip.flac",
+                "title": "Library Quarantine Track",
+                "path": quarantine_path,
+                "duration": 180.0,
+                "size": 1000,
+                "format": "flac",
+            }
+        )
+
+        bliss_vec = [0.42] * 20
+        with transaction_scope() as session:
+            rows = (
+                session.execute(
+                    text(
+                        """
+                        SELECT id, path
+                        FROM library_tracks
+                        WHERE path = ANY(:paths)
+                        """
+                    ),
+                    {"paths": [clean_path, hidden_path, quarantine_path]},
+                )
+                .mappings()
+                .all()
+            )
+            ids_by_path = {row["path"]: row["id"] for row in rows}
+            session.execute(
+                text(
+                    "UPDATE library_tracks SET bliss_vector = :bv WHERE path = ANY(:paths)"
+                ),
+                {"bv": bliss_vec, "paths": [clean_path, hidden_path, quarantine_path]},
+            )
+            session.execute(
+                text("UPDATE library_albums SET quarantined_at = NOW() WHERE id = :id"),
+                {"id": quarantine_album_id},
+            )
+
+        monkeypatch.setattr(radio_library_queries.random, "randint", lambda _a, _b: 1)
+
+        seed_rows = radio_library_queries.get_random_library_seed_rows(limit=10)
+        seed_paths = {row["track_id"] for row in seed_rows}
+
+        assert ids_by_path[clean_path] in seed_paths
+        assert ids_by_path[hidden_path] not in seed_paths
+        assert ids_by_path[quarantine_path] not in seed_paths
+        assert (
+            radio_library_queries.get_track_path_by_id(ids_by_path[hidden_path]) is None
+        )
+        assert (
+            radio_library_queries.get_track_bliss_vector(ids_by_path[hidden_path])
+            is None
+        )
+
 
 class TestRadioUserQueries:
     def _setup_track(self, pg_db, artist_name, track_title, bliss_vec):
@@ -528,6 +662,59 @@ class TestRadioUserQueries:
         assert 1 in sources
         assert len(sources[1]) >= 1
 
+    def test_user_seed_sources_exclude_hidden_and_quarantined_tracks(self, pg_db):
+        from crate.db.queries.radio_user_queries import (
+            get_discovery_seed_sources,
+            get_recent_liked_seed_rows,
+        )
+        from crate.db.tx import transaction_scope
+        from sqlalchemy import text
+
+        clean_id = self._setup_track(
+            pg_db, "User Seed Clean", "User Seed Clean Track", [0.91] * 20
+        )
+        hidden_id = self._setup_track(
+            pg_db, ".crate-trash", "User Seed Hidden Track", [0.92] * 20
+        )
+        quarantine_id = self._setup_track(
+            pg_db,
+            "User Seed Quarantine",
+            "User Seed Quarantine Track",
+            [0.93] * 20,
+        )
+
+        with transaction_scope() as session:
+            quarantine_album_id = session.execute(
+                text("SELECT album_id FROM library_tracks WHERE id = :id"),
+                {"id": quarantine_id},
+            ).scalar()
+            session.execute(
+                text("UPDATE library_albums SET quarantined_at = NOW() WHERE id = :id"),
+                {"id": quarantine_album_id},
+            )
+            for index, track_id in enumerate([clean_id, hidden_id, quarantine_id]):
+                session.execute(
+                    text(
+                        """
+                        INSERT INTO user_liked_tracks (user_id, track_id, created_at)
+                        VALUES (:uid, :tid, NOW() - (:offset * INTERVAL '1 minute'))
+                        """
+                    ),
+                    {"uid": 1, "tid": track_id, "offset": index},
+                )
+
+        recent_likes = get_recent_liked_seed_rows(1, limit=10)
+        discovery_sources = get_discovery_seed_sources(1)
+        recent_ids = {row["track_id"] for row in recent_likes}
+        discovery_ids = {row["track_id"] for row in discovery_sources.get(1, [])}
+
+        assert clean_id in recent_ids
+        assert hidden_id not in recent_ids
+        assert quarantine_id not in recent_ids
+        assert clean_id in discovery_ids
+        assert hidden_id not in discovery_ids
+        assert quarantine_id not in discovery_ids
+
     def test_load_feedback_history_empty(self, pg_db):
         from crate.db.queries.radio_user_queries import load_feedback_history
 
@@ -635,6 +822,20 @@ class TestRadioSeedQueries:
         assert context["seed_artists"] == ["Seed Track Artist"]
         assert context["seed_track_ids"] == [track_id]
 
+    def test_get_track_seed_context_excludes_hidden_tracks(self, pg_db):
+        from crate.db.queries.radio_seed_queries import get_track_seed_context
+
+        track_id, track_path = self._setup_track_with_bliss(
+            pg_db,
+            ".crate-trash",
+            "Hidden Seed Track",
+            [0.11] * 20,
+            path="/music/.crate-trash/Hidden Seed/01-hidden.flac",
+        )
+
+        assert get_track_seed_context(str(track_id)) is None
+        assert get_track_seed_context(track_path) is None
+
     def test_get_track_seed_not_found(self, pg_db):
         from crate.db.queries.radio_seed_queries import get_track_seed
 
@@ -693,6 +894,29 @@ class TestRadioSeedQueries:
         assert len(vectors) >= 1
         assert vectors[0] == bliss_vec
         assert label == "PL Seed"
+
+    def test_get_album_seed_context_excludes_quarantined_album(self, pg_db):
+        from crate.db.queries.radio_seed_queries import get_album_seed_context
+        from crate.db.tx import transaction_scope
+        from sqlalchemy import text
+
+        track_id, _ = self._setup_track_with_bliss(
+            pg_db,
+            "Quarantined Seed Artist",
+            "Quarantined Seed Track",
+            [0.31] * 20,
+        )
+        with transaction_scope() as session:
+            album_id = session.execute(
+                text("SELECT album_id FROM library_tracks WHERE id = :id"),
+                {"id": track_id},
+            ).scalar()
+            session.execute(
+                text("UPDATE library_albums SET quarantined_at = NOW() WHERE id = :id"),
+                {"id": album_id},
+            )
+
+        assert get_album_seed_context(str(album_id)) is None
 
     def test_get_playlist_seed_with_data(self, pg_db):
         from crate.db.queries.radio_seed_queries import get_playlist_seed

--- a/app/tests/test_radio_stations.py
+++ b/app/tests/test_radio_stations.py
@@ -1,0 +1,85 @@
+def test_radio_station_payload_splits_artist_and_genre_stations(monkeypatch):
+    from crate.db.queries import radio_stations
+
+    monkeypatch.setattr(
+        radio_stations,
+        "get_genre_taxonomy_cover_path",
+        lambda slug: "hardcore.webp" if slug == "hardcore" else None,
+    )
+    monkeypatch.setattr(
+        radio_stations,
+        "resolve_genre_slug",
+        lambda value: "hardcore" if value == "Hardcore" else None,
+    )
+    monkeypatch.setattr(
+        radio_stations,
+        "get_genre_display_name",
+        lambda slug: slug,
+    )
+
+    payload = radio_stations.build_radio_stations_from_context(
+        {
+            "top_artists": [
+                {
+                    "artist_id": 3,
+                    "artist_slug": "crate-trash",
+                    "artist_name": ".crate-trash",
+                    "play_count": 999,
+                    "minutes_listened": 999,
+                },
+                {
+                    "artist_id": 7,
+                    "artist_slug": "converge",
+                    "artist_name": "Converge",
+                    "play_count": 44,
+                    "minutes_listened": 180,
+                },
+            ],
+            "followed": [
+                {
+                    "artist_id": 8,
+                    "artist_slug": "crate-trash",
+                    "artist_name": ".crate-trash",
+                },
+                {
+                    "artist_id": 9,
+                    "artist_slug": "botch",
+                    "artist_name": "Botch",
+                },
+            ],
+            "top_genres": [
+                {
+                    "genre_name": "Hardcore",
+                    "play_count": 88,
+                    "minutes_listened": 320,
+                }
+            ],
+        },
+        artist_limit=4,
+        genre_limit=4,
+    )
+
+    assert [station["seed_type"] for station in payload["artist_stations"]] == [
+        "artist",
+        "artist",
+    ]
+    assert payload["artist_stations"][0]["seed_value"] == "7"
+    assert payload["artist_stations"][0]["seed_label"] == "Converge"
+    assert payload["artist_stations"][1]["seed_label"] == "Botch"
+
+    assert payload["genre_stations"] == [
+        {
+            "type": "genre",
+            "seed_type": "genre",
+            "seed_value": "hardcore",
+            "seed_label": "hardcore",
+            "seed_subtitle": "Genre",
+            "genre_slug": "hardcore",
+            "genre_name": "hardcore",
+            "cover_url": "/api/genres/hardcore/cover?size=640&format=webp",
+            "title": "hardcore Radio",
+            "subtitle": "",
+            "play_count": 88,
+            "minutes_listened": 320,
+        }
+    ]

--- a/app/ui/src/pages/PlaylistEditor.test.tsx
+++ b/app/ui/src/pages/PlaylistEditor.test.tsx
@@ -126,5 +126,8 @@ describe("PlaylistEditor", () => {
     ).toBeInTheDocument();
     expect(screen.getByText("Add rule")).toBeInTheDocument();
     expect(screen.getByText("generated")).toBeInTheDocument();
+    expect(
+      screen.getByText(/Upload a clean image-only hero asset/i),
+    ).toBeInTheDocument();
   });
 });

--- a/app/ui/src/pages/PlaylistEditor.tsx
+++ b/app/ui/src/pages/PlaylistEditor.tsx
@@ -1115,8 +1115,8 @@ export function PlaylistEditor() {
                 <ImagePlus size={16} /> Cover
               </CardTitle>
               <p className="text-sm text-muted-foreground">
-                Upload a manual cover when the playlist needs a strong editorial
-                identity. Remove it to fall back to the collage.
+                Upload a clean image-only hero asset. Listen renders the
+                playlist title, description and metadata on top.
               </p>
             </CardHeader>
             <CardContent>
@@ -1139,9 +1139,8 @@ export function PlaylistEditor() {
                   </div>
 
                   <p className="text-sm text-muted-foreground">
-                    Covers help playlists feel editorially finished. Use a
-                    manual asset when this collection has a strong identity or
-                    featured placement.
+                    Keep text out of the image itself; the public playlist page
+                    composes the typography and metadata in the hero layout.
                   </p>
 
                   <div className="flex flex-wrap gap-2">


### PR DESCRIPTION
## Summary

- Refines Listen discovery, Explore genre detail, radio stations, playlist pages, loader, search, and mobile player surfaces.
- Adds playable-media filtering so radio/continuous play avoid trashed content.
- Extends genre membership/detail data through backend and readplane, including related genres and richer cover fallbacks.
- Adds playlist hero treatment and strengthens contextual/share UI coverage.
- Adds focused tests for Listen pages/components, backend query/contract behavior, radio stations, and readplane genre membership.

## Validation

- `npm run --workspace=app/listen test`
- `npm run --workspace=app/listen typecheck`
- `uv run pytest app/tests/test_bliss_queries.py app/tests/test_browse_queries.py app/tests/test_genres_queries.py app/tests/test_paths_queries.py app/tests/test_radio_contracts.py app/tests/test_radio_queries.py app/tests/test_radio_stations.py -q`
- `go test ./...` from `app/readplane`
- pre-commit hooks: ruff, ruff format, prettier, eslint listen, eslint ui