### PR TITLE
fix: secure Redis recovery artifact

### DIFF
--- a/app/tests/test_deploy_release_commands.py
+++ b/app/tests/test_deploy_release_commands.py
@@ -140,6 +140,8 @@ def test_remote_recovery_snapshot_captures_database_and_durable_redis() -> None:
     assert "recovery.env" in snapshot_body
     assert 'sha256sum "${checksum_files[@]}"' in snapshot_body
     assert "recovery_complete" in script
+    assert 'log "Stopping any quiesce service missed by Compose"' in snapshot_body
+    assert 'docker stop --time 45 "$service"' in snapshot_body
 
 
 def test_remote_backup_preserves_a_sealed_recovery_set() -> None:

--- a/app/tests/test_deploy_release_commands.py
+++ b/app/tests/test_deploy_release_commands.py
@@ -130,6 +130,12 @@ def test_remote_recovery_snapshot_captures_database_and_durable_redis() -> None:
     assert "pg_dump" in script
     assert "redis-durable.tar.gz" in script
     assert "sha256sum" in script
+    assert 'BACKUP_UID="$(id -u)"' in snapshot_body
+    assert 'BACKUP_GID="$(id -g)"' in snapshot_body
+    assert 'chown "$BACKUP_UID:$BACKUP_GID" /backup/redis-durable.tar.gz' in (
+        snapshot_body
+    )
+    assert "chmod 600 /backup/redis-durable.tar.gz" in snapshot_body
     assert "docker-compose.yaml" in snapshot_body
     assert "recovery.env" in snapshot_body
     assert 'sha256sum "${checksum_files[@]}"' in snapshot_body

--- a/scripts/deploy-remote.sh
+++ b/scripts/deploy-remote.sh
@@ -472,10 +472,16 @@ cmd_recovery_snapshot() {
     >/dev/null
   dc stop --timeout 30 "$redis_service"
   docker run --rm \
+    -e BACKUP_UID="$(id -u)" \
+    -e BACKUP_GID="$(id -g)" \
     --volumes-from "$redis_service" \
     -v "$BACKUP_DIR:/backup" \
     redis:7-alpine \
-    sh -ec 'tar -C /data -czf /backup/redis-durable.tar.gz .'
+    sh -ec '
+      tar -C /data -czf /backup/redis-durable.tar.gz .
+      chown "$BACKUP_UID:$BACKUP_GID" /backup/redis-durable.tar.gz
+      chmod 600 /backup/redis-durable.tar.gz
+    '
 
   {
     printf 'deploy_id=%s\n' "$DEPLOY_ID"

--- a/scripts/deploy-remote.sh
+++ b/scripts/deploy-remote.sh
@@ -441,6 +441,17 @@ cmd_recovery_snapshot() {
     dc stop --timeout 45 "${running_services[@]}"
   fi
 
+  log "Stopping any quiesce service missed by Compose"
+  for service in "${QUIESCE_SERVICES[@]}"; do
+    if [[ "$(docker inspect -f '{{.State.Running}}' "$service" 2>/dev/null || true)" != "true" ]]; then
+      continue
+    fi
+    if ! grep -Fxq "$service" "$BACKUP_DIR/recovery_running_services"; then
+      printf '%s\n' "$service" >> "$BACKUP_DIR/recovery_running_services"
+    fi
+    docker stop --time 45 "$service" >/dev/null
+  done
+
   pg_user="$(env_value CRATE_POSTGRES_USER)"
   pg_password="$(env_value CRATE_POSTGRES_PASSWORD)"
   pg_db="$(env_value CRATE_POSTGRES_DB)"


### PR DESCRIPTION
## Summary

- make the backup helper container return the Redis recovery tar to the deploy operator
- keep the artifact restricted to mode `0600`
- cover ownership and permission handling in the deploy contract test

## Root cause

The helper container created `redis-durable.tar.gz` as root inside the bind-mounted recovery directory. The unprivileged deploy user could not read it for `sha256sum`, so the recovery snapshot aborted and resumed the previous release before any migration.

## Validation

- `uv run pytest -q app/tests/test_deploy_release_commands.py`
- `bash -n scripts/deploy-remote.sh`
- production release automatically resumed and public API/Listen returned 200 after the guarded abort