### PR TITLE
fix: resolve local tracks through album artists

### DIFF
--- a/app/crate/db/jobs/global_catalog_reconciliation.py
+++ b/app/crate/db/jobs/global_catalog_reconciliation.py
@@ -303,15 +303,19 @@ def _reconcile_local_source(session, source: dict[str, Any]) -> None:
         _upsert_album(session, source, global_uid, artist_uid)
     elif entity_type == "track":
         payload = source["source_payload"]
-        artist_uid = _find_artist_uid(session, payload["artist_name"])
-        if artist_uid is None:
-            raise RuntimeError("Track source is waiting for its canonical artist")
         album_uid = _find_album_uid(
             session,
             artist_name=payload["artist_name"],
             album_name=payload.get("album_name"),
             local_album_id=payload.get("local_album_id"),
         )
+        artist_uid = _find_local_track_artist_uid(
+            session,
+            album_uid=album_uid,
+            track_artist_name=payload["artist_name"],
+        )
+        if artist_uid is None:
+            raise RuntimeError("Track source is waiting for its canonical artist")
         global_uid, score = _resolve_track_target(session, source, artist_uid)
         source = _with_match(source, score)
         _upsert_track(session, source, global_uid, artist_uid, album_uid)
@@ -894,15 +898,19 @@ def _reconcile_local_batch_sources(
                 _upsert_album(session, source, global_uid, artist_uid)
             else:
                 payload = source["source_payload"]
-                artist_uid = _find_artist_uid(session, payload["artist_name"])
-                if artist_uid is None:
-                    continue
                 album_uid = _find_album_uid(
                     session,
                     artist_name=payload["artist_name"],
                     album_name=payload.get("album_name"),
                     local_album_id=payload.get("local_album_id"),
                 )
+                artist_uid = _find_local_track_artist_uid(
+                    session,
+                    album_uid=album_uid,
+                    track_artist_name=payload["artist_name"],
+                )
+                if artist_uid is None:
+                    continue
                 global_uid, score = _resolve_track_target(session, source, artist_uid)
                 source = _with_match(source, score)
                 existed = _canonical_exists(
@@ -2487,6 +2495,28 @@ def _find_album_uid(
         .first()
     )
     return row["global_album_uid"] if row else None
+
+
+def _find_local_track_artist_uid(
+    session,
+    *,
+    album_uid: str | None,
+    track_artist_name: str,
+) -> str | None:
+    if album_uid is not None:
+        artist_uid = session.execute(
+            text(
+                """
+                SELECT global_artist_uid::text
+                FROM global_catalog_albums
+                WHERE global_album_uid = CAST(:album_uid AS uuid)
+                """
+            ),
+            {"album_uid": album_uid},
+        ).scalar_one_or_none()
+        if artist_uid is not None:
+            return str(artist_uid)
+    return _find_artist_uid(session, track_artist_name)
 
 
 def _source_conflict_target(source: dict[str, Any]) -> str:

--- a/app/tests/test_global_catalog_reconciliation.py
+++ b/app/tests/test_global_catalog_reconciliation.py
@@ -292,6 +292,84 @@ def test_local_track_resolves_album_through_merged_local_source(pg_db):
     assert row["track_album_uid"] == row["source_album_uid"]
 
 
+@pytest.mark.parametrize("reconciliation_mode", ["full", "incremental"])
+def test_local_track_uses_album_artist_when_track_credit_is_not_canonical(
+    pg_db, reconciliation_mode
+):
+    from crate.db.tx import read_scope
+    from crate.federation.global_reconciliation import (
+        reconcile_dirty_catalog_sources,
+        reconcile_local_catalog,
+    )
+
+    pg_db.upsert_artist(
+        {
+            "name": "The Who",
+            "entity_uid": str(uuid.uuid4()),
+        }
+    )
+    album_id = pg_db.upsert_album(
+        {
+            "artist": "The Who",
+            "name": "Who Came First",
+            "path": "/music/The Who/Who Came First",
+            "entity_uid": str(uuid.uuid4()),
+            "track_count": 1,
+        }
+    )
+    track_uid = str(uuid.uuid4())
+    pg_db.upsert_track(
+        {
+            "album_id": album_id,
+            "artist": "Pete Townshend",
+            "album": "Who Came First",
+            "filename": "01 - Pure And Easy.flac",
+            "title": "Pure And Easy",
+            "path": "/music/The Who/Who Came First/01 - Pure And Easy.flac",
+            "entity_uid": track_uid,
+            "duration": 333.0,
+            "disc_number": 1,
+            "track_number": 1,
+            "format": "flac",
+            "size": 1024,
+        }
+    )
+
+    if reconciliation_mode == "full":
+        reconcile_local_catalog()
+    else:
+        result = reconcile_dirty_catalog_sources(limit=10)
+        assert result["failed"] == 0
+        assert result["remaining"] == 0
+
+    with read_scope() as session:
+        row = (
+            session.execute(
+                text(
+                    """
+                    SELECT
+                        track.global_artist_uid::text AS track_artist_uid,
+                        album.global_artist_uid::text AS album_artist_uid
+                    FROM global_catalog_sources source
+                    JOIN global_catalog_tracks track
+                      ON track.global_track_uid = source.global_entity_uid
+                    JOIN global_catalog_albums album
+                      ON album.global_album_uid = track.global_album_uid
+                    WHERE source.source_kind = 'local'
+                      AND source.entity_type = 'track'
+                      AND source.local_entity_uid = CAST(:track_uid AS uuid)
+                    """
+                ),
+                {"track_uid": track_uid},
+            )
+            .mappings()
+            .one_or_none()
+        )
+
+    assert row is not None
+    assert row["track_artist_uid"] == row["album_artist_uid"]
+
+
 def test_full_local_reconciliation_prunes_a_source_missing_from_write_model(pg_db):
     from sqlalchemy import text
 


### PR DESCRIPTION
## Qué cambia

- resuelve primero el álbum local canónico de cada track
- usa el `global_artist_uid` del álbum como padre canónico del track
- conserva el crédito original del track en el payload y lo usa como fallback cuando no hay álbum
- aplica la misma regla a reconciliación full e incremental

## Causa raíz

El reconciliador intentaba resolver `library_tracks.artist` antes de consultar el álbum. En producción hay 6.018 tracks cuyo crédito es un colaborador, featured artist u orchestra que no existe como `library_artist`, aunque su álbum y album artist sí están correctamente proyectados. Esos tracks se omitían silenciosamente del catálogo global.

La auditoría de producción confirmó:

- 6.018/6.018 tracks ausentes tienen fuente de álbum global
- 6.018/6.018 tienen `track.artist != album.artist`
- 0/6.018 tienen un artista local equivalente para el crédito del track

## Impacto

Tras reanudar el full backfill, las fuentes locales de track deben pasar de 108.903 a 114.921 sin crear artistas sintéticos ni alterar URLs humanas.

## Validación

- test TDD con `Pete Townshend` como crédito y `The Who` como album artist
- misma regresión ejecutada por reconciliación full e incremental
- 20 tests relacionados de reconciliación/local/dirty/deletions
- `uv run pyright`: 0 errores
- Ruff, format y `git diff --check`: green
