### PR TITLE
fix(listen): restore mobile playback and discovery

### DIFF
--- a/app/crate/db/queries/browse_artist_filters.py
+++ b/app/crate/db/queries/browse_artist_filters.py
@@ -5,7 +5,7 @@ from sqlalchemy import text
 from crate.db.tx import read_scope
 from crate.genre_taxonomy import resolve_genre_slug, slugify_genre
 
-MIN_GENRE_MEMBERSHIP_SCORE = 0.45
+MIN_GENRE_MEMBERSHIP_SCORE = 0.70
 
 
 def artist_decade_filter_sql(artist_alias: str) -> str:

--- a/app/listen/src/components/cards/AlbumCard.test.tsx
+++ b/app/listen/src/components/cards/AlbumCard.test.tsx
@@ -5,6 +5,19 @@ import { renderWithListenProviders } from "@/test/render-with-listen-providers";
 
 import { AlbumCard } from "./AlbumCard";
 
+const apiMocks = vi.hoisted(() => ({
+  resolveMaybeApiAssetUrl: vi.fn((url: string | null | undefined) =>
+    url?.startsWith("/api/")
+      ? `https://api.example.test${url}&token=native-token`
+      : url ?? null,
+  ),
+}));
+
+vi.mock("@/lib/api", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/lib/api")>()),
+  resolveMaybeApiAssetUrl: apiMocks.resolveMaybeApiAssetUrl,
+}));
+
 vi.mock("@/contexts/SavedAlbumsContext", () => ({
   useSavedAlbums: () => ({
     isSaved: () => false,
@@ -40,6 +53,25 @@ beforeEach(() => {
 });
 
 describe("AlbumCard", () => {
+  it("resolves API cover paths for configurable native servers", () => {
+    renderWithListenProviders(
+      <AlbumCard
+        artist="Hum"
+        album="Inlet"
+        globalAlbumUid="album-global-1"
+        cover="/api/catalog/albums/album-global-1/cover?size=256"
+      />,
+    );
+
+    expect(apiMocks.resolveMaybeApiAssetUrl).toHaveBeenCalledWith(
+      "/api/catalog/albums/album-global-1/cover?size=256",
+    );
+    expect(screen.getByAltText("Inlet")).toHaveAttribute(
+      "src",
+      "https://api.example.test/api/catalog/albums/album-global-1/cover?size=256&token=native-token",
+    );
+  });
+
   it("renders responsive WebP candidates for generated covers", () => {
     renderWithListenProviders(
       <AlbumCard artist="Hum" album="Inlet" albumId={42} layout="grid" />,

--- a/app/listen/src/components/cards/AlbumCard.tsx
+++ b/app/listen/src/components/cards/AlbumCard.tsx
@@ -16,7 +16,7 @@ import { useOffline } from "@/contexts/OfflineContext";
 import { usePlayerActions, type Track } from "@/contexts/PlayerContext";
 import { useSavedAlbums } from "@/contexts/SavedAlbumsContext";
 import { ActionIconButton } from "@crate/ui/primitives/ActionIconButton";
-import { api } from "@/lib/api";
+import { api, resolveMaybeApiAssetUrl } from "@/lib/api";
 import { getOfflineStateLabel, isOfflineBusy } from "@/lib/offline";
 import { toPlayableTrack } from "@/lib/playable-track";
 import { cn } from "@/lib/utils";
@@ -97,7 +97,7 @@ export const AlbumCard = memo(function AlbumCard({
     albumName: album,
   };
   const coverUrl =
-    cover ||
+    resolveMaybeApiAssetUrl(cover) ||
     albumCoverApiUrl(albumRouteInput, {
       size: layout === "grid" ? 320 : compact ? 192 : 256,
     });

--- a/app/listen/src/components/explore/ExploreViews.tsx
+++ b/app/listen/src/components/explore/ExploreViews.tsx
@@ -853,17 +853,11 @@ function buildGenreHeroArtistBackgroundFallback(
   artists?: GenreDetail["artists"],
 ) {
   if (!artists?.length) return null;
-  const topArtist = artists
-    .filter(
-      (artist) =>
-        (artist.artist_id != null || artist.global_artist_uid) &&
-        artist.has_photo,
-    )
-    .sort((a, b) => {
-      const aListeners = a.listeners ?? -1;
-      const bListeners = b.listeners ?? -1;
-      return bListeners - aListeners;
-    })[0];
+  const topArtist = artists.find(
+    (artist) =>
+      (artist.artist_id != null || artist.global_artist_uid) &&
+      artist.has_photo,
+  );
 
   if (!topArtist?.artist_id && !topArtist?.global_artist_uid) return null;
 

--- a/app/listen/src/contexts/PlayerContext.tsx
+++ b/app/listen/src/contexts/PlayerContext.tsx
@@ -551,12 +551,15 @@ export function PlayerProvider({ children }: { children: ReactNode }) {
       recoveryQueue.length,
     );
     const positionMs = Math.max(0, Math.round(currentTimeRef.current * 1000));
+    const nativePlayerActive = shouldUseAndroidNativePlayer();
     const engineTracks = await toStartupEngineTracks(
       recoveryQueue,
       recoveryIndex,
+      undefined,
+      nativePlayerActive ? { target: "android-native" } : undefined,
     );
 
-    if (shouldUseAndroidNativePlayer()) {
+    if (nativePlayerActive) {
       await androidNativeEngine.loadQueue({
         revision: createQueueRevision(),
         tracks: engineTracks,
@@ -673,7 +676,9 @@ export function PlayerProvider({ children }: { children: ReactNode }) {
       const nativePlayerActive = shouldUseAndroidNativePlayer();
       if (nativePlayerActive) {
         void (async () => {
-          const engineTracks = await toFreshEngineTracks(unique);
+          const engineTracks = await toFreshEngineTracks(unique, undefined, {
+            target: "android-native",
+          });
           return androidNativeEngine.appendTracks(engineTracks);
         })().catch((error) => {
           console.error(
@@ -724,7 +729,9 @@ export function PlayerProvider({ children }: { children: ReactNode }) {
       nextQueue.splice(insertionIndex, 0, marked);
       if (shouldUseAndroidNativePlayer()) {
         void (async () => {
-          const engineTrack = await toFreshEngineTrack(marked);
+          const engineTrack = await toFreshEngineTrack(marked, undefined, {
+            target: "android-native",
+          });
           return androidNativeEngine.insertTrack(insertionIndex, engineTrack);
         })().catch((error) => {
           console.error(
@@ -769,7 +776,9 @@ export function PlayerProvider({ children }: { children: ReactNode }) {
       const nativePlayerActive = shouldUseAndroidNativePlayer();
       if (nativePlayerActive) {
         void (async () => {
-          const engineTracks = await toFreshEngineTracks(unique);
+          const engineTracks = await toFreshEngineTracks(unique, undefined, {
+            target: "android-native",
+          });
           await androidNativeEngine.appendTracks(engineTracks);
           return androidNativeEngine.jumpTo(queue.length, true);
         })().catch((error) => {
@@ -861,7 +870,12 @@ export function PlayerProvider({ children }: { children: ReactNode }) {
         return false;
       }
 
-      const engineTracks = await toStartupEngineTracks(queueSnapshot, index);
+      const engineTracks = await toStartupEngineTracks(
+        queueSnapshot,
+        index,
+        undefined,
+        { target: "android-native" },
+      );
       await androidNativeEngine.loadQueue({
         revision: createQueueRevision(),
         tracks: engineTracks,
@@ -1022,7 +1036,12 @@ export function PlayerProvider({ children }: { children: ReactNode }) {
         if (!(await refreshAuthToken())) {
           throw new Error("Could not refresh the native playback token");
         }
-        const engineTracks = await toStartupEngineTracks(queueSnapshot, index);
+        const engineTracks = await toStartupEngineTracks(
+          queueSnapshot,
+          index,
+          undefined,
+          { target: "android-native" },
+        );
         await androidNativeEngine.loadQueue({
           revision: createQueueRevision(),
           tracks: engineTracks,

--- a/app/listen/src/contexts/player-engine-adapter.test.ts
+++ b/app/listen/src/contexts/player-engine-adapter.test.ts
@@ -1,10 +1,12 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const { apiMock, authState, ensureFreshAuthTokenMock } = vi.hoisted(() => ({
-  apiMock: vi.fn(),
-  authState: { token: "listen-token" },
-  ensureFreshAuthTokenMock: vi.fn(),
-}));
+const { apiMock, authState, ensureFreshAuthTokenMock, offlineUrlState } =
+  vi.hoisted(() => ({
+    apiMock: vi.fn(),
+    authState: { token: "listen-token" },
+    ensureFreshAuthTokenMock: vi.fn(),
+    offlineUrlState: { url: null as string | null },
+  }));
 
 vi.mock("@/lib/api", () => ({
   api: apiMock,
@@ -24,7 +26,7 @@ vi.mock("@/lib/capacitor-runtime", () => ({
 }));
 
 vi.mock("@/lib/offline", () => ({
-  getOfflineNativePlaybackUrl: () => null,
+  getOfflineNativePlaybackUrl: () => offlineUrlState.url,
 }));
 
 import {
@@ -40,6 +42,7 @@ describe("player engine adapter", () => {
     apiMock.mockReset();
     ensureFreshAuthTokenMock.mockReset();
     ensureFreshAuthTokenMock.mockResolvedValue(true);
+    offlineUrlState.url = null;
   });
 
   it("sends absolute authenticated artwork URLs to the native player", () => {
@@ -122,6 +125,27 @@ describe("player engine adapter", () => {
       "/api/catalog/tracks/global-track-1/stream",
     );
     expect(getPlaybackSession(sourceTrack)).toBe("signed-global-playback");
+  });
+
+  it("keeps an offline file URI instead of resolving global playback", async () => {
+    offlineUrlState.url =
+      "file:///data/user/0/app.cratemusic.crate/files/offline/song.m4a";
+    const sourceTrack = {
+      id: "global-track-offline",
+      globalTrackUid: "global-track-offline",
+      entityUid: "entity-track-offline",
+      title: "Offline Song",
+      artist: "Offline Band",
+    };
+
+    const track = await toFreshEngineTrack(sourceTrack, undefined, {
+      target: "android-native",
+    });
+
+    expect(apiMock).not.toHaveBeenCalled();
+    expect(track.url).toBe(
+      "file:///data/user/0/app.cratemusic.crate/files/offline/song.m4a",
+    );
   });
 
   it("reuses fresh remote stream tickets before resolving global catalog playback again", async () => {

--- a/app/listen/src/contexts/player-engine-adapter.ts
+++ b/app/listen/src/contexts/player-engine-adapter.ts
@@ -1,5 +1,9 @@
 import type { Track } from "@/contexts/player-types";
-import { getStreamUrl } from "@/contexts/player-utils";
+import {
+  getOfflineStreamUrl,
+  getStreamUrl,
+  type StreamUrlOptions,
+} from "@/contexts/player-utils";
 import { ensureFreshAuthToken, resolveMaybeApiAssetUrl } from "@/lib/api";
 import { fetchTrackPlayback } from "@/lib/track-playback";
 import type { EngineTrack } from "@/lib/playback-engine";
@@ -13,12 +17,13 @@ export function toEngineTrack(
   track: Track,
   eqGains?: number[],
   streamUrl?: string,
+  options: StreamUrlOptions = {},
 ): EngineTrack {
   const artwork = resolveMaybeApiAssetUrl(track.albumCover) || undefined;
 
   return {
     id: track.id,
-    url: streamUrl ?? getStreamUrl(track),
+    url: streamUrl ?? getStreamUrl(track, options),
     title: track.title || "Unknown",
     artist: track.artist || "",
     album: track.album || undefined,
@@ -37,27 +42,31 @@ export function toEngineTrack(
 export function toEngineTracks(
   tracks: Track[],
   eqGainsByTrackId?: Map<string, number[]>,
+  options: StreamUrlOptions = {},
 ): EngineTrack[] {
   return tracks.map((track) =>
-    toEngineTrack(track, eqGainsByTrackId?.get(track.id)),
+    toEngineTrack(track, eqGainsByTrackId?.get(track.id), undefined, options),
   );
 }
 
 export async function toFreshEngineTrack(
   track: Track,
   eqGains?: number[],
+  options: StreamUrlOptions = {},
 ): Promise<EngineTrack> {
   await ensureFreshAuthToken();
   return toEngineTrack(
     track,
     eqGains,
-    await resolveFreshEngineStreamUrl(track),
+    await resolveFreshEngineStreamUrl(track, options),
+    options,
   );
 }
 
 export async function toFreshEngineTracks(
   tracks: Track[],
   eqGainsByTrackId?: Map<string, number[]>,
+  options: StreamUrlOptions = {},
 ): Promise<EngineTrack[]> {
   await ensureFreshAuthToken();
   return Promise.all(
@@ -65,7 +74,8 @@ export async function toFreshEngineTracks(
       toEngineTrack(
         track,
         eqGainsByTrackId?.get(track.id),
-        await resolveFreshEngineStreamUrl(track),
+        await resolveFreshEngineStreamUrl(track, options),
+        options,
       ),
     ),
   );
@@ -75,9 +85,10 @@ export async function toStartupEngineTracks(
   tracks: Track[],
   activeIndex: number,
   eqGainsByTrackId?: Map<string, number[]>,
+  options: StreamUrlOptions = {},
 ): Promise<EngineTrack[]> {
   await ensureFreshAuthToken();
-  const engineTracks = toEngineTracks(tracks, eqGainsByTrackId);
+  const engineTracks = toEngineTracks(tracks, eqGainsByTrackId, options);
   const normalizedIndex = Math.max(
     0,
     Math.min(Math.trunc(activeIndex), tracks.length - 1),
@@ -88,7 +99,8 @@ export async function toStartupEngineTracks(
   engineTracks[normalizedIndex] = toEngineTrack(
     activeTrack,
     eqGainsByTrackId?.get(activeTrack.id),
-    await resolveFreshEngineStreamUrl(activeTrack),
+    await resolveFreshEngineStreamUrl(activeTrack, options),
+    options,
   );
   return engineTracks;
 }
@@ -99,15 +111,20 @@ function hasFreshRemoteStream(track: Track): boolean {
   return new Date(track.remote.streamUrlExpiresAt).getTime() > Date.now();
 }
 
-async function resolveFreshEngineStreamUrl(track: Track): Promise<string> {
-  if (hasFreshRemoteStream(track)) return getStreamUrl(track);
-  if (!track.globalTrackUid) return getStreamUrl(track);
+async function resolveFreshEngineStreamUrl(
+  track: Track,
+  options: StreamUrlOptions,
+): Promise<string> {
+  const offlineUrl = getOfflineStreamUrl(track, options);
+  if (offlineUrl) return offlineUrl;
+  if (hasFreshRemoteStream(track)) return getStreamUrl(track, options);
+  if (!track.globalTrackUid) return getStreamUrl(track, options);
 
   const playback = await fetchTrackPlayback(
     track,
     getEffectivePlaybackDeliveryPolicy(),
   );
-  if (!playback) return getStreamUrl(track);
+  if (!playback) return getStreamUrl(track, options);
   setPlaybackSession(track, playback.playback_session);
   setPlaybackDeliveryProvenance(track, playback);
   return resolveMaybeApiAssetUrl(playback.stream_url) || playback.stream_url;

--- a/app/listen/src/contexts/player-utils.test.ts
+++ b/app/listen/src/contexts/player-utils.test.ts
@@ -232,6 +232,60 @@ describe("getStreamUrl", () => {
       "capacitor://localhost/_capacitor_file_/offline/song.flac",
     );
   });
+
+  it("requests a file URI for the Android native playback engine", () => {
+    vi.mocked(getOfflineNativePlaybackUrl).mockReturnValueOnce(
+      "file:///data/user/0/app.cratemusic.crate/files/offline/song.flac",
+    );
+
+    const url = getStreamUrl(
+      {
+        id: "t1",
+        entityUid: "entity-1",
+        title: "Song",
+        artist: "Band",
+      },
+      { target: "android-native" },
+    );
+
+    expect(getOfflineNativePlaybackUrl).toHaveBeenCalledWith(
+      { entityUid: "entity-1" },
+      undefined,
+      { target: "android-native" },
+    );
+    expect(url).toBe(
+      "file:///data/user/0/app.cratemusic.crate/files/offline/song.flac",
+    );
+  });
+
+  it("prefers an offline copy over an unexpired remote stream ticket", () => {
+    vi.mocked(getOfflineNativePlaybackUrl).mockReturnValueOnce(
+      "file:///data/user/0/app.cratemusic.crate/files/offline/remote.m4a",
+    );
+
+    const url = getStreamUrl(
+      {
+        id: "remote-track",
+        entityUid: "remote-entity",
+        title: "Remote Song",
+        artist: "Remote Band",
+        origin: "remote",
+        remote: {
+          nodeUid: "node-b",
+          nodeName: "Node B",
+          remoteEntityUid: "remote-track",
+          streamUrl: "/api/federation/remote/streams/ticket-live",
+          streamUrlExpiresAt: new Date(Date.now() + 60_000).toISOString(),
+          availability: { catalog: true, stream: true, import: false },
+        },
+      },
+      { target: "android-native" },
+    );
+
+    expect(url).toBe(
+      "file:///data/user/0/app.cratemusic.crate/files/offline/remote.m4a",
+    );
+  });
 });
 
 describe("getEffectiveCrossfadeSeconds", () => {

--- a/app/listen/src/contexts/player-utils.ts
+++ b/app/listen/src/contexts/player-utils.ts
@@ -188,7 +188,29 @@ export function saveRecentlyPlayed(tracks: Track[]) {
   }
 }
 
-export function getStreamUrl(track: Track): string {
+export interface StreamUrlOptions {
+  target?: "webview" | "android-native";
+}
+
+export function getOfflineStreamUrl(
+  track: Track,
+  options: StreamUrlOptions = {},
+): string | null {
+  if (!track.entityUid && !track.path) return null;
+  return getOfflineNativePlaybackUrl(
+    track.entityUid ? { entityUid: track.entityUid } : track.path ?? null,
+    undefined,
+    options,
+  );
+}
+
+export function getStreamUrl(
+  track: Track,
+  options: StreamUrlOptions = {},
+): string {
+  const localOfflineUrl = getOfflineStreamUrl(track, options);
+  if (localOfflineUrl) return localOfflineUrl;
+
   if (track.origin === "remote" && track.remote?.streamUrl) {
     const expired = track.remote.streamUrlExpiresAt
       ? new Date(track.remote.streamUrlExpiresAt).getTime() < Date.now()
@@ -196,13 +218,6 @@ export function getStreamUrl(track: Track): string {
     if (!expired) {
       return `${_apiBase()}${track.remote.streamUrl}`;
     }
-  }
-
-  if (track.entityUid || track.path) {
-    const localOfflineUrl = getOfflineNativePlaybackUrl(
-      track.entityUid ? { entityUid: track.entityUid } : track.path ?? null,
-    );
-    if (localOfflineUrl) return localOfflineUrl;
   }
 
   const base = _apiBase();

--- a/app/listen/src/contexts/use-player-engine-sync.ts
+++ b/app/listen/src/contexts/use-player-engine-sync.ts
@@ -276,6 +276,8 @@ export function usePlayerEngineSync({
           const engineTracks = await toStartupEngineTracks(
             nextQueue,
             nextIndex,
+            undefined,
+            { target: "android-native" },
           );
           return androidNativeEngine.loadQueue({
             revision: createQueueRevision(),

--- a/app/listen/src/contexts/use-player-queue-actions.ts
+++ b/app/listen/src/contexts/use-player-queue-actions.ts
@@ -263,6 +263,8 @@ export function usePlayerQueueActions({
           const engineTracks = await toStartupEngineTracks(
             tracks,
             normalizedIndex,
+            undefined,
+            { target: "android-native" },
           );
           return nativeEngine.loadQueue({
             revision: createQueueRevision(),
@@ -890,7 +892,9 @@ export function usePlayerQueueActions({
 
       if (shouldUseAndroidNativePlayer()) {
         void (async () => {
-          const engineTrack = await toFreshEngineTrack(track);
+          const engineTrack = await toFreshEngineTrack(track, undefined, {
+            target: "android-native",
+          });
           return nativeEngine.insertTrack(insertAt, engineTrack);
         })().catch((error) => {
           console.error("[native-player] failed to insert track:", error);
@@ -918,7 +922,9 @@ export function usePlayerQueueActions({
       const nextQueue = [...queueRef.current, track];
       if (shouldUseAndroidNativePlayer()) {
         void (async () => {
-          const engineTrack = await toFreshEngineTrack(track);
+          const engineTrack = await toFreshEngineTrack(track, undefined, {
+            target: "android-native",
+          });
           return nativeEngine.appendTracks([engineTrack]);
         })().catch((error) => {
           console.error("[native-player] failed to append track:", error);

--- a/app/listen/src/contexts/use-player-runtime-state.ts
+++ b/app/listen/src/contexts/use-player-runtime-state.ts
@@ -118,7 +118,7 @@ export function usePlayerRuntimeState() {
 
   const buildEngineUrls = useCallback(
     (tracks: Track[], resolvedUrls?: string[]): string[] => {
-      const urls = resolvedUrls ?? tracks.map(getStreamUrl);
+      const urls = resolvedUrls ?? tracks.map((track) => getStreamUrl(track));
 
       const nextMap = new Map<string, Track[]>();
       tracks.forEach((track, index) => {

--- a/app/listen/src/lib/gapless-player.test.ts
+++ b/app/listen/src/lib/gapless-player.test.ts
@@ -42,6 +42,7 @@ import {
   getCurrentTrackDuration,
   getCurrentBufferedAheadSeconds,
   getCurrentTrackUrl,
+  getPlaybackLoadLimit,
   getPlayer,
   getPosition,
   getTrackIndex,
@@ -177,6 +178,10 @@ describe("getCurrentBufferedAheadSeconds", () => {
 });
 
 describe("initPlayer", () => {
+  it("keeps the next HTML5 track preloaded for mobile auto-advance", () => {
+    expect(getPlaybackLoadLimit(true)).toBe(2);
+  });
+
   it("creates a Gapless5 instance with expected options", () => {
     const player = initPlayer();
 
@@ -555,13 +560,13 @@ describe("replaceTrack", () => {
     expect(mock.replaceTrack).toHaveBeenCalledWith(1, "/tracks/new/stream");
   });
 
-  it("restores sequential playlist indices after the underlying remove/insert", () => {
+  it("preserves shuffle order when refreshing a source in place", () => {
     initPlayer();
     mock.playlist.shuffledIndices = [2, 0, 1];
 
     replaceTrack(1, "/tracks/new/stream");
 
-    expect(mock.playlist.shuffledIndices).toEqual([0, 1, 2]);
+    expect(mock.playlist.shuffledIndices).toEqual([2, 0, 1]);
   });
 
   it("is a no-op when no instance exists", () => {

--- a/app/listen/src/lib/gapless-player.ts
+++ b/app/listen/src/lib/gapless-player.ts
@@ -45,6 +45,8 @@ type WindowWithGaplessContext = Window & {
 // LogLevel.Warning = 3, CrossfadeShape.EqualPower = 3.
 const GAPLESS_LOG_LEVEL_WARNING = 3;
 const GAPLESS_CROSSFADE_EQUAL_POWER = 3;
+const DESKTOP_DECODE_TRACK_LIMIT = 2;
+const MOBILE_HTML5_TRACK_LIMIT = 2;
 
 export interface GaplessPlayerCallbacks {
   onTimeUpdate?: (positionMs: number, trackIndex: number) => void;
@@ -88,6 +90,12 @@ let currentTrackFullyBuffered = false;
 let fadeSettle: (() => void) | null = null;
 // Active equalizer chain (null = direct output, no processing).
 let eqChain: EqChain | null = null;
+
+export function getPlaybackLoadLimit(preferHtml5Audio: boolean): number {
+  return preferHtml5Audio
+    ? MOBILE_HTML5_TRACK_LIMIT
+    : DESKTOP_DECODE_TRACK_LIMIT;
+}
 let eqEnabled = false;
 let lastEqGains: EqGains = [];
 let lastPlaybackRate = 1.0;
@@ -232,11 +240,9 @@ export function initPlayer(callbacks: GaplessPlayerCallbacks = {}): Gapless5 {
     crossfadeShape: GAPLESS_CROSSFADE_EQUAL_POWER,
     volume: lastVolume,
     logLevel: GAPLESS_LOG_LEVEL_WARNING,
-    // Keep the live HTML5 pipeline conservative on mobile. The vendored
-    // loader treats loadLimit=1 as the active source only; higher values
-    // create parallel <audio> loads and Android WebView/emulators can
-    // start dropping audio frames.
-    loadLimit: preferHtml5Audio ? 1 : 2,
+    // Keep the next mobile <audio> source ready before the active element
+    // reaches ended, preserving uninterrupted media-session/Bluetooth state.
+    loadLimit: getPlaybackLoadLimit(preferHtml5Audio),
   });
   appliedVolume = lastVolume;
 
@@ -440,9 +446,6 @@ export function removeTrack(indexOrUrl: number | string): void {
 
 export function replaceTrack(index: number, url: string): void {
   instance?.replaceTrack(index, url);
-  // Gapless-5 replaces by removing then inserting, and insertion mutates
-  // shuffledIndices. React owns the queue order, so restore identity order.
-  normalizeShuffledIndices();
 }
 
 function getAudioContext(): AudioContext | null {

--- a/app/listen/src/lib/gapless5/gapless5-buffering.test.ts
+++ b/app/listen/src/lib/gapless5/gapless5-buffering.test.ts
@@ -1,9 +1,14 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 import {
+  Gapless5,
   getBufferedAheadSeconds,
   getLoadableTrackIndices,
 } from "@/lib/gapless5/gapless5";
+
+afterEach(() => {
+  vi.useRealTimers();
+});
 
 function ranges(values: Array<[number, number]>): TimeRanges {
   return {
@@ -57,5 +62,30 @@ describe("getLoadableTrackIndices", () => {
 
   it("keeps the unlimited mode bounded to real source indices", () => {
     expect(getLoadableTrackIndices(0, 3, -1)).toEqual([0, 1, 2]);
+  });
+});
+
+describe("Gapless5.replaceTrack", () => {
+  it("preserves the active cursor when refreshing the next source", () => {
+    vi.useFakeTimers();
+    const player = new Gapless5({
+      tracks: ["one", "two", "three", "four", "five"],
+      startingTrack: 3,
+      useHTML5Audio: false,
+      useWebAudio: false,
+      loadLimit: 2,
+    });
+
+    player.replaceTrack(4, "five-refreshed");
+
+    expect(player.getIndex()).toBe(3);
+    expect(player.getTracks()).toEqual([
+      "one",
+      "two",
+      "three",
+      "four",
+      "five-refreshed",
+    ]);
+    player.removeAllTracks();
   });
 });

--- a/app/listen/src/lib/gapless5/gapless5.js
+++ b/app/listen/src/lib/gapless5/gapless5.js
@@ -1194,6 +1194,17 @@ function Gapless5FileList(
     this.updateLoading();
   };
 
+  this.replace = (playlistIndex, audioPath) => {
+    const { index, source } = this.getSourceIndexed(playlistIndex);
+    if (!source) {
+      return false;
+    }
+    source.unload();
+    this.sources[index] = new Gapless5Source(player, log, audioPath);
+    this.updateLoading();
+    return true;
+  };
+
   // process inputs from constructor
   if (inTracks.length > 0) {
     for (let i = 0; i < inTracks.length; i++) {
@@ -1810,8 +1821,13 @@ function Gapless5(options = {}, deprecated = {}) {
    * @param {string} audioPath - path to audio file(s) or blob URL(s)
    */
   this.replaceTrack = (point, audioPath) => {
-    this.removeTrack(point);
-    this.insertTrack(point, audioPath);
+    const playlistIndex = this.playlist.indexFromTrack(point);
+    if (!isValidIndex(playlistIndex)) {
+      log.warn(`Cannot replace missing track: ${point}`);
+      return;
+    }
+    this.playlist.replace(playlistIndex, audioPath);
+    this.uiDirty = true;
   };
 
   this.removeAllTracks = (flushPlaylist = true) => {

--- a/app/listen/src/lib/offline-native.test.ts
+++ b/app/listen/src/lib/offline-native.test.ts
@@ -81,5 +81,10 @@ describe("native offline playback bootstrap", () => {
     expect(getOfflineNativePlaybackUrl({ entityUid: "track-entity-1" })).toBe(
       "capacitor://localhost/_capacitor_file_/offline-media/profile/song.m4a",
     );
+    expect(
+      getOfflineNativePlaybackUrl({ entityUid: "track-entity-1" }, undefined, {
+        target: "android-native",
+      }),
+    ).toBe("file:///offline-media/profile/song.m4a");
   });
 });

--- a/app/listen/src/lib/offline.ts
+++ b/app/listen/src/lib/offline.ts
@@ -1233,6 +1233,7 @@ export function getOfflineActionLabel(state: OfflineItemState): string {
 export function getOfflineNativePlaybackUrl(
   track: OfflineTrackIdentityInput,
   storageId?: string | null,
+  options: { target?: "webview" | "android-native" } = {},
 ): string | null {
   if (!isNative) return null;
   const profileKey = getActiveOfflineProfileKey();
@@ -1241,7 +1242,10 @@ export function getOfflineNativePlaybackUrl(
   const entry = getOfflineTrackAssetAliases(track, storageId)
     .map((alias) => assets[alias])
     .find(Boolean);
-  return entry?.playbackUrl || null;
+  if (!entry) return null;
+  return options.target === "android-native"
+    ? entry.uri || null
+    : entry.playbackUrl || null;
 }
 
 export async function syncOfflineProfileToServiceWorker(

--- a/app/listen/src/pages/Explore.test.tsx
+++ b/app/listen/src/pages/Explore.test.tsx
@@ -502,14 +502,14 @@ describe("Explore", () => {
     });
   });
 
-  it("uses top artist background without probing an absent genre cover", () => {
+  it("keeps the API membership order when choosing a fallback hero", () => {
     mockGenreDetail({
       coverUrl: null,
       artists: [
         {
           artist_id: 111,
-          artist_name: "Less Popular",
-          artist_slug: "less-popular",
+          artist_name: "Core Artist",
+          artist_slug: "core-artist",
           album_count: 3,
           track_count: 6,
           has_photo: true,
@@ -517,8 +517,8 @@ describe("Explore", () => {
         },
         {
           artist_id: 222,
-          artist_name: "Most Popular",
-          artist_slug: "most-popular",
+          artist_name: "Popular Adjacent Artist",
+          artist_slug: "popular-adjacent-artist",
           album_count: 5,
           track_count: 9,
           has_photo: true,
@@ -534,7 +534,7 @@ describe("Explore", () => {
 
     expect(screen.getByAltText("hardcore genre cover")).toHaveAttribute(
       "src",
-      "/api/artists/222/background?size=1280&format=webp",
+      "/api/artists/111/background?size=1280&format=webp",
     );
   });
 

--- a/app/readplane/internal/routes/server.go
+++ b/app/readplane/internal/routes/server.go
@@ -113,6 +113,7 @@ func (s *Server) Handler() http.Handler {
 	mux.HandleFunc("/api/me/home/essentials", s.route(http.MethodGet, s.homeSlice))
 	mux.HandleFunc("/api/me/home/discovery", s.route(http.MethodGet, s.homeDiscovery))
 	mux.HandleFunc("/api/me/home/discovery-stream", s.route(http.MethodGet, s.homeDiscoveryStream))
+	mux.HandleFunc("/api/me/home/", s.route(http.MethodGet, s.fallbackOnly))
 	mux.HandleFunc("/api/me/stats/dashboard", s.route(http.MethodGet, s.statsDashboard))
 	mux.HandleFunc("/api/me/albums", s.route(http.MethodGet, s.myAlbumsRoute))
 	mux.HandleFunc("/api/me/follows", s.route(http.MethodGet, s.myFollowsRoute))
@@ -137,6 +138,10 @@ func (s *Server) Handler() http.Handler {
 	mux.HandleFunc("/api/artists/", s.routeGetHead(s.artistRoute))
 	mux.HandleFunc("/api/tracks/", s.routeGetHead(s.trackRoute))
 	return s.withCommonHeaders(s.withTraceID(s.withAccessLog(mux)))
+}
+
+func (s *Server) fallbackOnly(w http.ResponseWriter, r *http.Request) {
+	s.fallbackOrRouteMiss(w, r)
 }
 
 func (s *Server) routeGetHead(handler handlerFunc) http.HandlerFunc {

--- a/app/readplane/internal/routes/server_handler_test.go
+++ b/app/readplane/internal/routes/server_handler_test.go
@@ -639,6 +639,35 @@ func TestFallbackOrAuthError_Unauthorized(t *testing.T) {
 	assert.Equal(t, "Not authenticated", body["detail"])
 }
 
+func TestHomeSectionDetailFallsBackToFastAPI(t *testing.T) {
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/api/me/home/sections/suggested-albums", r.URL.Path)
+		assert.Equal(t, "42", r.URL.Query().Get("limit"))
+		assert.Equal(t, "1", r.Header.Get("X-Crate-Readplane-Fallback"))
+		_ = httpx.WriteJSON(w, http.StatusOK, map[string]any{
+			"id":    "suggested-albums",
+			"items": []any{},
+		})
+	}))
+	defer backend.Close()
+
+	fallback, err := httpx.NewFallbackProxy(true, backend.URL, "test")
+	assert.NoError(t, err)
+	server := newTestServerNoAuth()
+	server.fallback = fallback
+
+	req := httptest.NewRequest(
+		http.MethodGet,
+		"/api/me/home/sections/suggested-albums?limit=42",
+		nil,
+	)
+	rec := httptest.NewRecorder()
+	server.Handler().ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.Equal(t, "fallback", rec.Header().Get("X-Crate-Readplane"))
+}
+
 func TestCatalogUnavailable_WithoutFallback(t *testing.T) {
 	// catalog=nil, auth=nil, no fallback → requireCatalogUser returns catalogUnavailable → 503.
 	server := newTestServerNoAuth()

--- a/app/tests/test_browse_queries.py
+++ b/app/tests/test_browse_queries.py
@@ -281,8 +281,8 @@ def test_browse_filter_genres_orders_top_artists_by_genre_weight(pg_db):
     rows = get_browse_filter_genres()
     mathcore = next(row for row in rows if row["name"] == "mathcore")
 
-    assert mathcore["top_artists"] == ["Evenly Split 2", "Evenly Split 1"]
-    assert mathcore["count"] == 2
+    assert mathcore["top_artists"] == ["Evenly Split 2"]
+    assert mathcore["count"] == 1
 
 
 def test_browse_filter_genres_prefers_manual_taxonomy_cover(pg_db):


### PR DESCRIPTION
## Resumen

Corrige las regresiones de Listen detectadas tras el despliegue de la infraestructura federada:

- restaura el avance automático y la continuidad Bluetooth/MediaSession en Android y web móvil;
- reproduce descargas offline mediante la URI nativa, sin resolverlas contra `localhost`;
- normaliza las portadas relativas del catálogo global para Capacitor;
- recupera todos los enlaces `View all` delegando las rutas de detalle al API desde el readplane;
- alinea la portada hero de cada género con el orden de sus miembros;
- eleva el umbral de pertenencia a géneros para excluir asociaciones débiles.

## Causas raíz y solución

### Playback móvil

- El pipeline HTML5 móvil cargaba únicamente el track activo (`loadLimit=1`), por lo que al llegar a `ended` el siguiente origen todavía no estaba preparado y se perdía el estado de MediaSession/Bluetooth.
- La renovación de la URL de un track hacía `remove + insert` en Gapless5, desplazando el cursor activo y reseteando el orden aleatorio.
- Ahora se precargan el actual y el siguiente, y Gapless5 reemplaza una fuente de forma atómica conservando cursor y shuffle.

### Offline en Android

- Media3 recibía la URL convertida para el WebView (`localhost/_capacitor_file_...`) en vez de la URI nativa `file://`.
- La resolución fresca del catálogo podía priorizar un ticket remoto sobre una copia offline.
- La resolución distingue explícitamente entre destino WebView y Android nativo, y siempre prioriza la copia offline.

### Artwork nativo

- Los álbumes canónicos exponen rutas relativas `/api/catalog/.../cover`; en Capacitor se resolvían contra el origen del WebView.
- `AlbumCard` normaliza ahora cualquier portada explícita mediante la URL configurada del servidor y su autenticación.

### Home y géneros

- Traefik enviaba `/api/me/home/*` al readplane, pero este no delegaba las rutas de detalle desconocidas y respondía 404.
- El hero del género reordenaba miembros por listeners, mientras las cards usaban el orden canónico por peso.
- El umbral legacy de pertenencia (`0.45`) admitía asociaciones débiles frente al contrato federado (`0.70`).

## Validación

- Listen: 1524 tests passed, 4 skipped
- TypeScript typecheck: passed
- ESLint Listen: passed
- Go readplane `go test ./...`: passed
- Python browse/taxonomy: 108 passed
- Capacitor production build/sync: passed
- Android `testDebugUnitTest assembleDebug`: passed
- Pre-commit hooks: passed

