### PR TITLE
fix: preserve canonical artists across merged sources

### DIFF
--- a/app/crate/db/jobs/global_catalog_reconciliation.py
+++ b/app/crate/db/jobs/global_catalog_reconciliation.py
@@ -310,6 +310,7 @@ def _reconcile_local_source(session, source: dict[str, Any]) -> None:
             session,
             artist_name=payload["artist_name"],
             album_name=payload.get("album_name"),
+            local_album_id=payload.get("local_album_id"),
         )
         global_uid, score = _resolve_track_target(session, source, artist_uid)
         source = _with_match(source, score)
@@ -900,6 +901,7 @@ def _reconcile_local_batch_sources(
                     session,
                     artist_name=payload["artist_name"],
                     album_name=payload.get("album_name"),
+                    local_album_id=payload.get("local_album_id"),
                 )
                 global_uid, score = _resolve_track_target(session, source, artist_uid)
                 source = _with_match(source, score)
@@ -1472,20 +1474,70 @@ def _upsert_artist(session, source: dict[str, Any], global_uid: str) -> None:
                     NOW()
                 )
             ON CONFLICT (global_artist_uid) DO UPDATE SET
-                canonical_name = EXCLUDED.canonical_name,
-                public_slug = EXCLUDED.public_slug,
-                sort_name = EXCLUDED.sort_name,
-                normalized_name = EXCLUDED.normalized_name,
-                musicbrainz_artist_mbid = EXCLUDED.musicbrainz_artist_mbid,
-                local_artist_id = EXCLUDED.local_artist_id,
-                local_artist_entity_uid = EXCLUDED.local_artist_entity_uid,
-                display_source_json = EXCLUDED.display_source_json,
+                canonical_name = CASE
+                    WHEN global_catalog_artists.local_artist_id IS NULL
+                      OR EXCLUDED.local_artist_id <= global_catalog_artists.local_artist_id
+                    THEN EXCLUDED.canonical_name
+                    ELSE global_catalog_artists.canonical_name
+                END,
+                public_slug = CASE
+                    WHEN global_catalog_artists.local_artist_id IS NULL
+                      OR EXCLUDED.local_artist_id <= global_catalog_artists.local_artist_id
+                    THEN EXCLUDED.public_slug
+                    ELSE global_catalog_artists.public_slug
+                END,
+                sort_name = CASE
+                    WHEN global_catalog_artists.local_artist_id IS NULL
+                      OR EXCLUDED.local_artist_id <= global_catalog_artists.local_artist_id
+                    THEN EXCLUDED.sort_name
+                    ELSE global_catalog_artists.sort_name
+                END,
+                normalized_name = CASE
+                    WHEN global_catalog_artists.local_artist_id IS NULL
+                      OR EXCLUDED.local_artist_id <= global_catalog_artists.local_artist_id
+                    THEN EXCLUDED.normalized_name
+                    ELSE global_catalog_artists.normalized_name
+                END,
+                musicbrainz_artist_mbid = CASE
+                    WHEN global_catalog_artists.local_artist_id IS NULL
+                      OR EXCLUDED.local_artist_id <= global_catalog_artists.local_artist_id
+                    THEN EXCLUDED.musicbrainz_artist_mbid
+                    ELSE global_catalog_artists.musicbrainz_artist_mbid
+                END,
+                local_artist_id = CASE
+                    WHEN global_catalog_artists.local_artist_id IS NULL
+                      OR EXCLUDED.local_artist_id <= global_catalog_artists.local_artist_id
+                    THEN EXCLUDED.local_artist_id
+                    ELSE global_catalog_artists.local_artist_id
+                END,
+                local_artist_entity_uid = CASE
+                    WHEN global_catalog_artists.local_artist_id IS NULL
+                      OR EXCLUDED.local_artist_id <= global_catalog_artists.local_artist_id
+                    THEN EXCLUDED.local_artist_entity_uid
+                    ELSE global_catalog_artists.local_artist_entity_uid
+                END,
+                display_source_json = CASE
+                    WHEN global_catalog_artists.local_artist_id IS NULL
+                      OR EXCLUDED.local_artist_id <= global_catalog_artists.local_artist_id
+                    THEN EXCLUDED.display_source_json
+                    ELSE global_catalog_artists.display_source_json
+                END,
                 availability_json = EXCLUDED.availability_json,
-                match_json = EXCLUDED.match_json,
+                match_json = CASE
+                    WHEN global_catalog_artists.local_artist_id IS NULL
+                      OR EXCLUDED.local_artist_id <= global_catalog_artists.local_artist_id
+                    THEN EXCLUDED.match_json
+                    ELSE global_catalog_artists.match_json
+                END,
                 source_count = EXCLUDED.source_count,
                 has_local = true,
-                has_photo = EXCLUDED.has_photo,
-                search_vector = EXCLUDED.search_vector,
+                has_photo = global_catalog_artists.has_photo OR EXCLUDED.has_photo,
+                search_vector = CASE
+                    WHEN global_catalog_artists.local_artist_id IS NULL
+                      OR EXCLUDED.local_artist_id <= global_catalog_artists.local_artist_id
+                    THEN EXCLUDED.search_vector
+                    ELSE global_catalog_artists.search_vector
+                END,
                 updated_at = NOW()
             """
         ),
@@ -1505,11 +1557,17 @@ def _upsert_artist(session, source: dict[str, Any], global_uid: str) -> None:
             "search_text": payload["canonical_name"],
         },
     )
-    claim_artist_public_slug(
-        session,
-        global_uid,
-        build_artist_slug(payload["canonical_name"]),
-    )
+    canonical_name = session.execute(
+        text(
+            """
+            SELECT canonical_name
+            FROM global_catalog_artists
+            WHERE global_artist_uid = CAST(:global_uid AS uuid)
+            """
+        ),
+        {"global_uid": global_uid},
+    ).scalar_one()
+    claim_artist_public_slug(session, global_uid, build_artist_slug(canonical_name))
 
 
 def _upsert_album(
@@ -2333,6 +2391,31 @@ def _project_source_genres(
 
 
 def _find_artist_uid(session, artist_name: str) -> str | None:
+    local_source = (
+        session.execute(
+            text(
+                """
+                SELECT source.global_entity_uid::text AS global_artist_uid
+                FROM library_artists artist
+                JOIN global_catalog_sources source
+                  ON source.source_kind = 'local'
+                 AND source.entity_type = 'artist'
+                 AND source.local_id = artist.id
+                 AND source.source_deleted_at IS NULL
+                 AND NOT source.source_stale
+                WHERE artist.name = :artist_name
+                ORDER BY source.local_id
+                LIMIT 1
+                """
+            ),
+            {"artist_name": artist_name},
+        )
+        .mappings()
+        .first()
+    )
+    if local_source:
+        return local_source["global_artist_uid"]
+
     normalized_name = normalize_name(artist_name)
     row = (
         session.execute(
@@ -2353,7 +2436,36 @@ def _find_artist_uid(session, artist_name: str) -> str | None:
     return row["global_artist_uid"] if row else None
 
 
-def _find_album_uid(session, *, artist_name: str, album_name: str | None) -> str | None:
+def _find_album_uid(
+    session,
+    *,
+    artist_name: str,
+    album_name: str | None,
+    local_album_id: int | None = None,
+) -> str | None:
+    if local_album_id is not None:
+        local_source = (
+            session.execute(
+                text(
+                    """
+                    SELECT global_entity_uid::text AS global_album_uid
+                    FROM global_catalog_sources
+                    WHERE source_kind = 'local'
+                      AND entity_type = 'album'
+                      AND local_id = :local_album_id
+                      AND source_deleted_at IS NULL
+                      AND NOT source_stale
+                    LIMIT 1
+                    """
+                ),
+                {"local_album_id": local_album_id},
+            )
+            .mappings()
+            .first()
+        )
+        if local_source:
+            return local_source["global_album_uid"]
+
     if not album_name:
         return None
     normalized_name = normalize_name(album_name, strip_edition=True)

--- a/app/tests/test_global_catalog_reconciliation.py
+++ b/app/tests/test_global_catalog_reconciliation.py
@@ -1,6 +1,7 @@
 import uuid
 
 import pytest
+from sqlalchemy import text
 
 from tests.conftest import PG_AVAILABLE
 
@@ -121,6 +122,174 @@ def test_reconcile_local_catalog_is_idempotent(pg_db):
         "tracks": 1,
         "sources": 3,
     }
+
+
+def test_local_album_resolves_artist_through_merged_local_source(pg_db):
+    from crate.db.queries.global_catalog import get_global_catalog_counts
+    from crate.db.tx import read_scope, transaction_scope
+    from crate.federation.global_reconciliation import reconcile_local_catalog
+
+    shared_mbid = str(uuid.uuid4())
+    pg_db.upsert_artist(
+        {
+            "name": "Emma Ruth Rundle",
+            "entity_uid": str(uuid.uuid4()),
+            "mbid": shared_mbid,
+        }
+    )
+    with transaction_scope() as session:
+        session.execute(
+            text(
+                """
+                INSERT INTO library_artists (
+                    entity_uid, name, slug, folder_name, album_count, track_count,
+                    total_size, formats_json, has_photo, mbid, updated_at
+                )
+                VALUES (
+                    CAST(:entity_uid AS uuid), :name, :slug, :name, 0, 0,
+                    0, '[]'::jsonb, 0, :mbid, NOW()
+                )
+                """
+            ),
+            {
+                "entity_uid": str(uuid.uuid4()),
+                "name": "Emma Ruth Rundle & Thou",
+                "slug": "emma-ruth-rundle-and-thou",
+                "mbid": shared_mbid,
+            },
+        )
+    album_id = pg_db.upsert_album(
+        {
+            "artist": "Emma Ruth Rundle",
+            "name": "Engine of Hell",
+            "path": "/music/Emma Ruth Rundle/Engine of Hell",
+            "entity_uid": str(uuid.uuid4()),
+            "track_count": 1,
+        }
+    )
+    pg_db.upsert_track(
+        {
+            "album_id": album_id,
+            "artist": "Emma Ruth Rundle",
+            "album": "Engine of Hell",
+            "filename": "01 - Return.flac",
+            "title": "Return",
+            "path": "/music/Emma Ruth Rundle/Engine of Hell/01 - Return.flac",
+            "entity_uid": str(uuid.uuid4()),
+            "duration": 246.0,
+            "disc_number": 1,
+            "track_number": 1,
+            "format": "flac",
+            "size": 1024,
+        }
+    )
+
+    result = reconcile_local_catalog()
+
+    with read_scope() as session:
+        canonical_artist = (
+            session.execute(
+                text(
+                    """
+                    SELECT canonical_name, source_count
+                    FROM global_catalog_artists
+                    """
+                )
+            )
+            .mappings()
+            .one()
+        )
+
+    assert result["source_rows_seen"] == 4
+    assert get_global_catalog_counts() == {
+        "artists": 1,
+        "albums": 1,
+        "tracks": 1,
+        "sources": 4,
+    }
+    assert canonical_artist == {
+        "canonical_name": "Emma Ruth Rundle",
+        "source_count": 2,
+    }
+
+
+def test_local_track_resolves_album_through_merged_local_source(pg_db):
+    from crate.db.tx import read_scope
+    from crate.federation.global_reconciliation import reconcile_local_catalog
+
+    pg_db.upsert_artist(
+        {
+            "name": "Alias Artist",
+            "entity_uid": str(uuid.uuid4()),
+        }
+    )
+    shared_release_mbid = str(uuid.uuid4())
+    original_album_id = pg_db.upsert_album(
+        {
+            "artist": "Alias Artist",
+            "name": "Original Title",
+            "path": "/music/Alias Artist/Original Title",
+            "entity_uid": str(uuid.uuid4()),
+            "musicbrainz_albumid": shared_release_mbid,
+            "track_count": 1,
+        }
+    )
+    pg_db.upsert_album(
+        {
+            "artist": "Alias Artist",
+            "name": "Renamed Edition",
+            "path": "/music/Alias Artist/Renamed Edition",
+            "entity_uid": str(uuid.uuid4()),
+            "musicbrainz_albumid": shared_release_mbid,
+            "track_count": 1,
+        }
+    )
+    track_uid = str(uuid.uuid4())
+    pg_db.upsert_track(
+        {
+            "album_id": original_album_id,
+            "artist": "Alias Artist",
+            "album": "Original Title",
+            "filename": "01 - Source Bound.flac",
+            "title": "Source Bound",
+            "path": "/music/Alias Artist/Original Title/01 - Source Bound.flac",
+            "entity_uid": track_uid,
+            "duration": 180.0,
+            "disc_number": 1,
+            "track_number": 1,
+            "format": "flac",
+            "size": 1024,
+        }
+    )
+
+    reconcile_local_catalog()
+
+    with read_scope() as session:
+        row = (
+            session.execute(
+                text(
+                    """
+                    SELECT
+                        track.global_album_uid::text AS track_album_uid,
+                        source.global_entity_uid::text AS source_album_uid
+                    FROM global_catalog_tracks track
+                    JOIN global_catalog_sources track_source
+                      ON track_source.global_entity_uid = track.global_track_uid
+                     AND track_source.entity_type = 'track'
+                    JOIN global_catalog_sources source
+                      ON source.source_kind = 'local'
+                     AND source.entity_type = 'album'
+                     AND source.local_id = :album_id
+                    WHERE track_source.local_entity_uid = CAST(:track_uid AS uuid)
+                    """
+                ),
+                {"album_id": original_album_id, "track_uid": track_uid},
+            )
+            .mappings()
+            .one()
+        )
+
+    assert row["track_album_uid"] == row["source_album_uid"]
 
 
 def test_full_local_reconciliation_prunes_a_source_missing_from_write_model(pg_db):


### PR DESCRIPTION
## Context

The production federation backfill exposed a local-source alias case: `Emma Ruth Rundle` and `Emma Ruth Rundle & Thou` share an MBID and correctly collapse to one global entity, but the later source replaced the canonical display name. Album dependency lookup then searched only the overwritten canonical name and skipped 12 albums plus their tracks.

## Changes

- Resolve local album artist dependencies through `global_catalog_sources` before canonical-name fallback.
- Resolve local track album dependencies through the exact local album source.
- Keep the earliest local artist source as the stable display source when several local rows merge.
- Preserve the canonical human route for `Emma Ruth Rundle` while retaining the merged source only as internal provenance.
- Preserve artist artwork availability across merged local sources.

## Safety

- No schema migration.
- Remote/federated dependency lookup retains the existing canonical fallback.
- Reconciliation remains idempotent and source provenance is not deleted.

## Tests

- Reproduces a shared-MBID artist alias and verifies one canonical artist plus complete album/track projection.
- Reproduces merged album aliases and verifies tracks retain the canonical album relation.
- 36 related reconciliation, matching, source, route, and user-reference tests pass.
- Ruff and Pyright pass.