### PR TITLE
fix: repair catalog data regressions

### DIFF
--- a/app/crate/api/browse_artist.py
+++ b/app/crate/api/browse_artist.py
@@ -424,15 +424,23 @@ def _build_artist_top_tracks_payload(
     *,
     count: int,
     lastfm_top: list[dict] | None,
+    local_tracks: list[dict] | None = None,
 ) -> list[dict]:
     all_tracks: dict[str, dict] = {}
-    for row in get_artist_all_tracks(artist_name, limit=max(count * 8, 200)):
-        all_tracks.setdefault(row["title"].lower(), row)
+    rows = (
+        local_tracks
+        if local_tracks is not None
+        else get_artist_all_tracks(artist_name, limit=max(count * 8, 200))
+    )
+    for row in rows:
+        title = str(row.get("title") or "").strip()
+        if title:
+            all_tracks.setdefault(title.casefold(), row)
 
     ranked = []
     seen_ids: set[int] = set()
     for item in lastfm_top or []:
-        match = all_tracks.get(item["title"].lower())
+        match = all_tracks.get(str(item.get("title") or "").strip().casefold())
         if match and match["id"] not in seen_ids:
             seen_ids.add(match["id"])
             ranked.append(match)
@@ -441,22 +449,47 @@ def _build_artist_top_tracks_payload(
 
     if len(ranked) < count:
         remaining = [
-            track for track in all_tracks.values() if track["id"] not in seen_ids
+            track
+            for track in all_tracks.values()
+            if track["id"] not in seen_ids and _has_track_level_popularity_signal(track)
         ]
-        remaining.sort(
-            key=lambda track: (
-                track.get("year") or "0",
-                track.get("track_number") or 0,
-            ),
-            reverse=True,
-        )
+        remaining.sort(key=_persisted_top_track_sort_key)
         ranked.extend(remaining[: count - len(ranked)])
 
     return [_format_artist_top_track(row) for row in ranked]
 
 
+def _has_track_level_popularity_signal(track: dict) -> bool:
+    return any(
+        track.get(field) is not None
+        for field in (
+            "lastfm_top_rank",
+            "lastfm_listeners",
+            "lastfm_playcount",
+            "spotify_top_rank",
+            "spotify_track_popularity",
+            "popularity_score",
+        )
+    )
+
+
+def _persisted_top_track_sort_key(track: dict) -> tuple:
+    return (
+        track.get("lastfm_top_rank") is None,
+        int(track.get("lastfm_top_rank") or 1_000_000),
+        track.get("spotify_top_rank") is None,
+        int(track.get("spotify_top_rank") or 1_000_000),
+        -int(track.get("lastfm_playcount") or 0),
+        -int(track.get("lastfm_listeners") or 0),
+        -int(track.get("spotify_track_popularity") or 0),
+        -float(track.get("popularity_score") or 0.0),
+        -float(track.get("popularity_confidence") or 0.0),
+        str(track.get("title") or "").casefold(),
+    )
+
+
 def _get_artist_top_tracks_payload(artist_name: str, *, count: int) -> list[dict]:
-    cache_key = f"listen:artist_top_tracks:v1:{artist_name.strip().lower()}:{count}"
+    cache_key = f"listen:artist_top_tracks:v2:{artist_name.strip().lower()}:{count}"
     cached = get_cache(cache_key, max_age_seconds=300)
     if cached is not None:
         return cached

--- a/app/crate/db/jobs/genre_taxonomy.py
+++ b/app/crate/db/jobs/genre_taxonomy.py
@@ -12,13 +12,22 @@ def _slugify_genre(value: str) -> str:
 
 
 def assign_genre_alias_in_session(
-    session, alias_value: str, canonical_slug: str
+    session,
+    alias_value: str,
+    canonical_slug: str,
+    *,
+    origin: str = "manual",
+    confidence: float | None = None,
 ) -> bool:
     alias_name = (alias_value or "").strip().lower()
     alias_slug = _slugify_genre(alias_name)
     canonical_slug = (canonical_slug or "").strip().lower()
     if not alias_name or not alias_slug or not canonical_slug:
         return False
+    normalized_origin = origin if origin in {"core", "manual", "inferred"} else "manual"
+    normalized_confidence = (
+        max(0.0, min(1.0, float(confidence))) if confidence is not None else None
+    )
 
     session.execute(
         text("SELECT pg_advisory_xact_lock(hashtext(:lock_key))"),
@@ -40,7 +49,7 @@ def assign_genre_alias_in_session(
         session.execute(
             text(
                 """
-            SELECT alias_slug, genre_id
+            SELECT alias_slug, genre_id, origin, confidence
             FROM genre_taxonomy_aliases
             WHERE alias_name = :alias_name
             """
@@ -54,6 +63,15 @@ def assign_genre_alias_in_session(
         existing
         and existing["alias_slug"] == alias_slug
         and int(existing["genre_id"]) == int(node_row["id"])
+        and existing["origin"] == normalized_origin
+        and (
+            existing["confidence"] == normalized_confidence
+            or (
+                existing["confidence"] is not None
+                and normalized_confidence is not None
+                and float(existing["confidence"]) == normalized_confidence
+            )
+        )
     ):
         return True
 
@@ -66,25 +84,45 @@ def assign_genre_alias_in_session(
     session.execute(
         text(
             """
-            INSERT INTO genre_taxonomy_aliases (alias_slug, alias_name, genre_id)
-            VALUES (:alias_slug, :alias_name, :genre_id)
+            INSERT INTO genre_taxonomy_aliases (
+                alias_slug, alias_name, genre_id, origin, confidence
+            )
+            VALUES (
+                :alias_slug, :alias_name, :genre_id, :origin, :confidence
+            )
             ON CONFLICT (alias_slug) DO UPDATE
             SET alias_name = EXCLUDED.alias_name,
-                genre_id = EXCLUDED.genre_id
+                genre_id = EXCLUDED.genre_id,
+                origin = EXCLUDED.origin,
+                confidence = EXCLUDED.confidence
             """
         ),
         {
             "alias_slug": alias_slug,
             "alias_name": alias_name,
             "genre_id": node_row["id"],
+            "origin": normalized_origin,
+            "confidence": normalized_confidence,
         },
     )
     return True
 
 
-def assign_genre_alias_value(alias_value: str, canonical_slug: str) -> bool:
+def assign_genre_alias_value(
+    alias_value: str,
+    canonical_slug: str,
+    *,
+    origin: str = "manual",
+    confidence: float | None = None,
+) -> bool:
     with transaction_scope() as session:
-        return assign_genre_alias_in_session(session, alias_value, canonical_slug)
+        return assign_genre_alias_in_session(
+            session,
+            alias_value,
+            canonical_slug,
+            origin=origin,
+            confidence=confidence,
+        )
 
 
 def merge_duplicate_library_genres_in_session(session) -> list[dict]:
@@ -265,11 +303,15 @@ def seed_genre_taxonomy_definitions(session, definitions) -> None:
             session.execute(
                 text(
                     """
-                    INSERT INTO genre_taxonomy_aliases (alias_slug, alias_name, genre_id)
-                    VALUES (:alias_slug, :alias_name, :genre_id)
+                    INSERT INTO genre_taxonomy_aliases (
+                        alias_slug, alias_name, genre_id, origin, confidence
+                    )
+                    VALUES (:alias_slug, :alias_name, :genre_id, 'core', 1.0)
                     ON CONFLICT (alias_slug) DO UPDATE
                     SET alias_name = EXCLUDED.alias_name,
-                        genre_id = EXCLUDED.genre_id
+                        genre_id = EXCLUDED.genre_id,
+                        origin = 'core',
+                        confidence = 1.0
                     """
                 ),
                 {
@@ -278,6 +320,8 @@ def seed_genre_taxonomy_definitions(session, definitions) -> None:
                     "genre_id": genre_id,
                 },
             )
+
+    session.execute(text("DELETE FROM genre_taxonomy_aliases WHERE origin = 'legacy'"))
 
     for definition in definitions:
         source_id = node_ids.get(definition.slug)

--- a/app/crate/db/jobs/global_catalog_reconciliation.py
+++ b/app/crate/db/jobs/global_catalog_reconciliation.py
@@ -5,8 +5,9 @@ from __future__ import annotations
 import json
 import logging
 import uuid
-from itertools import islice
+from collections.abc import Mapping
 from datetime import datetime, timezone
+from itertools import islice
 from typing import Any
 
 from sqlalchemy import text
@@ -554,14 +555,21 @@ def reconcile_remote_catalog(
 
 
 def reconcile_local_catalog_batch(
-    *, batch_size: int = 500, cursor: dict[str, Any] | None = None
+    *,
+    batch_size: int = 500,
+    cursor: dict[str, Any] | None = None,
+    recompute_matches: bool = False,
 ) -> dict[str, Any]:
     """Project one durable, dependency-ordered batch of local sources."""
     entity_type, after_id = _reconciliation_cursor(cursor)
     sources = _local_batch_sources(entity_type, after_id, batch_size)
     result = _new_batch_result("local", len(sources))
     if sources:
-        _reconcile_local_batch_sources(sources, result)
+        _reconcile_local_batch_sources(
+            sources,
+            result,
+            recompute_matches=recompute_matches,
+        )
     return _complete_batch_result(result, entity_type, after_id, sources, batch_size)
 
 
@@ -570,6 +578,7 @@ def reconcile_remote_catalog_batch(
     batch_size: int = 500,
     cursor: dict[str, Any] | None = None,
     node_uid: str | None = None,
+    recompute_matches: bool = False,
 ) -> dict[str, Any]:
     """Project one durable, dependency-ordered batch of federated sources."""
     entity_type, after_id = _reconciliation_cursor(cursor)
@@ -586,7 +595,11 @@ def reconcile_remote_catalog_batch(
     )
     result = _new_batch_result("peer" if node_uid else "incremental", len(sources))
     if sources:
-        _reconcile_remote_batch_sources(sources, result)
+        _reconcile_remote_batch_sources(
+            sources,
+            result,
+            recompute_matches=recompute_matches,
+        )
     return _complete_batch_result(result, entity_type, after_id, sources, batch_size)
 
 
@@ -866,13 +879,20 @@ def _merge_batch_result(result: dict[str, Any], batch: dict[str, Any]) -> None:
 
 
 def _reconcile_local_batch_sources(
-    sources: list[dict[str, Any]], result: dict[str, Any]
+    sources: list[dict[str, Any]],
+    result: dict[str, Any],
+    *,
+    recompute_matches: bool = False,
 ) -> None:
     with transaction_scope() as session:
         for source in sources:
             entity_type = source["entity_type"]
             if entity_type == "artist":
-                global_uid, score = _resolve_artist_target(session, source)
+                global_uid, score = _resolve_artist_target(
+                    session,
+                    source,
+                    recompute_matches=recompute_matches,
+                )
                 source = _with_match(source, score)
                 existed = _canonical_exists(
                     session,
@@ -887,7 +907,12 @@ def _reconcile_local_batch_sources(
                 )
                 if artist_uid is None:
                     continue
-                global_uid, score = _resolve_album_target(session, source, artist_uid)
+                global_uid, score = _resolve_album_target(
+                    session,
+                    source,
+                    artist_uid,
+                    recompute_matches=recompute_matches,
+                )
                 source = _with_match(source, score)
                 existed = _canonical_exists(
                     session,
@@ -911,7 +936,12 @@ def _reconcile_local_batch_sources(
                 )
                 if artist_uid is None:
                     continue
-                global_uid, score = _resolve_track_target(session, source, artist_uid)
+                global_uid, score = _resolve_track_target(
+                    session,
+                    source,
+                    artist_uid,
+                    recompute_matches=recompute_matches,
+                )
                 source = _with_match(source, score)
                 existed = _canonical_exists(
                     session,
@@ -927,13 +957,20 @@ def _reconcile_local_batch_sources(
 
 
 def _reconcile_remote_batch_sources(
-    sources: list[dict[str, Any]], result: dict[str, Any]
+    sources: list[dict[str, Any]],
+    result: dict[str, Any],
+    *,
+    recompute_matches: bool = False,
 ) -> None:
     with transaction_scope() as session:
         for source in sources:
             entity_type = source["entity_type"]
             if entity_type == "artist":
-                target_uid, score = _resolve_artist_target(session, source)
+                target_uid, score = _resolve_artist_target(
+                    session,
+                    source,
+                    recompute_matches=recompute_matches,
+                )
                 source = _with_match(source, score)
                 existed = _canonical_exists(
                     session, "global_catalog_artists", "global_artist_uid", target_uid
@@ -947,7 +984,12 @@ def _reconcile_remote_batch_sources(
                 )
                 if artist_uid is None:
                     continue
-                target_uid, score = _resolve_album_target(session, source, artist_uid)
+                target_uid, score = _resolve_album_target(
+                    session,
+                    source,
+                    artist_uid,
+                    recompute_matches=recompute_matches,
+                )
                 source = _with_match(source, score)
                 existed = _canonical_exists(
                     session, "global_catalog_albums", "global_album_uid", target_uid
@@ -965,7 +1007,12 @@ def _reconcile_remote_batch_sources(
                     artist_name=payload["artist_name"],
                     album_name=payload.get("album_name"),
                 )
-                target_uid, score = _resolve_track_target(session, source, artist_uid)
+                target_uid, score = _resolve_track_target(
+                    session,
+                    source,
+                    artist_uid,
+                    recompute_matches=recompute_matches,
+                )
                 source = _with_match(source, score)
                 existed = _canonical_exists(
                     session, "global_catalog_tracks", "global_track_uid", target_uid
@@ -993,6 +1040,85 @@ def _insert_run(session, *, run_id: str, mode: str, started_at: datetime) -> Non
         ),
         {"run_id": run_id, "mode": mode, "started_at": started_at},
     )
+
+
+def begin_global_catalog_reconciliation_run(*, mode: str) -> str:
+    run_id = str(uuid.uuid4())
+    started_at = datetime.now(timezone.utc)
+    with transaction_scope() as session:
+        _insert_run(session, run_id=run_id, mode=mode, started_at=started_at)
+    _emit_reconcile_event("started", run_id=run_id, mode=mode)
+    return run_id
+
+
+def record_global_catalog_reconciliation_batch(
+    run_id: str, result: Mapping[str, Any]
+) -> None:
+    with transaction_scope() as session:
+        session.execute(
+            text(
+                """
+                UPDATE global_catalog_reconciliation_runs
+                SET
+                    source_rows_seen = source_rows_seen + :source_rows_seen,
+                    sources_upserted = sources_upserted + :sources_upserted,
+                    canonical_created = canonical_created + :canonical_created,
+                    canonical_updated = canonical_updated + :canonical_updated,
+                    auto_merged = auto_merged + :auto_merged,
+                    ambiguous_candidates =
+                        ambiguous_candidates + :ambiguous_candidates
+                WHERE run_id = :run_id
+                  AND status = 'running'
+                """
+            ),
+            {
+                "run_id": run_id,
+                "source_rows_seen": int(result.get("source_rows_seen") or 0),
+                "sources_upserted": int(result.get("sources_upserted") or 0),
+                "canonical_created": int(result.get("canonical_created") or 0),
+                "canonical_updated": int(result.get("canonical_updated") or 0),
+                "auto_merged": int(result.get("auto_merged") or 0),
+                "ambiguous_candidates": int(result.get("ambiguous_candidates") or 0),
+            },
+        )
+
+
+def complete_global_catalog_reconciliation_run(run_id: str) -> None:
+    with transaction_scope() as session:
+        session.execute(
+            text(
+                """
+                UPDATE global_catalog_reconciliation_runs
+                SET
+                    status = 'completed',
+                    completed_at = :completed_at
+                WHERE run_id = :run_id
+                  AND status = 'running'
+                """
+            ),
+            {
+                "run_id": run_id,
+                "completed_at": datetime.now(timezone.utc),
+            },
+        )
+        _emit_reconcile_event(
+            "completed",
+            run_id=run_id,
+            mode="full",
+            session=session,
+        )
+
+
+def fail_global_catalog_reconciliation_run(run_id: str, error: str) -> None:
+    with transaction_scope() as session:
+        _fail_run(session, run_id=run_id, error=error)
+        _emit_reconcile_event(
+            "failed",
+            run_id=run_id,
+            mode="full",
+            error=error,
+            session=session,
+        )
 
 
 def _complete_run(session, *, run_id: str, result: dict[str, Any]) -> None:
@@ -1100,7 +1226,12 @@ def _count_result(result: dict[str, Any], existed: bool) -> None:
         result["canonical_created"] += 1
 
 
-def _resolve_artist_target(session, source: dict[str, Any]) -> tuple[str, MatchScore]:
+def _resolve_artist_target(
+    session,
+    source: dict[str, Any],
+    *,
+    recompute_matches: bool = False,
+) -> tuple[str, MatchScore]:
     forced_target = force_merge_target_for_source(session, source)
     if forced_target:
         return forced_target, MatchScore(1.0, "manual_force_merge", auto_merge=True)
@@ -1109,10 +1240,21 @@ def _resolve_artist_target(session, source: dict[str, Any]) -> tuple[str, MatchS
     if existing_target and not merge_blocked_for_source(
         session, source, existing_target
     ):
-        return existing_target, _existing_source_score(source)
+        if not recompute_matches:
+            return existing_target, _existing_source_score(source)
+        revalidated = _revalidate_existing_target(
+            session,
+            source,
+            existing_target,
+            score_artist_match,
+        )
+        if revalidated is not None:
+            return revalidated
 
     payload = source["source_payload"]
     rows = _candidate_artists(session, payload)
+    if recompute_matches and existing_target:
+        rows = [row for row in rows if row["global_artist_uid"] != existing_target]
     best_uid, best_score = _best_match(
         rows,
         payload,
@@ -1134,6 +1276,8 @@ def _resolve_album_target(
     session,
     source: dict[str, Any],
     artist_uid: str,
+    *,
+    recompute_matches: bool = False,
 ) -> tuple[str, MatchScore]:
     forced_target = force_merge_target_for_source(session, source)
     if forced_target:
@@ -1157,10 +1301,21 @@ def _resolve_album_target(
     if existing_target and not merge_blocked_for_source(
         session, source, existing_target
     ):
-        return existing_target, _existing_source_score(source)
+        if not recompute_matches:
+            return existing_target, _existing_source_score(source)
+        revalidated = _revalidate_existing_target(
+            session,
+            source,
+            existing_target,
+            score_album_match,
+        )
+        if revalidated is not None:
+            return revalidated
 
     payload = source["source_payload"]
     rows = _candidate_albums(session, payload, artist_uid)
+    if recompute_matches and existing_target:
+        rows = [row for row in rows if row["global_album_uid"] != existing_target]
     best_uid, best_score = _best_match(
         rows,
         payload,
@@ -1182,6 +1337,8 @@ def _resolve_track_target(
     session,
     source: dict[str, Any],
     artist_uid: str,
+    *,
+    recompute_matches: bool = False,
 ) -> tuple[str, MatchScore]:
     forced_target = force_merge_target_for_source(session, source)
     if forced_target:
@@ -1191,10 +1348,21 @@ def _resolve_track_target(
     if existing_target and not merge_blocked_for_source(
         session, source, existing_target
     ):
-        return existing_target, _existing_source_score(source)
+        if not recompute_matches:
+            return existing_target, _existing_source_score(source)
+        revalidated = _revalidate_existing_target(
+            session,
+            source,
+            existing_target,
+            score_track_match,
+        )
+        if revalidated is not None:
+            return revalidated
 
     payload = source["source_payload"]
     rows = _candidate_tracks(session, payload, artist_uid)
+    if recompute_matches and existing_target:
+        rows = [row for row in rows if row["global_track_uid"] != existing_target]
     best_uid, best_score = _best_match(
         rows,
         payload,
@@ -1210,6 +1378,74 @@ def _resolve_track_target(
             )
         return best_uid, best_score
     return _global_uid(source), best_score or MatchScore(0.0, "new_remote_track")
+
+
+def _revalidate_existing_target(
+    session,
+    source: dict[str, Any],
+    existing_target: str,
+    scorer,
+) -> tuple[str, MatchScore] | None:
+    if _global_uid(source) == existing_target:
+        return existing_target, MatchScore(
+            1.0,
+            "existing_source_identity",
+            auto_merge=True,
+        )
+
+    rows = (
+        session.execute(
+            text(
+                """
+                SELECT
+                    source_kind,
+                    node_uid::text AS node_uid,
+                    remote_entity_uid,
+                    local_id,
+                    local_entity_uid::text AS local_entity_uid,
+                    source_payload_json
+                FROM global_catalog_sources
+                WHERE entity_type = :entity_type
+                  AND global_entity_uid = CAST(:global_entity_uid AS uuid)
+                  AND source_deleted_at IS NULL
+                  AND NOT source_stale
+                """
+            ),
+            {
+                "entity_type": source["entity_type"],
+                "global_entity_uid": existing_target,
+            },
+        )
+        .mappings()
+        .all()
+    )
+    anchor = next(
+        (
+            row
+            for row in rows
+            if _global_uid(
+                {
+                    "entity_type": source["entity_type"],
+                    "source_kind": row["source_kind"],
+                    "local_id": row["local_id"],
+                    "local_entity_uid": row["local_entity_uid"],
+                    "remote_entity_uid": row["remote_entity_uid"],
+                }
+            )
+            == existing_target
+        ),
+        None,
+    )
+    if anchor is None:
+        return None
+    payload = anchor.get("source_payload_json")
+    if isinstance(payload, str):
+        payload = json.loads(payload)
+    if isinstance(payload, dict):
+        score = scorer(source["source_payload"], payload)
+        if score.auto_merge:
+            return existing_target, score
+    return None
 
 
 def _best_match(

--- a/app/crate/db/migrations/versions/077_genre_alias_provenance.py
+++ b/app/crate/db/migrations/versions/077_genre_alias_provenance.py
@@ -1,0 +1,88 @@
+"""Track genre alias provenance and quarantine unclassified legacy aliases.
+
+Revision ID: 077
+Revises: 076
+"""
+
+from collections.abc import Sequence
+
+from alembic import op
+
+
+revision = "077"
+down_revision = "076"
+branch_labels: Sequence[str] | None = None
+depends_on: Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.execute(
+        """
+        ALTER TABLE genre_taxonomy_aliases
+        ADD COLUMN IF NOT EXISTS origin TEXT NOT NULL DEFAULT 'legacy'
+        """
+    )
+    op.execute(
+        """
+        ALTER TABLE genre_taxonomy_aliases
+        ADD COLUMN IF NOT EXISTS confidence DOUBLE PRECISION
+        """
+    )
+    op.execute(
+        """
+        DO $$
+        BEGIN
+            IF NOT EXISTS (
+                SELECT 1
+                FROM pg_constraint
+                WHERE conname = 'genre_taxonomy_aliases_origin_check'
+            ) THEN
+                ALTER TABLE genre_taxonomy_aliases
+                ADD CONSTRAINT genre_taxonomy_aliases_origin_check
+                CHECK (origin IN ('core', 'manual', 'inferred', 'legacy'));
+            END IF;
+        END
+        $$
+        """
+    )
+    op.execute(
+        """
+        DO $$
+        BEGIN
+            IF NOT EXISTS (
+                SELECT 1
+                FROM pg_constraint
+                WHERE conname = 'genre_taxonomy_aliases_confidence_check'
+            ) THEN
+                ALTER TABLE genre_taxonomy_aliases
+                ADD CONSTRAINT genre_taxonomy_aliases_confidence_check
+                CHECK (confidence IS NULL OR (confidence >= 0 AND confidence <= 1));
+            END IF;
+        END
+        $$
+        """
+    )
+    op.execute(
+        """
+        CREATE INDEX IF NOT EXISTS idx_genre_taxonomy_aliases_origin
+        ON genre_taxonomy_aliases (origin)
+        """
+    )
+
+
+def downgrade() -> None:
+    op.execute("DROP INDEX IF EXISTS idx_genre_taxonomy_aliases_origin")
+    op.execute(
+        """
+        ALTER TABLE genre_taxonomy_aliases
+        DROP CONSTRAINT IF EXISTS genre_taxonomy_aliases_confidence_check
+        """
+    )
+    op.execute(
+        """
+        ALTER TABLE genre_taxonomy_aliases
+        DROP CONSTRAINT IF EXISTS genre_taxonomy_aliases_origin_check
+        """
+    )
+    op.execute("ALTER TABLE genre_taxonomy_aliases DROP COLUMN IF EXISTS confidence")
+    op.execute("ALTER TABLE genre_taxonomy_aliases DROP COLUMN IF EXISTS origin")

--- a/app/crate/db/orm/genre.py
+++ b/app/crate/db/orm/genre.py
@@ -52,6 +52,12 @@ class GenreTaxonomyAlias(Base):
         ForeignKey("genre_taxonomy_nodes.id", ondelete="CASCADE"),
         nullable=False,
     )
+    origin: Mapped[str] = mapped_column(
+        Text,
+        nullable=False,
+        server_default="legacy",
+    )
+    confidence: Mapped[float | None] = mapped_column(Float)
 
     genre: Mapped["GenreTaxonomyNode"] = relationship(back_populates="aliases")
 

--- a/app/crate/db/queries/admin_global_catalog.py
+++ b/app/crate/db/queries/admin_global_catalog.py
@@ -61,7 +61,9 @@ def get_global_catalog_admin_status() -> dict[str, Any]:
                     SELECT COUNT(*)
                     FROM global_catalog_sources
                     WHERE match_confidence >= 0.850
-                      AND match_confidence < 0.950
+                      AND match_confidence < 0.900
+                      AND source_deleted_at IS NULL
+                      AND NOT source_stale
                     """
                 )
             ).scalar()
@@ -165,8 +167,10 @@ def list_global_catalog_duplicate_candidates(
                         ) AS sources
                     FROM global_catalog_sources
                     WHERE match_confidence >= 0.850
+                      AND source_deleted_at IS NULL
+                      AND NOT source_stale
                     GROUP BY entity_type, match_key
-                    HAVING COUNT(*) > 1
+                    HAVING COUNT(DISTINCT global_entity_uid) > 1
                     ORDER BY source_count DESC, entity_type ASC, match_key ASC
                     LIMIT :limit
                     """

--- a/app/crate/db/queries/browse_artist_tracks.py
+++ b/app/crate/db/queries/browse_artist_tracks.py
@@ -22,6 +22,9 @@ def get_artist_all_tracks(artist_name: str, limit: int | None = None) -> list[di
                     t.track_number, t.format,
                     t.bpm, t.audio_key, t.audio_scale, t.energy,
                     t.danceability, t.valence, t.bliss_vector,
+                    t.lastfm_top_rank, t.lastfm_listeners, t.lastfm_playcount,
+                    t.spotify_top_rank, t.spotify_track_popularity,
+                    t.popularity_score, t.popularity_confidence,
                     t.entity_uid::text AS track_entity_uid,
                     a.id as album_id, a.entity_uid::text AS album_entity_uid, a.slug as album_slug, a.year,
                     ar.id as artist_id, ar.entity_uid::text AS artist_entity_uid, ar.slug as artist_slug
@@ -29,7 +32,13 @@ def get_artist_all_tracks(artist_name: str, limit: int | None = None) -> list[di
                 LEFT JOIN library_albums a ON a.id = t.album_id
                 LEFT JOIN library_artists ar ON ar.name = t.artist
                 WHERE t.artist = :artist_name
-                ORDER BY COALESCE(t.lastfm_playcount, 0) DESC,
+                ORDER BY t.lastfm_top_rank ASC NULLS LAST,
+                    t.spotify_top_rank ASC NULLS LAST,
+                    COALESCE(t.lastfm_playcount, 0) DESC,
+                    COALESCE(t.lastfm_listeners, 0) DESC,
+                    COALESCE(t.spotify_track_popularity, 0) DESC,
+                    COALESCE(t.popularity_score, 0) DESC,
+                    COALESCE(t.popularity_confidence, 0) DESC,
                     a.year DESC NULLS LAST,
                     t.track_number ASC NULLS LAST,
                     t.title ASC

--- a/app/crate/db/queries/genres_library_detail.py
+++ b/app/crate/db/queries/genres_library_detail.py
@@ -16,6 +16,7 @@ from crate.genre_taxonomy import (
 )
 
 MIN_GENRE_MEMBERSHIP_SCORE = 0.45
+MIN_ARTIST_ROOM_MEMBERSHIP_SCORE = 0.70
 ARTIST_ALBUM_FALLBACK_FACTOR = 0.70
 RELATED_GENRE_LIMIT = 24
 
@@ -210,7 +211,7 @@ def get_genre_detail(slug: str, *, include_global_entities: bool = True) -> dict
                 ),
                 {
                     "genre_id": genre["id"],
-                    "min_membership_score": MIN_GENRE_MEMBERSHIP_SCORE,
+                    "min_membership_score": MIN_ARTIST_ROOM_MEMBERSHIP_SCORE,
                 },
             )
             .mappings()

--- a/app/crate/db/queries/global_catalog.py
+++ b/app/crate/db/queries/global_catalog.py
@@ -294,6 +294,7 @@ def list_global_catalog_genres() -> list[dict]:
                             membership.global_genre_uid,
                             membership.global_genre_uid AS direct_genre_uid
                         FROM global_catalog_entity_genres membership
+                        WHERE membership.aggregate_score >= 0.700
                         UNION
                         SELECT
                             inherited.entity_type,
@@ -448,6 +449,7 @@ _GLOBAL_GENRE_ARTISTS_SQL = text(
             membership.supporting_source_count
         FROM global_catalog_entity_genres membership
         WHERE membership.entity_type = 'artist'
+          AND membership.aggregate_score >= 0.700
         UNION
         SELECT
             inherited.entity_type,
@@ -518,6 +520,7 @@ _GLOBAL_GENRE_ALBUMS_SQL = text(
             membership.supporting_source_count
         FROM global_catalog_entity_genres membership
         WHERE membership.entity_type = 'album'
+          AND membership.aggregate_score >= 0.700
         UNION
         SELECT
             inherited.entity_type,
@@ -581,6 +584,7 @@ _GLOBAL_GENRE_RELATED_SQL = text(
             membership.global_genre_uid
         FROM global_catalog_entity_genres membership
         WHERE membership.entity_type IN ('artist', 'album')
+          AND membership.aggregate_score >= 0.700
         UNION
         SELECT
             inherited.entity_type,

--- a/app/crate/db/repositories/genres_taxonomy_nodes.py
+++ b/app/crate/db/repositories/genres_taxonomy_nodes.py
@@ -192,11 +192,15 @@ def upsert_genre_taxonomy_node(
         session.execute(
             text(
                 """
-                INSERT INTO genre_taxonomy_aliases (alias_slug, alias_name, genre_id)
-                VALUES (:alias_slug, :alias_name, :genre_id)
+                INSERT INTO genre_taxonomy_aliases (
+                    alias_slug, alias_name, genre_id, origin, confidence
+                )
+                VALUES (:alias_slug, :alias_name, :genre_id, 'manual', 1.0)
                 ON CONFLICT (alias_slug) DO UPDATE
                 SET alias_name = EXCLUDED.alias_name,
-                    genre_id = EXCLUDED.genre_id
+                    genre_id = EXCLUDED.genre_id,
+                    origin = 'manual',
+                    confidence = 1.0
                 """
             ),
             {"alias_slug": alias_slug, "alias_name": alias_name, "genre_id": row["id"]},

--- a/app/crate/db/schema_sections/library_genres.py
+++ b/app/crate/db/schema_sections/library_genres.py
@@ -67,8 +67,22 @@ def create_library_genres_schema(cur) -> None:
         CREATE TABLE IF NOT EXISTS genre_taxonomy_aliases (
             alias_slug TEXT PRIMARY KEY,
             alias_name TEXT UNIQUE NOT NULL,
-            genre_id INTEGER NOT NULL REFERENCES genre_taxonomy_nodes(id) ON DELETE CASCADE
+            genre_id INTEGER NOT NULL REFERENCES genre_taxonomy_nodes(id) ON DELETE CASCADE,
+            origin TEXT NOT NULL DEFAULT 'legacy',
+            confidence DOUBLE PRECISION,
+            CONSTRAINT genre_taxonomy_aliases_origin_check
+                CHECK (origin IN ('core', 'manual', 'inferred', 'legacy')),
+            CONSTRAINT genre_taxonomy_aliases_confidence_check
+                CHECK (confidence IS NULL OR (confidence >= 0 AND confidence <= 1))
         )
+    """)
+    cur.execute("""
+        ALTER TABLE genre_taxonomy_aliases
+        ADD COLUMN IF NOT EXISTS origin TEXT NOT NULL DEFAULT 'legacy'
+    """)
+    cur.execute("""
+        ALTER TABLE genre_taxonomy_aliases
+        ADD COLUMN IF NOT EXISTS confidence DOUBLE PRECISION
     """)
     cur.execute("""
         CREATE TABLE IF NOT EXISTS genre_taxonomy_edges (
@@ -105,6 +119,9 @@ def create_library_genres_schema(cur) -> None:
     )
     cur.execute(
         "CREATE INDEX IF NOT EXISTS idx_genre_taxonomy_alias_genre_id ON genre_taxonomy_aliases(genre_id)"
+    )
+    cur.execute(
+        "CREATE INDEX IF NOT EXISTS idx_genre_taxonomy_aliases_origin ON genre_taxonomy_aliases(origin)"
     )
     cur.execute(
         "CREATE INDEX IF NOT EXISTS idx_genre_taxonomy_edges_source ON genre_taxonomy_edges(source_genre_id)"

--- a/app/crate/federation/global_matching.py
+++ b/app/crate/federation/global_matching.py
@@ -11,11 +11,15 @@ AUTO_MERGE_THRESHOLD = 0.90
 CANDIDATE_THRESHOLD = 0.85
 
 _FEAT_SUFFIX_RE = re.compile(
-    r"\s*[\(\[]?\s*(?:feat|ft|featuring)\.?\s+.+?[\)\]]?\s*$",
+    r"(?:\s+|\s*[\(\[]\s*)(?:feat|ft|featuring)\.?\s+.+?[\)\]]?\s*$",
     re.IGNORECASE,
 )
-_EDITION_SUFFIX_RE = re.compile(
-    r"\s*[\(\[]?\s*(?:deluxe|expanded|remaster(?:ed)?|anniversary|special|bonus|limited|live)(?:\s+(?:edition|version|remaster))?.*?[\)\]]?\s*$",
+_BRACKETED_EDITION_SUFFIX_RE = re.compile(
+    r"\s*[\(\[]\s*(?:deluxe|expanded|remaster(?:ed)?|anniversary|special|bonus|limited)\b[^\)\]]*[\)\]]\s*$",
+    re.IGNORECASE,
+)
+_UNBRACKETED_EDITION_SUFFIX_RE = re.compile(
+    r"\s+(?:deluxe|expanded|remaster(?:ed)?|anniversary|special|bonus|limited)(?:\s+(?:edition|version|remaster))?\s*$",
     re.IGNORECASE,
 )
 _PUNCT_RE = re.compile(r"[^a-z0-9]+")
@@ -36,7 +40,8 @@ def normalize_name(value: Any, *, strip_edition: bool = False) -> str:
 
     text = _FEAT_SUFFIX_RE.sub("", text)
     if strip_edition:
-        text = _EDITION_SUFFIX_RE.sub("", text)
+        text = _BRACKETED_EDITION_SUFFIX_RE.sub("", text)
+        text = _UNBRACKETED_EDITION_SUFFIX_RE.sub("", text)
     text = text.replace("&", " and ")
     text = unicodedata.normalize("NFKD", text)
     text = text.encode("ascii", "ignore").decode("ascii")

--- a/app/crate/federation/global_reconciliation.py
+++ b/app/crate/federation/global_reconciliation.py
@@ -1,8 +1,12 @@
 """Compatibility facade for global catalog reconciliation jobs."""
 
 from crate.db.jobs.global_catalog_reconciliation import (
+    begin_global_catalog_reconciliation_run,
+    complete_global_catalog_reconciliation_run,
+    fail_global_catalog_reconciliation_run,
     prune_local_catalog_sources_batch,
     prune_remote_catalog_sources_batch,
+    record_global_catalog_reconciliation_batch,
     reconcile_dirty_catalog_sources,
     reconcile_local_catalog,
     reconcile_local_catalog_batch,
@@ -13,8 +17,12 @@ from crate.db.jobs.global_catalog_reconciliation import (
 )
 
 __all__ = [
+    "begin_global_catalog_reconciliation_run",
+    "complete_global_catalog_reconciliation_run",
+    "fail_global_catalog_reconciliation_run",
     "prune_local_catalog_sources_batch",
     "prune_remote_catalog_sources_batch",
+    "record_global_catalog_reconciliation_batch",
     "reconcile_dirty_catalog_sources",
     "reconcile_local_catalog",
     "reconcile_local_catalog_batch",

--- a/app/crate/genre_taxonomy.py
+++ b/app/crate/genre_taxonomy.py
@@ -1489,9 +1489,9 @@ def seed_genre_taxonomy(session) -> None:
     """Upsert the static genre definitions into the taxonomy tables.
 
     Tables must already exist (created by _create_schema / migrations).
-    This is safe to run on every boot — it only inserts or updates rows
-    that diverge from the Python definitions and never touches
-    user-created or externally-enriched data.
+    This is safe to run on every boot: it refreshes core definitions and
+    removes only pre-provenance aliases that cannot be trusted. Classified
+    manual and inferred aliases are preserved.
     """
     from crate.db.jobs.genre_taxonomy import seed_genre_taxonomy_definitions
 

--- a/app/crate/genre_taxonomy_inference.py
+++ b/app/crate/genre_taxonomy_inference.py
@@ -25,6 +25,7 @@ from crate.genre_taxonomy import (
 log = logging.getLogger(__name__)
 
 _TOKEN_RE = re.compile(r"[a-z0-9]+")
+_AUTO_APPLY_ALIAS_CONFIDENCE = 0.90
 
 
 @dataclass
@@ -259,6 +260,18 @@ def infer_canonical_genre(
                 }
 
     return None
+
+
+def _should_auto_apply_alias(proposal: dict | None) -> bool:
+    if not proposal or not proposal.get("canonical_slug"):
+        return False
+    try:
+        confidence = float(proposal.get("confidence") or 0.0)
+    except (TypeError, ValueError):
+        return False
+    return confidence >= _AUTO_APPLY_ALIAS_CONFIDENCE and str(
+        proposal.get("mode") or ""
+    ) in {"direct", "specific"}
 
 
 def _list_unmapped_genres(limit: int, focus_slug: str | None = None) -> list[dict]:
@@ -524,7 +537,13 @@ def infer_genre_taxonomy_batch(
             confidence = proposal.get("confidence")
             mode = proposal.get("mode")
             reason = proposal.get("reason")
-            applied = assign_genre_alias_value(genre_name, canonical_slug)
+            if _should_auto_apply_alias(proposal):
+                applied = assign_genre_alias_value(
+                    genre_name,
+                    canonical_slug,
+                    origin="inferred",
+                    confidence=float(confidence or 0.0),
+                )
 
         if applied:
             mapped += 1

--- a/app/crate/worker_handlers/enrichment.py
+++ b/app/crate/worker_handlers/enrichment.py
@@ -65,6 +65,7 @@ def _unmark_processing(artist_name: str):
 
 def _invalidate_artist_top_tracks_cache(artist_name: str) -> None:
     delete_cache_prefix(f"listen:artist_top_tracks:v1:{artist_name.strip().lower()}:")
+    delete_cache_prefix(f"listen:artist_top_tracks:v2:{artist_name.strip().lower()}:")
 
 
 def _clean_album_lookup_name(album_name: str) -> str:

--- a/app/crate/worker_handlers/global_catalog.py
+++ b/app/crate/worker_handlers/global_catalog.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 from datetime import datetime, timezone
 
 from crate.db.repositories.global_catalog_state import (
@@ -21,14 +22,20 @@ from crate.db.repositories.global_user_library import (
 )
 from crate.federation.global_genres import refresh_global_catalog_genre_snapshots
 from crate.federation.global_reconciliation import (
+    begin_global_catalog_reconciliation_run,
+    complete_global_catalog_reconciliation_run,
+    fail_global_catalog_reconciliation_run,
     prune_local_catalog_sources_batch,
     prune_remote_catalog_sources_batch,
+    record_global_catalog_reconciliation_batch,
     reconcile_dirty_catalog_sources,
     reconcile_local_catalog_batch,
     reconcile_remote_catalog_batch,
 )
 from crate.task_dedup_keys import GLOBAL_CATALOG_FULL_DEDUP_KEY
 from crate.worker_handlers import TaskHandler
+
+log = logging.getLogger(__name__)
 
 DEFAULT_BATCH_SIZE = 500
 MAX_BATCH_SIZE = 5000
@@ -58,18 +65,23 @@ def _handle_reconcile_incremental(task_id: str, params: dict, config: dict) -> d
 def _handle_reconcile_full(task_id: str, params: dict, config: dict) -> dict:
     batch_size = _batch_size(params)
     state = get_catalog_state()
-    if state["status"] != "backfilling":
-        transition_catalog_state("backfilling")
     bootstrap = state.get("bootstrap_cursor_json")
     bootstrap = bootstrap if isinstance(bootstrap, dict) else {}
+    run_id = str(bootstrap.get("run_id") or "")
     phase = str(bootstrap.get("phase") or "local")
     cursor = bootstrap.get("cursor")
     try:
+        if state["status"] != "backfilling":
+            transition_catalog_state("backfilling")
+        if not run_id:
+            run_id = begin_global_catalog_reconciliation_run(mode="full")
         if phase == "local":
             batch = reconcile_local_catalog_batch(
                 batch_size=batch_size,
                 cursor=cursor if isinstance(cursor, dict) else None,
+                recompute_matches=True,
             )
+            record_global_catalog_reconciliation_batch(run_id, batch)
             return _continue_full_reconciliation(
                 task_id,
                 params,
@@ -77,6 +89,7 @@ def _handle_reconcile_full(task_id: str, params: dict, config: dict) -> dict:
                 next_phase="local_prune" if batch["completed"] else "local",
                 result=batch,
                 batch_size=batch_size,
+                run_id=run_id,
             )
         if phase == "local_prune":
             batch = prune_local_catalog_sources_batch(
@@ -90,12 +103,15 @@ def _handle_reconcile_full(task_id: str, params: dict, config: dict) -> dict:
                 next_phase="remote" if batch["completed"] else "local_prune",
                 result=batch,
                 batch_size=batch_size,
+                run_id=run_id,
             )
         if phase == "remote":
             batch = reconcile_remote_catalog_batch(
                 batch_size=batch_size,
                 cursor=cursor if isinstance(cursor, dict) else None,
+                recompute_matches=True,
             )
+            record_global_catalog_reconciliation_batch(run_id, batch)
             return _continue_full_reconciliation(
                 task_id,
                 params,
@@ -103,6 +119,7 @@ def _handle_reconcile_full(task_id: str, params: dict, config: dict) -> dict:
                 next_phase="remote_prune" if batch["completed"] else "remote",
                 result=batch,
                 batch_size=batch_size,
+                run_id=run_id,
             )
         if phase == "remote_prune":
             batch = prune_remote_catalog_sources_batch(
@@ -113,9 +130,38 @@ def _handle_reconcile_full(task_id: str, params: dict, config: dict) -> dict:
                 task_id,
                 params,
                 current_phase="remote_prune",
-                next_phase="user_refs" if batch["completed"] else "remote_prune",
+                next_phase="local_refresh" if batch["completed"] else "remote_prune",
                 result=batch,
                 batch_size=batch_size,
+                run_id=run_id,
+            )
+        if phase == "local_refresh":
+            batch = reconcile_local_catalog_batch(
+                batch_size=batch_size,
+                cursor=cursor if isinstance(cursor, dict) else None,
+            )
+            return _continue_full_reconciliation(
+                task_id,
+                params,
+                current_phase="local_refresh",
+                next_phase="remote_refresh" if batch["completed"] else "local_refresh",
+                result=batch,
+                batch_size=batch_size,
+                run_id=run_id,
+            )
+        if phase == "remote_refresh":
+            batch = reconcile_remote_catalog_batch(
+                batch_size=batch_size,
+                cursor=cursor if isinstance(cursor, dict) else None,
+            )
+            return _continue_full_reconciliation(
+                task_id,
+                params,
+                current_phase="remote_refresh",
+                next_phase="user_refs" if batch["completed"] else "remote_refresh",
+                result=batch,
+                batch_size=batch_size,
+                run_id=run_id,
             )
         if phase == "user_refs":
             report = bootstrap.get("user_refs_report")
@@ -138,12 +184,14 @@ def _handle_reconcile_full(task_id: str, params: dict, config: dict) -> dict:
                     "phase": "search_documents",
                     "cursor": None,
                     "user_refs_report": finalized_report,
+                    "run_id": run_id,
                 }
             else:
                 next_cursor_json = {
                     "phase": "user_refs",
                     "cursor": user_refs["next_cursor"],
                     "user_refs_report": report,
+                    "run_id": run_id,
                 }
             transition_catalog_state(
                 "backfilling",
@@ -178,6 +226,7 @@ def _handle_reconcile_full(task_id: str, params: dict, config: dict) -> dict:
                 bootstrap_cursor_json={
                     "phase": next_phase,
                     "cursor": search_documents.get("next_cursor"),
+                    "run_id": run_id,
                 },
             )
             continuation_task_id = _queue_full_reconciliation_continuation(
@@ -195,9 +244,18 @@ def _handle_reconcile_full(task_id: str, params: dict, config: dict) -> dict:
             raise ValueError(f"Unsupported catalog reconciliation phase: {phase}")
         refresh_global_catalog_genre_snapshots()
     except Exception as exc:
+        if run_id:
+            try:
+                fail_global_catalog_reconciliation_run(run_id, str(exc))
+            except Exception:
+                log.exception(
+                    "Failed to persist full catalog reconciliation failure",
+                    extra={"run_id": run_id},
+                )
         transition_catalog_state("failed", last_error=str(exc)[:4000])
         raise
 
+    complete_global_catalog_reconciliation_run(run_id)
     completed_at = datetime.now(timezone.utc).isoformat()
     transition_catalog_state(
         "ready",
@@ -227,11 +285,16 @@ def _continue_full_reconciliation(
     next_phase: str,
     result: dict,
     batch_size: int,
+    run_id: str,
 ) -> dict:
     next_cursor = result.get("next_cursor") if next_phase == current_phase else None
     transition_catalog_state(
         "backfilling",
-        bootstrap_cursor_json={"phase": next_phase, "cursor": next_cursor},
+        bootstrap_cursor_json={
+            "phase": next_phase,
+            "cursor": next_cursor,
+            "run_id": run_id,
+        },
     )
     continuation_task_id = _queue_full_reconciliation_continuation(
         task_id, params, batch_size

--- a/app/readplane/internal/catalog/genre.go
+++ b/app/readplane/internal/catalog/genre.go
@@ -12,9 +12,10 @@ import (
 )
 
 const (
-	minGenreMembershipScore  = 0.45
-	artistAlbumFallbackScore = 0.70
-	relatedGenreLimit        = 24
+	minGenreMembershipScore      = 0.45
+	minArtistRoomMembershipScore = 0.70
+	artistAlbumFallbackScore     = 0.70
+	relatedGenreLimit            = 24
 )
 
 var genreRelationLabels = map[string]string{
@@ -49,7 +50,7 @@ func genreMembershipTier(score float64) string {
 }
 
 func visibleGenreMembership(score float64) bool {
-	return score >= minGenreMembershipScore
+	return score >= minArtistRoomMembershipScore
 }
 
 func annotateGenreMembershipRows(rows []map[string]any) {

--- a/app/readplane/internal/catalog/genre_membership_test.go
+++ b/app/readplane/internal/catalog/genre_membership_test.go
@@ -15,7 +15,7 @@ func TestGenreMembershipTier(t *testing.T) {
 	}{
 		{name: "core", score: 0.90, tier: "core", visible: true},
 		{name: "strong", score: 0.70, tier: "strong", visible: true},
-		{name: "adjacent", score: 0.45, tier: "adjacent", visible: true},
+		{name: "adjacent", score: 0.45, tier: "adjacent", visible: false},
 		{name: "weak", score: 0.44, tier: "weak", visible: false},
 	}
 

--- a/app/readplane/internal/catalog/store.go
+++ b/app/readplane/internal/catalog/store.go
@@ -743,7 +743,7 @@ func (s *Store) GenreDetail(ctx context.Context, slug string, userID int64) (map
 			la.spotify_popularity DESC NULLS LAST,
 			la.album_count DESC NULLS LAST,
 			ag.artist_name ASC
-	`, genreID, minGenreMembershipScore))
+	`, genreID, minArtistRoomMembershipScore))
 	if err != nil {
 		return nil, err
 	}

--- a/app/tests/test_admin_global_catalog.py
+++ b/app/tests/test_admin_global_catalog.py
@@ -65,6 +65,90 @@ def test_admin_global_catalog_status_reports_serving_mode(monkeypatch):
     assert status["serving_mode"] == "local-fallback"
 
 
+def test_admin_status_counts_only_non_merged_matches_as_ambiguous(monkeypatch):
+    from crate.db.queries import admin_global_catalog
+
+    executed_sql: list[str] = []
+
+    class _Session:
+        def __init__(self):
+            self.results = iter(
+                [
+                    _QueryResult(row=None),
+                    _QueryResult(scalar_value=0),
+                    _QueryResult(scalar_value=7),
+                    _QueryResult(
+                        row={
+                            "active_assertions": 0,
+                            "unmapped_assertions": 0,
+                            "memberships": 0,
+                        }
+                    ),
+                ]
+            )
+
+        def execute(self, statement, *_args, **_kwargs):
+            executed_sql.append(str(statement))
+            return next(self.results)
+
+    @contextmanager
+    def fake_read_scope():
+        yield _Session()
+
+    monkeypatch.setattr(admin_global_catalog, "get_global_catalog_counts", lambda: {})
+    monkeypatch.setattr(
+        admin_global_catalog.global_catalog_state,
+        "get_catalog_state",
+        lambda: {"status": "ready", "last_full_reconcile_at": "2026-07-25"},
+    )
+    monkeypatch.setattr(
+        admin_global_catalog,
+        "get_core_taxonomy_descriptor",
+        lambda: {"taxonomy_id": "crate-core", "version": "1", "digest": "x"},
+    )
+    monkeypatch.setattr(admin_global_catalog, "read_scope", fake_read_scope)
+
+    status = admin_global_catalog.get_global_catalog_admin_status()
+
+    ambiguity_query = next(
+        query for query in executed_sql if "match_confidence" in query
+    )
+    assert "match_confidence < 0.900" in ambiguity_query
+    assert "source_deleted_at IS NULL" in ambiguity_query
+    assert "NOT source_stale" in ambiguity_query
+    assert status["ambiguous_candidate_count"] == 7
+
+
+def test_duplicate_candidates_exclude_sources_already_on_same_canonical(monkeypatch):
+    from crate.db.queries import admin_global_catalog
+
+    executed_sql: list[str] = []
+
+    class _Rows:
+        def mappings(self):
+            return self
+
+        def all(self):
+            return []
+
+    class _Session:
+        def execute(self, statement, *_args, **_kwargs):
+            executed_sql.append(str(statement))
+            return _Rows()
+
+    @contextmanager
+    def fake_read_scope():
+        yield _Session()
+
+    monkeypatch.setattr(admin_global_catalog, "read_scope", fake_read_scope)
+
+    assert admin_global_catalog.list_global_catalog_duplicate_candidates() == []
+    query = executed_sql[0]
+    assert "COUNT(DISTINCT global_entity_uid) > 1" in query
+    assert "source_deleted_at IS NULL" in query
+    assert "NOT source_stale" in query
+
+
 def test_admin_global_catalog_status_endpoint(test_app):
     with patch(
         "crate.api.admin_global_catalog.get_global_catalog_admin_status",

--- a/app/tests/test_artist_interactive_read_path.py
+++ b/app/tests/test_artist_interactive_read_path.py
@@ -51,8 +51,16 @@ def test_artist_top_tracks_use_persisted_local_ranking_when_cache_misses(
     from crate.api import browse_artist
 
     persisted_tracks = [
-        _local_track(track_id=1, title="Persisted Top Track"),
-        _local_track(track_id=2, title="Persisted Second Track"),
+        {
+            **_local_track(track_id=1, title="Persisted Top Track"),
+            "lastfm_top_rank": 2,
+            "lastfm_playcount": 100,
+        },
+        {
+            **_local_track(track_id=2, title="Persisted Second Track"),
+            "lastfm_top_rank": 1,
+            "lastfm_playcount": 200,
+        },
     ]
     monkeypatch.setattr(browse_artist, "get_cache", lambda *_args, **_kwargs: None)
     monkeypatch.setattr(browse_artist, "set_cache", lambda *_args, **_kwargs: None)

--- a/app/tests/test_browse_artist_api.py
+++ b/app/tests/test_browse_artist_api.py
@@ -4,6 +4,116 @@ from fastapi import Response
 from fastapi.responses import JSONResponse
 
 
+def _top_track_row(**overrides):
+    row = {
+        "id": 1,
+        "title": "Track",
+        "artist": "Example Artist",
+        "artist_id": 10,
+        "artist_slug": "example-artist",
+        "album": "Album",
+        "album_id": 20,
+        "album_slug": "album",
+        "duration": 180,
+        "track_number": 1,
+        "format": "FLAC",
+    }
+    row.update(overrides)
+    return row
+
+
+def test_top_tracks_fall_back_to_persisted_rank_signals_not_recent_album_order():
+    from crate.api.browse_artist import _build_artist_top_tracks_payload
+
+    rows = [
+        _top_track_row(
+            id=1,
+            title="Current Single",
+            year="2025",
+            track_number=1,
+            lastfm_top_rank=45,
+            lastfm_playcount=3_800_000,
+        ),
+        _top_track_row(
+            id=2,
+            title="Catalog Favorite",
+            year="2010",
+            track_number=8,
+            lastfm_top_rank=4,
+            lastfm_playcount=29_000_000,
+        ),
+        _top_track_row(
+            id=3,
+            title="Unranked Album Closer",
+            year="2025",
+            track_number=11,
+            lastfm_top_rank=None,
+            lastfm_playcount=None,
+        ),
+    ]
+
+    payload = _build_artist_top_tracks_payload(
+        "Example Artist",
+        count=10,
+        lastfm_top=None,
+        local_tracks=rows,
+    )
+
+    assert [track["title"] for track in payload] == [
+        "Catalog Favorite",
+        "Current Single",
+    ]
+
+
+def test_top_tracks_do_not_invent_rankings_without_track_level_signals():
+    from crate.api.browse_artist import _build_artist_top_tracks_payload
+
+    payload = _build_artist_top_tracks_payload(
+        "Example Artist",
+        count=10,
+        lastfm_top=None,
+        local_tracks=[
+            _top_track_row(
+                id=1,
+                title="Album Track",
+                year="2025",
+                track_number=1,
+            )
+        ],
+    )
+
+    assert payload == []
+
+
+def test_top_tracks_use_persisted_composite_popularity_when_source_ranks_are_missing():
+    from crate.api.browse_artist import _build_artist_top_tracks_payload
+
+    payload = _build_artist_top_tracks_payload(
+        "Example Artist",
+        count=10,
+        lastfm_top=None,
+        local_tracks=[
+            _top_track_row(
+                id=1,
+                title="Lower Composite Score",
+                popularity_score=0.41,
+                popularity_confidence=0.8,
+            ),
+            _top_track_row(
+                id=2,
+                title="Higher Composite Score",
+                popularity_score=0.93,
+                popularity_confidence=0.9,
+            ),
+        ],
+    )
+
+    assert [track["title"] for track in payload] == [
+        "Higher Composite Score",
+        "Lower Composite Score",
+    ]
+
+
 def test_artist_page_by_slug_falls_back_to_remote_global_catalog(monkeypatch):
     from crate.api import catalog_artist_compat
 

--- a/app/tests/test_db.py
+++ b/app/tests/test_db.py
@@ -1217,6 +1217,86 @@ class TestGenreTaxonomyCleanup:
         assert second is not None
         assert first["entity_uid"] == second["entity_uid"]
 
+    def test_overlay_genre_taxonomy_aliases_are_persisted_as_manual(self, pg_db):
+        from crate.db.tx import read_scope
+
+        pg_db.upsert_genre_taxonomy_node("crank-wave", name="Crank Wave")
+
+        with read_scope() as session:
+            aliases = (
+                session.execute(
+                    text(
+                        """
+                        SELECT alias_slug, origin, confidence
+                        FROM genre_taxonomy_aliases
+                        WHERE genre_id = (
+                            SELECT id
+                            FROM genre_taxonomy_nodes
+                            WHERE slug = 'crank-wave'
+                        )
+                        ORDER BY alias_slug
+                        """
+                    )
+                )
+                .mappings()
+                .all()
+            )
+
+        assert aliases
+        assert {row["origin"] for row in aliases} == {"manual"}
+        assert {float(row["confidence"]) for row in aliases} == {1.0}
+
+    def test_taxonomy_seed_removes_unclassified_legacy_aliases_only(self, pg_db):
+        from crate.db.tx import read_scope, transaction_scope
+        from crate.genre_taxonomy import seed_genre_taxonomy
+
+        with transaction_scope() as session:
+            punk_id = session.execute(
+                text("SELECT id FROM genre_taxonomy_nodes WHERE slug = 'hardcore-punk'")
+            ).scalar_one()
+            session.execute(
+                text(
+                    """
+                    INSERT INTO genre_taxonomy_aliases (
+                        alias_slug, alias_name, genre_id, origin, confidence
+                    )
+                    VALUES
+                        ('country-code-jp', 'country code jp', :genre_id, 'legacy', NULL),
+                        ('curated-scene', 'curated scene', :genre_id, 'manual', 1.0)
+                    ON CONFLICT (alias_slug) DO UPDATE
+                    SET genre_id = EXCLUDED.genre_id,
+                        origin = EXCLUDED.origin,
+                        confidence = EXCLUDED.confidence
+                    """
+                ),
+                {"genre_id": punk_id},
+            )
+            seed_genre_taxonomy(session)
+
+        with read_scope() as session:
+            aliases = {
+                row["alias_slug"]: row["origin"]
+                for row in session.execute(
+                    text(
+                        """
+                        SELECT alias_slug, origin
+                        FROM genre_taxonomy_aliases
+                        WHERE alias_slug IN (
+                            'country-code-jp',
+                            'curated-scene',
+                            'hardcore'
+                        )
+                        """
+                    )
+                )
+                .mappings()
+                .all()
+            }
+
+        assert "country-code-jp" not in aliases
+        assert aliases["curated-scene"] == "manual"
+        assert aliases["hardcore"] == "core"
+
     def test_assign_genre_alias_is_noop_when_alias_already_points_to_same_canonical(
         self, pg_db
     ):

--- a/app/tests/test_deploy_release_commands.py
+++ b/app/tests/test_deploy_release_commands.py
@@ -158,13 +158,20 @@ def test_remote_backup_preserves_a_sealed_recovery_set() -> None:
     assert "return 0" in backup_body[backup_body.index(sealed_guard) :]
 
 
-def test_remote_verify_executes_inline_python_inside_the_api_container() -> None:
+def test_remote_verify_checks_internal_urls_inside_the_api_container() -> None:
     script = (ROOT / "scripts/deploy-remote.sh").read_text()
     verify_body = script[
         script.index("cmd_verify() {") : script.index("cmd_rollback() {")
     ]
 
-    assert verify_body.count("docker exec -i crate-api python - <<'PY'") == 2
+    assert (
+        'wait_for_container_http_url crate-api "http://127.0.0.1:8585/api/status"'
+        in verify_body
+    )
+    assert (
+        'wait_for_container_http_url crate-api "http://crate-readplane:8686/readyz"'
+        in verify_body
+    )
 
 
 def test_remote_verify_waits_for_public_routes_to_become_ready() -> None:
@@ -188,6 +195,17 @@ def test_health_wait_does_not_treat_running_before_health_init_as_ready() -> Non
 
     assert ".State.Health.Status" in wait_body
     assert "{{else}}{{.State.Running}}" not in wait_body
+
+
+def test_internal_api_checks_retry_with_exponential_backoff() -> None:
+    script = (ROOT / "scripts/deploy-remote.sh").read_text()
+    verify_body = script[
+        script.index("cmd_verify() {") : script.index("cmd_rollback() {")
+    ]
+
+    assert "wait_for_container_http_url" in verify_body
+    assert "retry_delay=$((retry_delay * 2))" in script
+    assert "DEPLOY_API_RETRY_MAX_SECONDS" in script
 
 
 def test_remote_state_rollback_restores_database_before_old_images() -> None:

--- a/app/tests/test_enrichment.py
+++ b/app/tests/test_enrichment.py
@@ -909,7 +909,10 @@ class TestArtistEnrichment:
 
         worker_enrichment._invalidate_artist_top_tracks_cache(" Birds In Row ")
 
-        assert prefixes == ["listen:artist_top_tracks:v1:birds in row:"]
+        assert prefixes == [
+            "listen:artist_top_tracks:v1:birds in row:",
+            "listen:artist_top_tracks:v2:birds in row:",
+        ]
 
 
 def test_download_artist_photo_queues_persistent_variants(monkeypatch, tmp_path):

--- a/app/tests/test_federation_migration_matrix.py
+++ b/app/tests/test_federation_migration_matrix.py
@@ -306,7 +306,7 @@ def _seed_063_legacy_state() -> dict[str, str]:
 
 
 def _assert_hardened_state(ids: dict[str, str]) -> None:
-    assert _scalar("SELECT version_num FROM alembic_version") == "076"
+    assert _scalar("SELECT version_num FROM alembic_version") == "077"
     assert (
         _scalar(
             "SELECT status FROM federation_local_keys WHERE node_uid = %s",
@@ -356,7 +356,7 @@ def test_empty_database_migrates_from_base_to_head(pg_db):
 
     _migrate("head")
 
-    assert _scalar("SELECT version_num FROM alembic_version") == "076"
+    assert _scalar("SELECT version_num FROM alembic_version") == "077"
     for table in (
         "federation_local_keys",
         "federation_catalog_changes",
@@ -378,7 +378,7 @@ def test_real_main_049_snapshot_upgrades_without_user_data_loss(pg_db):
 
     _migrate("head")
 
-    assert _scalar("SELECT version_num FROM alembic_version") == "076"
+    assert _scalar("SELECT version_num FROM alembic_version") == "077"
     assert _scalar("SELECT email FROM users WHERE id = %s", (ids["user_id"],)) == (
         "legacy@example.test"
     )

--- a/app/tests/test_genre_alias_provenance_migration.py
+++ b/app/tests/test_genre_alias_provenance_migration.py
@@ -1,0 +1,19 @@
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+MIGRATION = (
+    ROOT / "app/crate/db/migrations/versions/077_genre_alias_provenance.py"
+).read_text()
+
+
+def test_genre_alias_provenance_migration_is_revision_077() -> None:
+    assert 'revision = "077"' in MIGRATION
+    assert 'down_revision = "076"' in MIGRATION
+
+
+def test_genre_alias_provenance_is_bounded_and_reversible() -> None:
+    assert "origin IN ('core', 'manual', 'inferred', 'legacy')" in MIGRATION
+    assert "confidence >= 0 AND confidence <= 1" in MIGRATION
+    assert "DROP COLUMN IF EXISTS confidence" in MIGRATION
+    assert "DROP COLUMN IF EXISTS origin" in MIGRATION

--- a/app/tests/test_genre_taxonomy.py
+++ b/app/tests/test_genre_taxonomy.py
@@ -11,7 +11,10 @@ from crate.genre_taxonomy import (
     resolve_genre_eq_preset,
     summarize_taste_genres,
 )
-from crate.genre_taxonomy_inference import infer_canonical_genre
+from crate.genre_taxonomy_inference import (
+    _should_auto_apply_alias,
+    infer_canonical_genre,
+)
 
 
 def test_summarize_taste_genres_normalizes_aliases() -> None:
@@ -216,6 +219,29 @@ def test_infer_canonical_genre_falls_back_to_family_when_needed() -> None:
 
     assert proposal is not None
     assert proposal["canonical_slug"] in {"techno", "house", "electronic"}
+
+
+def test_taxonomy_inference_does_not_persist_weak_contextual_aliases() -> None:
+    assert (
+        _should_auto_apply_alias(
+            {
+                "canonical_slug": "punk",
+                "confidence": 0.82,
+                "mode": "family_fallback",
+            }
+        )
+        is False
+    )
+    assert (
+        _should_auto_apply_alias(
+            {
+                "canonical_slug": "doom-metal",
+                "confidence": 0.95,
+                "mode": "specific",
+            }
+        )
+        is True
+    )
 
 
 def test_infer_canonical_genre_prefers_specific_runtime_child_over_generic_family() -> (

--- a/app/tests/test_genres_queries.py
+++ b/app/tests/test_genres_queries.py
@@ -243,9 +243,7 @@ class TestGenresLibraryDetail:
         assert len(result["artists"]) >= 1
         assert result["artists"][0]["artist_name"] == "Detail Artist"
 
-    def test_get_genre_detail_includes_all_genre_artists_by_weight_then_popularity(
-        self, pg_db
-    ):
+    def test_get_genre_detail_excludes_weak_contextual_artist_tags(self, pg_db):
         from crate.db.queries.genres_library_detail import get_genre_detail
 
         self._setup_genre_library_data(pg_db)
@@ -253,7 +251,7 @@ class TestGenresLibraryDetail:
         pg_db.upsert_artist({"name": "Weak Detail Artist", "listeners": 9999999})
         pg_db.set_artist_genres(
             "Secondary Detail Artist",
-            [("experimental", 1.0, "test"), ("post-punk", 0.5, "test")],
+            [("experimental", 1.0, "test"), ("post-punk", 0.72, "test")],
         )
         pg_db.set_artist_genres(
             "Weak Detail Artist",
@@ -295,9 +293,9 @@ class TestGenresLibraryDetail:
             > result["artists"][1]["membership_score"]
         )
         assert result["artists"][0]["membership_tier"] == "core"
-        assert result["artists"][1]["membership_tier"] == "adjacent"
+        assert result["artists"][1]["membership_tier"] == "strong"
         album_names = [album["name"] for album in result["albums"]]
-        assert "Secondary Detail Album" not in album_names
+        assert "Secondary Detail Album" in album_names
         assert "Weak Detail Album" not in album_names
         assert result["artist_count"] == len(result["artists"])
         assert result["album_count"] == len(result["albums"])

--- a/app/tests/test_global_catalog_matching.py
+++ b/app/tests/test_global_catalog_matching.py
@@ -14,6 +14,24 @@ def test_normalize_name_is_case_punctuation_whitespace_and_feat_safe():
     assert normalize_name("Artist feat. Guest") == "artist"
     assert normalize_name("Artist (feat. Guest)") == "artist"
     assert normalize_name("Björk & The Sugarcubes") == "bjork and the sugarcubes"
+    assert normalize_name("DRIFT Episode 2 “ATOM”") == "drift episode 2 atom"
+
+
+def test_normalize_name_only_strips_explicit_edition_suffixes():
+    assert (
+        normalize_name(
+            "Live from Teatro Dal Verme, Milan, Italy. March 24th, 2005",
+            strip_edition=True,
+        )
+        == "live from teatro dal verme milan italy march 24th 2005"
+    )
+    assert normalize_name("Songs of Faith and Devotion Live", strip_edition=True) == (
+        "songs of faith and devotion live"
+    )
+    assert normalize_name("Toward the Within (Live)", strip_edition=True) == (
+        "toward the within live"
+    )
+    assert normalize_name("Pedals (Deluxe Edition)", strip_edition=True) == "pedals"
 
 
 def test_match_keys_are_deterministic_and_conservative():

--- a/app/tests/test_global_catalog_reconciliation.py
+++ b/app/tests/test_global_catalog_reconciliation.py
@@ -124,6 +124,208 @@ def test_reconcile_local_catalog_is_idempotent(pg_db):
     }
 
 
+def test_full_match_recompute_splits_sources_that_no_longer_match(pg_db):
+    from crate.db.tx import read_scope, transaction_scope
+    from crate.federation.global_reconciliation import (
+        reconcile_local_catalog,
+        reconcile_local_catalog_batch,
+    )
+
+    pg_db.upsert_artist(
+        {
+            "name": "Underworld",
+            "entity_uid": str(uuid.uuid4()),
+        }
+    )
+    album_ids = [
+        pg_db.upsert_album(
+            {
+                "artist": "Underworld",
+                "name": title,
+                "path": f"/music/Underworld/{title}",
+                "entity_uid": str(uuid.uuid4()),
+                "year": "2019",
+                "track_count": 5,
+            }
+        )
+        for title in ('DRIFT Episode 1 "DUST"', 'DRIFT Episode 2 "ATOM"')
+    ]
+    reconcile_local_catalog()
+
+    with read_scope() as session:
+        source_rows = (
+            session.execute(
+                text(
+                    """
+                    SELECT id, local_id, global_entity_uid::text AS global_entity_uid
+                    FROM global_catalog_sources
+                    WHERE entity_type = 'album'
+                      AND local_id = ANY(:album_ids)
+                    ORDER BY local_id
+                    """
+                ),
+                {"album_ids": album_ids},
+            )
+            .mappings()
+            .all()
+        )
+    assert len({row["global_entity_uid"] for row in source_rows}) == 2
+
+    with transaction_scope() as session:
+        session.execute(
+            text(
+                """
+                UPDATE global_catalog_sources
+                SET global_entity_uid = CAST(:wrong_uid AS uuid)
+                WHERE id = :source_id
+                """
+            ),
+            {
+                "wrong_uid": source_rows[0]["global_entity_uid"],
+                "source_id": source_rows[1]["id"],
+            },
+        )
+
+    cursor = None
+    while True:
+        batch = reconcile_local_catalog_batch(
+            batch_size=1,
+            cursor=cursor,
+            recompute_matches=True,
+        )
+        if batch["completed"]:
+            break
+        cursor = batch["next_cursor"]
+
+    with read_scope() as session:
+        repaired = (
+            session.execute(
+                text(
+                    """
+                    SELECT
+                        global_entity_uid::text AS global_entity_uid,
+                        match_key
+                    FROM global_catalog_sources
+                    WHERE entity_type = 'album'
+                      AND local_id = ANY(:album_ids)
+                    ORDER BY local_id
+                    """
+                ),
+                {"album_ids": album_ids},
+            )
+            .mappings()
+            .all()
+        )
+
+    assert len({row["global_entity_uid"] for row in repaired}) == 2
+    assert [row["match_key"] for row in repaired] == [
+        "album:underworld|drift episode 1 dust|2019",
+        "album:underworld|drift episode 2 atom|2019",
+    ]
+
+
+def test_full_match_recompute_splits_mixed_clusters_into_valid_subgroups(pg_db):
+    from crate.db.tx import read_scope, transaction_scope
+    from crate.federation.global_reconciliation import (
+        reconcile_local_catalog,
+        reconcile_local_catalog_batch,
+    )
+
+    pg_db.upsert_artist(
+        {
+            "name": "Dead Can Dance",
+            "entity_uid": str(uuid.uuid4()),
+        }
+    )
+    titles = [
+        "Live at the Acropolis",
+        "Live at the Acropolis (Deluxe Edition)",
+        "Live in Paris",
+        "Live in Paris (Deluxe Edition)",
+    ]
+    album_ids = [
+        pg_db.upsert_album(
+            {
+                "artist": "Dead Can Dance",
+                "name": title,
+                "path": f"/music/Dead Can Dance/{title}",
+                "entity_uid": str(uuid.uuid4()),
+                "year": "2021",
+                "track_count": 10,
+            }
+        )
+        for title in titles
+    ]
+    reconcile_local_catalog()
+
+    with read_scope() as session:
+        sources = (
+            session.execute(
+                text(
+                    """
+                    SELECT id, local_id, global_entity_uid::text AS global_entity_uid
+                    FROM global_catalog_sources
+                    WHERE entity_type = 'album'
+                      AND local_id = ANY(:album_ids)
+                    ORDER BY local_id
+                    """
+                ),
+                {"album_ids": album_ids},
+            )
+            .mappings()
+            .all()
+        )
+    wrong_uid = sources[0]["global_entity_uid"]
+    with transaction_scope() as session:
+        session.execute(
+            text(
+                """
+                UPDATE global_catalog_sources
+                SET global_entity_uid = CAST(:wrong_uid AS uuid)
+                WHERE id = ANY(:source_ids)
+                """
+            ),
+            {
+                "wrong_uid": wrong_uid,
+                "source_ids": [row["id"] for row in sources],
+            },
+        )
+
+    cursor = None
+    while True:
+        batch = reconcile_local_catalog_batch(
+            batch_size=1,
+            cursor=cursor,
+            recompute_matches=True,
+        )
+        if batch["completed"]:
+            break
+        cursor = batch["next_cursor"]
+
+    with read_scope() as session:
+        repaired = (
+            session.execute(
+                text(
+                    """
+                    SELECT local_id, global_entity_uid::text AS global_entity_uid
+                    FROM global_catalog_sources
+                    WHERE entity_type = 'album'
+                      AND local_id = ANY(:album_ids)
+                    ORDER BY local_id
+                    """
+                ),
+                {"album_ids": album_ids},
+            )
+            .mappings()
+            .all()
+        )
+
+    targets = {row["local_id"]: row["global_entity_uid"] for row in repaired}
+    assert targets[album_ids[0]] == targets[album_ids[1]]
+    assert targets[album_ids[2]] == targets[album_ids[3]]
+    assert targets[album_ids[0]] != targets[album_ids[2]]
+
+
 def test_local_album_resolves_artist_through_merged_local_source(pg_db):
     from crate.db.queries.global_catalog import get_global_catalog_counts
     from crate.db.tx import read_scope, transaction_scope
@@ -425,3 +627,90 @@ def test_reconcile_local_catalog_prefers_local_sources(pg_db):
         assert source["preferred_for_display"] is True
         assert source["preferred_for_artwork"] is True
         assert source["preferred_for_playback"] is True
+
+
+def test_full_reconciliation_run_lifecycle_persists_batch_totals(pg_db):
+    from crate.db.tx import read_scope
+    from crate.federation.global_reconciliation import (
+        begin_global_catalog_reconciliation_run,
+        complete_global_catalog_reconciliation_run,
+        record_global_catalog_reconciliation_batch,
+    )
+
+    run_id = begin_global_catalog_reconciliation_run(mode="full")
+    record_global_catalog_reconciliation_batch(
+        run_id,
+        {
+            "source_rows_seen": 500,
+            "sources_upserted": 498,
+            "canonical_created": 2,
+            "canonical_updated": 496,
+            "auto_merged": 7,
+            "ambiguous_candidates": 3,
+        },
+    )
+    complete_global_catalog_reconciliation_run(run_id)
+
+    with read_scope() as session:
+        run = (
+            session.execute(
+                text(
+                    """
+                    SELECT
+                        status,
+                        source_rows_seen,
+                        sources_upserted,
+                        canonical_created,
+                        canonical_updated,
+                        auto_merged,
+                        ambiguous_candidates,
+                        completed_at
+                    FROM global_catalog_reconciliation_runs
+                    WHERE run_id = CAST(:run_id AS uuid)
+                    """
+                ),
+                {"run_id": run_id},
+            )
+            .mappings()
+            .one()
+        )
+
+    assert run["status"] == "completed"
+    assert run["source_rows_seen"] == 500
+    assert run["sources_upserted"] == 498
+    assert run["canonical_created"] == 2
+    assert run["canonical_updated"] == 496
+    assert run["auto_merged"] == 7
+    assert run["ambiguous_candidates"] == 3
+    assert run["completed_at"] is not None
+
+
+def test_full_reconciliation_run_failure_is_persisted(pg_db):
+    from crate.db.tx import read_scope
+    from crate.federation.global_reconciliation import (
+        begin_global_catalog_reconciliation_run,
+        fail_global_catalog_reconciliation_run,
+    )
+
+    run_id = begin_global_catalog_reconciliation_run(mode="full")
+    fail_global_catalog_reconciliation_run(run_id, "projection failed")
+
+    with read_scope() as session:
+        run = (
+            session.execute(
+                text(
+                    """
+                    SELECT status, error, completed_at
+                    FROM global_catalog_reconciliation_runs
+                    WHERE run_id = CAST(:run_id AS uuid)
+                    """
+                ),
+                {"run_id": run_id},
+            )
+            .mappings()
+            .one()
+        )
+
+    assert run["status"] == "failed"
+    assert run["error"] == "projection failed"
+    assert run["completed_at"] is not None

--- a/app/tests/test_global_catalog_worker.py
+++ b/app/tests/test_global_catalog_worker.py
@@ -1,3 +1,26 @@
+def _stub_full_run_tracking(monkeypatch, global_catalog, *, run_id="run-1"):
+    monkeypatch.setattr(
+        global_catalog,
+        "begin_global_catalog_reconciliation_run",
+        lambda **_kwargs: run_id,
+    )
+    monkeypatch.setattr(
+        global_catalog,
+        "record_global_catalog_reconciliation_batch",
+        lambda *_args, **_kwargs: None,
+    )
+    monkeypatch.setattr(
+        global_catalog,
+        "complete_global_catalog_reconciliation_run",
+        lambda *_args, **_kwargs: None,
+    )
+    monkeypatch.setattr(
+        global_catalog,
+        "fail_global_catalog_reconciliation_run",
+        lambda *_args, **_kwargs: None,
+    )
+
+
 def test_incremental_worker_claims_only_dirty_catalog_sources(monkeypatch):
     from crate.worker_handlers import global_catalog
 
@@ -56,6 +79,7 @@ def test_incremental_worker_has_no_global_catalog_feature_gate(monkeypatch):
 def test_full_worker_advances_from_local_to_prune_without_scanning_remote(monkeypatch):
     from crate.worker_handlers import global_catalog
 
+    _stub_full_run_tracking(monkeypatch, global_catalog)
     calls: list[str] = []
     monkeypatch.setattr(
         global_catalog,
@@ -68,8 +92,9 @@ def test_full_worker_advances_from_local_to_prune_without_scanning_remote(monkey
     monkeypatch.setattr(
         global_catalog,
         "reconcile_local_catalog_batch",
-        lambda *, batch_size, cursor: (
+        lambda *, batch_size, cursor, recompute_matches: (
             calls.append(f"local:{batch_size}")
+            or calls.append(f"recompute:{recompute_matches}")
             or {"completed": True, "source_rows_seen": batch_size}
         ),
     )
@@ -77,7 +102,7 @@ def test_full_worker_advances_from_local_to_prune_without_scanning_remote(monkey
 
     result = global_catalog._handle_reconcile_full("task-1", {}, {})
 
-    assert calls == ["local:500"]
+    assert calls == ["local:500", "recompute:True"]
     assert result["status"] == "continued"
     assert result["phase"] == "local"
 
@@ -87,6 +112,7 @@ def test_full_worker_processes_one_bounded_batch_then_enqueues_continuation(
 ):
     from crate.worker_handlers import global_catalog
 
+    _stub_full_run_tracking(monkeypatch, global_catalog)
     transitions: list[tuple[str, dict]] = []
     continuations: list[dict] = []
     local_calls: list[dict | None] = []
@@ -103,8 +129,9 @@ def test_full_worker_processes_one_bounded_batch_then_enqueues_continuation(
     monkeypatch.setattr(
         global_catalog,
         "reconcile_local_catalog_batch",
-        lambda *, batch_size, cursor: (
+        lambda *, batch_size, cursor, recompute_matches: (
             local_calls.append(cursor)
+            or local_calls.append(recompute_matches)
             or {
                 "completed": False,
                 "next_cursor": {"entity_type": "artist", "after_id": batch_size},
@@ -124,7 +151,7 @@ def test_full_worker_processes_one_bounded_batch_then_enqueues_continuation(
 
     result = global_catalog._handle_reconcile_full("task-1", {"batch_size": 25}, {})
 
-    assert local_calls == [None]
+    assert local_calls == [None, True]
     assert result["status"] == "continued"
     assert result["completed"] is False
     assert result["phase"] == "local"
@@ -142,6 +169,7 @@ def test_full_worker_processes_one_bounded_batch_then_enqueues_continuation(
             "bootstrap_cursor_json": {
                 "phase": "local",
                 "cursor": {"entity_type": "artist", "after_id": 25},
+                "run_id": "run-1",
             }
         },
     )
@@ -150,6 +178,7 @@ def test_full_worker_processes_one_bounded_batch_then_enqueues_continuation(
 def test_full_worker_resumes_persisted_batches_before_marking_ready(monkeypatch):
     from crate.worker_handlers import global_catalog
 
+    _stub_full_run_tracking(monkeypatch, global_catalog)
     transitions: list[tuple[str, dict]] = []
     local_cursors: list[dict | None] = []
     monkeypatch.setattr(
@@ -160,6 +189,7 @@ def test_full_worker_resumes_persisted_batches_before_marking_ready(monkeypatch)
             "bootstrap_cursor_json": {
                 "phase": "local",
                 "cursor": {"entity_type": "artist", "after_id": 500},
+                "run_id": "run-1",
             },
         },
     )
@@ -171,8 +201,9 @@ def test_full_worker_resumes_persisted_batches_before_marking_ready(monkeypatch)
     monkeypatch.setattr(
         global_catalog,
         "reconcile_local_catalog_batch",
-        lambda *, batch_size, cursor: (
+        lambda *, batch_size, cursor, recompute_matches: (
             local_cursors.append(cursor)
+            or local_cursors.append(recompute_matches)
             or {"completed": True, "next_cursor": None, "source_rows_seen": 1}
         ),
     )
@@ -181,13 +212,17 @@ def test_full_worker_resumes_persisted_batches_before_marking_ready(monkeypatch)
     result = global_catalog._handle_reconcile_full("task-1", {}, {})
 
     assert result["status"] == "continued"
-    assert local_cursors == [{"entity_type": "artist", "after_id": 500}]
+    assert local_cursors == [
+        {"entity_type": "artist", "after_id": 500},
+        True,
+    ]
     assert transitions[-1] == (
         "backfilling",
         {
             "bootstrap_cursor_json": {
                 "phase": "local_prune",
                 "cursor": None,
+                "run_id": "run-1",
             }
         },
     )
@@ -196,6 +231,7 @@ def test_full_worker_resumes_persisted_batches_before_marking_ready(monkeypatch)
 def test_full_worker_resumes_a_checkpoint_after_a_previous_task_stops(monkeypatch):
     from crate.worker_handlers import global_catalog
 
+    _stub_full_run_tracking(monkeypatch, global_catalog)
     remote_cursors: list[dict | None] = []
     monkeypatch.setattr(
         global_catalog,
@@ -205,6 +241,7 @@ def test_full_worker_resumes_a_checkpoint_after_a_previous_task_stops(monkeypatc
             "bootstrap_cursor_json": {
                 "phase": "remote",
                 "cursor": {"entity_type": "artist", "after_id": 500},
+                "run_id": "run-1",
             },
         },
     )
@@ -218,8 +255,10 @@ def test_full_worker_resumes_a_checkpoint_after_a_previous_task_stops(monkeypatc
     monkeypatch.setattr(
         global_catalog,
         "reconcile_remote_catalog_batch",
-        lambda *, batch_size, cursor: (
-            remote_cursors.append(cursor) or {"completed": True, "source_rows_seen": 1}
+        lambda *, batch_size, cursor, recompute_matches: (
+            remote_cursors.append(cursor)
+            or remote_cursors.append(recompute_matches)
+            or {"completed": True, "source_rows_seen": 1}
         ),
     )
     monkeypatch.setattr(
@@ -231,12 +270,66 @@ def test_full_worker_resumes_a_checkpoint_after_a_previous_task_stops(monkeypatc
 
     assert result["status"] == "continued"
     assert result["phase"] == "remote"
-    assert remote_cursors == [{"entity_type": "artist", "after_id": 500}]
+    assert remote_cursors == [
+        {"entity_type": "artist", "after_id": 500},
+        True,
+    ]
+
+
+def test_full_worker_refreshes_canonical_payloads_after_match_recompute(monkeypatch):
+    from crate.worker_handlers import global_catalog
+
+    _stub_full_run_tracking(monkeypatch, global_catalog)
+    transitions: list[dict] = []
+    calls: list[dict] = []
+    monkeypatch.setattr(
+        global_catalog,
+        "get_catalog_state",
+        lambda: {
+            "status": "backfilling",
+            "bootstrap_cursor_json": {
+                "phase": "local_refresh",
+                "cursor": None,
+                "run_id": "run-1",
+            },
+        },
+    )
+    monkeypatch.setattr(
+        global_catalog,
+        "reconcile_local_catalog_batch",
+        lambda **kwargs: (
+            calls.append(kwargs)
+            or {
+                "completed": True,
+                "next_cursor": None,
+                "source_rows_seen": 5,
+            }
+        ),
+    )
+    monkeypatch.setattr(
+        global_catalog,
+        "transition_catalog_state",
+        lambda _status, **kwargs: transitions.append(
+            dict(kwargs["bootstrap_cursor_json"])
+        ),
+    )
+    monkeypatch.setattr(global_catalog, "create_task", lambda *_args, **_kwargs: "next")
+
+    result = global_catalog._handle_reconcile_full("task-refresh", {}, {})
+
+    assert calls == [{"batch_size": 500, "cursor": None}]
+    assert result["phase"] == "local_refresh"
+    assert transitions[-1] == {
+        "phase": "remote_refresh",
+        "cursor": None,
+        "run_id": "run-1",
+    }
 
 
 def test_full_worker_backfills_legacy_user_refs_before_catalog_is_ready(monkeypatch):
     from crate.worker_handlers import global_catalog
 
+    _stub_full_run_tracking(monkeypatch, global_catalog)
     calls: list[str] = []
     transitions: list[str] = []
     monkeypatch.setattr(
@@ -244,7 +337,11 @@ def test_full_worker_backfills_legacy_user_refs_before_catalog_is_ready(monkeypa
         "get_catalog_state",
         lambda: {
             "status": "backfilling",
-            "bootstrap_cursor_json": {"phase": "user_refs", "cursor": None},
+            "bootstrap_cursor_json": {
+                "phase": "user_refs",
+                "cursor": None,
+                "run_id": "run-1",
+            },
         },
     )
     monkeypatch.setattr(
@@ -289,6 +386,7 @@ def test_full_worker_backfills_legacy_user_refs_before_catalog_is_ready(monkeypa
 def test_full_worker_checkpoints_one_user_reference_batch(monkeypatch):
     from crate.worker_handlers import global_catalog
 
+    _stub_full_run_tracking(monkeypatch, global_catalog)
     transitions: list[tuple[str, dict]] = []
     monkeypatch.setattr(
         global_catalog,
@@ -300,6 +398,7 @@ def test_full_worker_checkpoints_one_user_reference_batch(monkeypatch):
                 "phase": "user_refs",
                 "cursor": 10,
                 "user_refs_report": {"artist_follows": 2},
+                "run_id": "run-1",
             },
         },
     )
@@ -356,6 +455,7 @@ def test_full_worker_checkpoints_one_user_reference_batch(monkeypatch):
                         "play_events": 0,
                         "listening_stats_users": 0,
                     },
+                    "run_id": "run-1",
                 }
             },
         )
@@ -365,13 +465,24 @@ def test_full_worker_checkpoints_one_user_reference_batch(monkeypatch):
 def test_full_worker_marks_catalog_ready_only_after_both_sources_finish(monkeypatch):
     from crate.worker_handlers import global_catalog
 
+    completed_runs: list[str] = []
+    _stub_full_run_tracking(monkeypatch, global_catalog)
+    monkeypatch.setattr(
+        global_catalog,
+        "complete_global_catalog_reconciliation_run",
+        lambda run_id: completed_runs.append(run_id),
+    )
     transitions: list[tuple[str, dict]] = []
     monkeypatch.setattr(
         global_catalog,
         "get_catalog_state",
         lambda: {
             "status": "backfilling",
-            "bootstrap_cursor_json": {"phase": "snapshots", "cursor": None},
+            "bootstrap_cursor_json": {
+                "phase": "snapshots",
+                "cursor": None,
+                "run_id": "run-1",
+            },
         },
     )
     monkeypatch.setattr(
@@ -387,6 +498,141 @@ def test_full_worker_marks_catalog_ready_only_after_both_sources_finish(monkeypa
     assert result["status"] == "completed"
     assert [status for status, _ in transitions] == ["ready"]
     assert "last_full_reconcile_at" in transitions[-1][1]
+    assert completed_runs == ["run-1"]
+
+
+def test_full_worker_starts_and_checkpoints_a_persisted_run(monkeypatch):
+    from crate.worker_handlers import global_catalog
+
+    started: list[str] = []
+    recorded: list[tuple[str, int]] = []
+    transitions: list[dict] = []
+    monkeypatch.setattr(
+        global_catalog,
+        "get_catalog_state",
+        lambda: {"status": "ready", "bootstrap_cursor_json": {}},
+    )
+    monkeypatch.setattr(
+        global_catalog,
+        "begin_global_catalog_reconciliation_run",
+        lambda **_kwargs: started.append("full") or "persisted-run",
+    )
+    monkeypatch.setattr(
+        global_catalog,
+        "record_global_catalog_reconciliation_batch",
+        lambda run_id, result: recorded.append(
+            (run_id, int(result["source_rows_seen"]))
+        ),
+    )
+    monkeypatch.setattr(
+        global_catalog,
+        "fail_global_catalog_reconciliation_run",
+        lambda *_args, **_kwargs: None,
+    )
+    monkeypatch.setattr(
+        global_catalog,
+        "transition_catalog_state",
+        lambda _status, **kwargs: transitions.append(
+            dict(kwargs.get("bootstrap_cursor_json") or {})
+        ),
+    )
+    monkeypatch.setattr(
+        global_catalog,
+        "reconcile_local_catalog_batch",
+        lambda **_kwargs: {
+            "completed": False,
+            "next_cursor": {"entity_type": "track", "after_id": 500},
+            "source_rows_seen": 500,
+        },
+    )
+    monkeypatch.setattr(global_catalog, "create_task", lambda *_args, **_kwargs: "next")
+
+    global_catalog._handle_reconcile_full("task-1", {}, {})
+
+    assert started == ["full"]
+    assert recorded == [("persisted-run", 500)]
+    assert transitions[-1] == {
+        "phase": "local",
+        "cursor": {"entity_type": "track", "after_id": 500},
+        "run_id": "persisted-run",
+    }
+
+
+def test_full_worker_marks_catalog_failed_when_run_tracking_cannot_start(monkeypatch):
+    from crate.worker_handlers import global_catalog
+
+    transitions: list[tuple[str, dict]] = []
+    monkeypatch.setattr(
+        global_catalog,
+        "get_catalog_state",
+        lambda: {"status": "ready", "bootstrap_cursor_json": {}},
+    )
+    monkeypatch.setattr(
+        global_catalog,
+        "begin_global_catalog_reconciliation_run",
+        lambda **_kwargs: (_ for _ in ()).throw(RuntimeError("run table unavailable")),
+    )
+    monkeypatch.setattr(
+        global_catalog,
+        "transition_catalog_state",
+        lambda status, **kwargs: transitions.append((status, kwargs)),
+    )
+
+    try:
+        global_catalog._handle_reconcile_full("task-1", {}, {})
+    except RuntimeError as exc:
+        assert str(exc) == "run table unavailable"
+    else:
+        raise AssertionError("run creation failure must abort reconciliation")
+
+    assert transitions[-1] == (
+        "failed",
+        {"last_error": "run table unavailable"},
+    )
+
+
+def test_full_worker_preserves_original_error_if_failure_tracking_also_fails(
+    monkeypatch,
+):
+    from crate.worker_handlers import global_catalog
+
+    _stub_full_run_tracking(monkeypatch, global_catalog)
+    monkeypatch.setattr(
+        global_catalog,
+        "get_catalog_state",
+        lambda: {
+            "status": "backfilling",
+            "bootstrap_cursor_json": {
+                "phase": "local",
+                "cursor": None,
+                "run_id": "run-1",
+            },
+        },
+    )
+    monkeypatch.setattr(
+        global_catalog,
+        "reconcile_local_catalog_batch",
+        lambda **_kwargs: (_ for _ in ()).throw(RuntimeError("source failure")),
+    )
+    monkeypatch.setattr(
+        global_catalog,
+        "fail_global_catalog_reconciliation_run",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            RuntimeError("run table failure")
+        ),
+    )
+    monkeypatch.setattr(
+        global_catalog,
+        "transition_catalog_state",
+        lambda *_args, **_kwargs: None,
+    )
+
+    try:
+        global_catalog._handle_reconcile_full("task-1", {}, {})
+    except RuntimeError as exc:
+        assert str(exc) == "source failure"
+    else:
+        raise AssertionError("source reconciliation failure must be preserved")
 
 
 def test_global_catalog_tasks_are_registered_in_worker():

--- a/app/tests/test_permissions.py
+++ b/app/tests/test_permissions.py
@@ -2492,11 +2492,15 @@ def test_album_enrich_rejects_regular_user():
 
 
 def test_artist_enrich_allows_metadata_editor_without_admin_access(monkeypatch):
+    import importlib
+
     from crate.api.browse_artist import api_artist_enrich
 
     queued: list[tuple[str, bool, str]] = []
+    content = importlib.import_module("crate.content")
     monkeypatch.setattr(
-        "crate.content.queue_process_new_content_if_needed",
+        content,
+        "queue_process_new_content_if_needed",
         lambda name, force, triggered_by: (
             queued.append((name, force, triggered_by)) or "task-artist"
         ),

--- a/app/tests/test_postgres_test_database.py
+++ b/app/tests/test_postgres_test_database.py
@@ -32,7 +32,7 @@ def test_pg_db_uses_an_isolated_clone_of_the_initialized_template(pg_db) -> None
 
     assert database_name != TEST_DB_NAME
     assert database_name.startswith(f"{TEST_DB_NAME}_case_")
-    assert revision == "076"
+    assert revision == "077"
     assert admin_count >= 1
     assert os.environ["CRATE_POSTGRES_DB"] == database_name
 

--- a/app/ui/src/pages/GlobalCatalog.test.tsx
+++ b/app/ui/src/pages/GlobalCatalog.test.tsx
@@ -77,6 +77,15 @@ describe("GlobalCatalog", () => {
       screen.getByRole("heading", { name: "Global Catalog" }),
     ).toBeInTheDocument();
     expect(screen.getByText("Artists")).toBeInTheDocument();
+    expect(screen.getByText("Entity sources")).toBeInTheDocument();
+    expect(
+      screen.getByText(/Unresolved match candidates:/),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "Similar sources below the automatic merge threshold; they remain separate until reviewed.",
+      ),
+    ).toBeInTheDocument();
     expect(screen.getByText("2")).toBeInTheDocument();
     expect(screen.getByText("Local fallback")).toBeInTheDocument();
     expect(

--- a/app/ui/src/pages/GlobalCatalog.tsx
+++ b/app/ui/src/pages/GlobalCatalog.tsx
@@ -219,7 +219,10 @@ export function GlobalCatalog() {
             <MetricCard label="Artists" value={formatNumber(counts?.artists)} />
             <MetricCard label="Albums" value={formatNumber(counts?.albums)} />
             <MetricCard label="Tracks" value={formatNumber(counts?.tracks)} />
-            <MetricCard label="Sources" value={formatNumber(counts?.sources)} />
+            <MetricCard
+              label="Entity sources"
+              value={formatNumber(counts?.sources)}
+            />
           </div>
 
           <div className="grid gap-4 lg:grid-cols-3">
@@ -254,8 +257,12 @@ export function GlobalCatalog() {
                   Stale peers: {formatNumber(status?.stale_peer_count)}
                 </p>
                 <p className="text-muted-foreground">
-                  Ambiguous candidates:{" "}
+                  Unresolved match candidates:{" "}
                   {formatNumber(status?.ambiguous_candidate_count)}
+                </p>
+                <p className="text-xs text-muted-foreground">
+                  Similar sources below the automatic merge threshold; they
+                  remain separate until reviewed.
                 </p>
               </CardContent>
             </Card>

--- a/scripts/deploy-remote.sh
+++ b/scripts/deploy-remote.sh
@@ -12,6 +12,7 @@ DEPLOY_IMAGE_WAIT_SECONDS="${DEPLOY_IMAGE_WAIT_SECONDS:-900}"
 DEPLOY_IMAGE_WAIT_INTERVAL="${DEPLOY_IMAGE_WAIT_INTERVAL:-20}"
 DEPLOY_HEALTH_WAIT_SECONDS="${DEPLOY_HEALTH_WAIT_SECONDS:-420}"
 DEPLOY_PUBLIC_WAIT_SECONDS="${DEPLOY_PUBLIC_WAIT_SECONDS:-120}"
+DEPLOY_API_RETRY_MAX_SECONDS="${DEPLOY_API_RETRY_MAX_SECONDS:-15}"
 DEPLOY_CONFIRM="${DEPLOY_CONFIRM:-}"
 CRATE_DEPLOY_PRUNE_UNUSED_IMAGES="${CRATE_DEPLOY_PRUNE_UNUSED_IMAGES:-1}"
 BACKUP_ROOT="${SERVER_PATH}/.deploy-backups"
@@ -282,6 +283,28 @@ wait_for_container_healthy() {
       return 1
     fi
     sleep 3
+  done
+}
+
+wait_for_container_http_url() {
+  local container="$1"
+  local url="$2"
+  local deadline=$((SECONDS + DEPLOY_HEALTH_WAIT_SECONDS))
+  local retry_delay=1
+
+  until docker exec "$container" python -c \
+    'import sys, urllib.request; response = urllib.request.urlopen(sys.argv[1], timeout=5); raise SystemExit(0 if response.status < 400 else 1)' \
+    "$url" >/dev/null 2>&1; do
+    if (( SECONDS >= deadline )); then
+      log "Container URL did not become ready: ${container} ${url}"
+      docker logs --tail=120 "$container" 2>/dev/null || true
+      return 1
+    fi
+    sleep "$retry_delay"
+    retry_delay=$((retry_delay * 2))
+    if (( retry_delay > DEPLOY_API_RETRY_MAX_SECONDS )); then
+      retry_delay="$DEPLOY_API_RETRY_MAX_SECONDS"
+    fi
   done
 }
 
@@ -636,23 +659,11 @@ cmd_verify() {
   done
 
   log "Checking API from inside the backend container"
-  docker exec -i crate-api python - <<'PY'
-import urllib.request
-
-with urllib.request.urlopen("http://127.0.0.1:8585/api/status", timeout=5) as response:
-    if response.status >= 400:
-        raise SystemExit(f"unexpected status {response.status}")
-PY
+  wait_for_container_http_url crate-api "http://127.0.0.1:8585/api/status"
 
   if compose_has_service crate-readplane; then
     log "Checking readplane readiness from inside the backend container"
-    docker exec -i crate-api python - <<'PY'
-import urllib.request
-
-with urllib.request.urlopen("http://crate-readplane:8686/readyz", timeout=5) as response:
-    if response.status >= 400:
-        raise SystemExit(f"unexpected status {response.status}")
-PY
+    wait_for_container_http_url crate-api "http://crate-readplane:8686/readyz"
   fi
 
   if [[ "$DEPLOY_PUBLIC_CHECKS" != "0" && -n "$domain" ]]; then


### PR DESCRIPTION
## Summary

Repairs the production regressions found after the federated catalog rollout:

- ranks artist top tracks from persisted Last.fm/Spotify/composite signals instead of recent album order
- fixes title normalization that collapsed `DRIFT` and `Live ...` releases
- revalidates existing multi-source canonicals during full rebuild and performs a second projection pass
- tracks full reconciliation runs across continuation tasks
- separates unresolved candidates from auto-merged sources in Admin
- raises visible artist genre membership to 0.70 while preserving album/show fallback behavior
- adds provenance to genre aliases, removes untrusted legacy inference, and limits automatic inference to high-confidence direct/specific matches
- retries internal deployment API checks with capped exponential backoff

## Production impact analysis

Read-only simulation against the current production source payloads inspected 7,386 sources across 3,564 multi-source canonicals. The corrected matcher projects 138 contaminated canonicals to split (8 album, 130 track), yielding 161 additional canonical components. This is a bounded correction of falsely merged editions, not source duplication.

The current taxonomy contains 1,247 aliases. Migration 077 classifies existing aliases as legacy; startup reseeds 87 shipped core aliases, preserves future/manual/inferred provenance, and removes the remaining untrusted legacy mappings that caused contextual tags such as `japanese` to resolve to `punk`.

## Verification

- 218 global catalog/admin tests
- 97 DB tests
- 41 genre query tests
- 15 worker/deploy tests plus focused ranking/enrichment tests
- full Go readplane suite
- Admin: 46 files / 135 Vitest tests, ESLint, TypeScript, production build
- Pyright, Ruff check/format, Prettier, bash syntax
- Alembic empty/063/head rollback-reupgrade matrix through revision 077

## Deployment plan

1. Merge only after all required checks pass and GHCR images exist for the merge SHA.
2. Deploy that immutable SHA using sealed recovery set `federation-0ee4d05-20260725T0638Z`.
3. Run full catalog rebuild and monitor persisted reconciliation run to completion.
4. Verify counts, duplicate candidates, top tracks, genre rooms, playback, stats, search, and public health.
5. Publish `v2.2.1-beta` only after production is green.

Full state rollback remains available with:

```sh
make deploy-rollback DEPLOY_ID=federation-0ee4d05-20260725T0638Z CONFIRM=restore-production
```