### PR TITLE
fix: harden catalog deployment recovery

### DIFF
--- a/app/crate/api/__init__.py
+++ b/app/crate/api/__init__.py
@@ -89,7 +89,7 @@ def _queue_global_catalog_bootstrap() -> None:
 
     state = get_catalog_state()
     if (
-        state["status"] not in {"cold", "failed"}
+        state["status"] == "ready"
         and state.get("user_refs_backfilled_at") is not None
         and state.get("user_refs_backfill_version", 0)
         >= USER_LIBRARY_REFS_BACKFILL_VERSION

--- a/app/tests/test_deploy_release_commands.py
+++ b/app/tests/test_deploy_release_commands.py
@@ -178,6 +178,18 @@ def test_remote_verify_waits_for_public_routes_to_become_ready() -> None:
     assert verify_body.count("wait_for_public_url") == 4
 
 
+def test_health_wait_does_not_treat_running_before_health_init_as_ready() -> None:
+    script = (ROOT / "scripts/deploy-remote.sh").read_text()
+    wait_body = script[
+        script.index("wait_for_container_healthy() {") : script.index(
+            "wait_for_public_url() {"
+        )
+    ]
+
+    assert ".State.Health.Status" in wait_body
+    assert "{{else}}{{.State.Running}}" not in wait_body
+
+
 def test_remote_state_rollback_restores_database_before_old_images() -> None:
     script = (ROOT / "scripts/deploy-remote.sh").read_text()
     rollback_body = script[

--- a/app/tests/test_node_first_catalog_contract.py
+++ b/app/tests/test_node_first_catalog_contract.py
@@ -183,6 +183,45 @@ def test_ready_node_without_search_projection_queues_a_catalog_backfill(monkeypa
     )
 
 
+def test_backfilling_node_resumes_catalog_backfill_on_startup(monkeypatch):
+    from crate import api
+    from crate.db import global_catalog_search_projection
+    from crate.db.repositories import global_catalog_state, tasks
+    from crate.db.repositories.global_user_library import (
+        USER_LIBRARY_REFS_BACKFILL_VERSION,
+    )
+
+    queued: dict[str, object] = {}
+    monkeypatch.setattr(
+        global_catalog_state,
+        "get_catalog_state",
+        lambda: {
+            "status": "backfilling",
+            "user_refs_backfilled_at": "2026-07-13T10:00:00+00:00",
+            "user_refs_backfill_version": USER_LIBRARY_REFS_BACKFILL_VERSION,
+        },
+    )
+    monkeypatch.setattr(
+        global_catalog_search_projection,
+        "get_global_catalog_search_projection_status",
+        lambda: "ready",
+        raising=False,
+    )
+    monkeypatch.setattr(
+        tasks,
+        "create_task_dedup",
+        lambda *args, **kwargs: queued.update({"args": args, "kwargs": kwargs}),
+    )
+
+    api._queue_global_catalog_bootstrap()
+
+    assert queued["args"] == (
+        "global_catalog_reconcile_full",
+        {"triggered_by": "api_startup"},
+    )
+    assert queued["kwargs"] == {"dedup_key": "global-catalog:full"}
+
+
 def test_ready_node_with_ready_search_projection_skips_catalog_backfill(monkeypatch):
     from crate import api
     from crate.db import global_catalog_search_projection

--- a/scripts/deploy-remote.sh
+++ b/scripts/deploy-remote.sh
@@ -266,8 +266,8 @@ wait_for_container_healthy() {
   local reported_unhealthy=0
 
   while true; do
-    status="$(docker inspect -f '{{if .State.Health}}{{.State.Health.Status}}{{else}}{{.State.Running}}{{end}}' "$container" 2>/dev/null || true)"
-    if [[ "$status" == "healthy" || "$status" == "true" ]]; then
+    status="$(docker inspect -f '{{if .State.Health}}{{.State.Health.Status}}{{end}}' "$container" 2>/dev/null || true)"
+    if [[ "$status" == "healthy" ]]; then
       return 0
     fi
     if [[ "$status" == "unhealthy" ]]; then


### PR DESCRIPTION
## Summary

- resume a durable global catalog reconciliation when API startup finds the catalog in `backfilling`
- only skip startup reconciliation when catalog, user-reference backfill and search projection are all fully ready
- require a real Docker `healthy` state during deploy verification instead of accepting the brief pre-health `running` state

## Production evidence

During the `ee8e327` rollout, Docker exposed the recreated API as running before its health state was initialized. The verifier accepted that transient state and probed port 8585 before Uvicorn completed startup. After startup, the API and public routes were healthy.

The same restart left the durable catalog cursor in `backfilling`, but startup skipped the resume because user refs and the search projection were already ready. A manually queued reconciliation with the shared `global-catalog:full` dedup key resumed the persisted cursor and is restoring the missing local track sources.

## TDD

Both regressions were reproduced with failing tests before the implementation:

- `test_backfilling_node_resumes_catalog_backfill_on_startup`
- `test_health_wait_does_not_treat_running_before_health_init_as_ready`

Validation:

- `23 passed` across node-first catalog and deploy release tests
- Ruff check/format green
- `bash -n scripts/deploy-remote.sh` green
