### PR TITLE
fix: use durable Redis for media progress

### DIFF
--- a/app/crate/media_worker_progress.py
+++ b/app/crate/media_worker_progress.py
@@ -6,7 +6,7 @@ import os
 import socket
 from typing import Any
 
-from crate.db.cache_runtime import get_redis
+from crate.config import get_durable_redis_url
 
 log = logging.getLogger(__name__)
 
@@ -20,6 +20,27 @@ DEFAULT_SLOT_TTL_SECONDS = 1_200
 DEFAULT_MAX_ACTIVE = 1
 
 _group_created = False
+_redis_client: Any | None = None
+
+
+def get_redis() -> Any | None:
+    global _redis_client
+    if _redis_client is not None:
+        return _redis_client
+    try:
+        import redis
+
+        _redis_client = redis.from_url(
+            get_durable_redis_url(),
+            decode_responses=True,
+            socket_timeout=2,
+            socket_connect_timeout=2,
+        )
+        _redis_client.ping()
+    except Exception:
+        log.warning("Durable Redis is not available for media-worker progress")
+        _redis_client = None
+    return _redis_client
 
 
 def media_worker_events_stream() -> str:

--- a/app/tests/test_media_worker_progress.py
+++ b/app/tests/test_media_worker_progress.py
@@ -1,4 +1,5 @@
 import json
+from types import SimpleNamespace
 
 import crate.media_worker_progress as media_progress
 
@@ -49,6 +50,27 @@ class FakeRedis:
 
     def hgetall(self, key):
         return self.hash_data.get(key, {})
+
+
+def test_media_worker_progress_uses_durable_redis(monkeypatch):
+    import redis
+
+    client = SimpleNamespace(ping=lambda: True)
+    urls: list[str] = []
+
+    monkeypatch.setenv("REDIS_URL", "redis://legacy:6379/0")
+    monkeypatch.setenv("REDIS_CACHE_URL", "redis://cache:6379/0")
+    monkeypatch.setenv("REDIS_DURABLE_URL", "redis://durable:6379/0")
+    monkeypatch.setattr(media_progress, "_redis_client", None, raising=False)
+    monkeypatch.setattr("crate.db.cache_runtime._redis_client", None)
+    monkeypatch.setattr(
+        redis,
+        "from_url",
+        lambda url, **_kwargs: urls.append(url) or client,
+    )
+
+    assert media_progress.get_redis() is client
+    assert urls == ["redis://durable:6379/0"]
 
 
 def test_bridge_media_worker_events_to_task_progress(monkeypatch):


### PR DESCRIPTION
## Summary

- make Python media-worker progress, cancellation, slot and event consumers use `REDIS_DURABLE_URL`
- keep the API/worker side on the same Redis instance as the Rust media-worker
- add a regression test proving cache and durable Redis URLs cannot be confused

## Root cause

The production Compose correctly points the Rust media-worker at durable Redis, but `media_worker_progress.py` imported the generic cache Redis client. After the Redis role split, writes and reads would occur on different servers, breaking task progress and cancellation.

## Validation

- `uv run pytest -q app/tests/test_media_worker_progress.py`
- `uv run ruff check app/crate/media_worker_progress.py app/tests/test_media_worker_progress.py`
- `uv run pyright app/crate/media_worker_progress.py app/tests/test_media_worker_progress.py`