### PR TITLE
fix(genres): repair stale global alias memberships

### DIFF
--- a/app/crate/db/jobs/genre_taxonomy.py
+++ b/app/crate/db/jobs/genre_taxonomy.py
@@ -216,7 +216,7 @@ def merge_duplicate_library_genres() -> list[dict]:
         return merge_duplicate_library_genres_in_session(session)
 
 
-def seed_genre_taxonomy_definitions(session, definitions) -> None:
+def seed_genre_taxonomy_definitions(session, definitions) -> bool:
     # Keep the seed idempotent, but always apply it so upgrades from the
     # pre-global taxonomy schema receive the stable core identity as well.
     from crate.genre_taxonomy import CORE_TAXONOMY_ID, core_genre_uid
@@ -321,7 +321,9 @@ def seed_genre_taxonomy_definitions(session, definitions) -> None:
                 },
             )
 
-    session.execute(text("DELETE FROM genre_taxonomy_aliases WHERE origin = 'legacy'"))
+    removed_legacy_aliases = session.execute(
+        text("DELETE FROM genre_taxonomy_aliases WHERE origin = 'legacy'")
+    ).rowcount
 
     for definition in definitions:
         source_id = node_ids.get(definition.slug)
@@ -379,3 +381,5 @@ def seed_genre_taxonomy_definitions(session, definitions) -> None:
                 ),
                 {"source_id": source_id, "target_id": target_id},
             )
+
+    return bool(removed_legacy_aliases)

--- a/app/crate/db/jobs/global_catalog_genres.py
+++ b/app/crate/db/jobs/global_catalog_genres.py
@@ -229,6 +229,180 @@ def recompute_entity_genre_memberships(
     )
 
 
+def repair_stale_alias_assertions(session) -> dict[str, int]:
+    """Invalidate removed alias mappings and rebuild only affected memberships."""
+    session.execute(
+        text(
+            """
+            SELECT pg_advisory_xact_lock(
+                hashtextextended('crate:repair-stale-genre-aliases', 0)
+            )
+            """
+        )
+    )
+    session.execute(
+        text(
+            """
+            CREATE TEMP TABLE crate_stale_genre_alias_assertions
+            ON COMMIT DROP AS
+            SELECT
+                assertion.id AS assertion_id,
+                source.entity_type,
+                source.global_entity_uid
+            FROM global_catalog_genre_assertions assertion
+            JOIN global_catalog_sources source ON source.id = assertion.source_id
+            WHERE assertion.invalidated_at IS NULL
+              AND assertion.global_genre_uid IS NOT NULL
+              AND assertion.mapping_method IN ('local_alias', 'receiver_mapping')
+              AND source.source_deleted_at IS NULL
+              AND NOT source.source_stale
+              AND NOT EXISTS (
+                  SELECT 1
+                  FROM genre_taxonomy_nodes node
+                  WHERE node.taxonomy_id = :taxonomy_id
+                    AND node.global_genre_uid = assertion.global_genre_uid
+                    AND (
+                        node.slug = trim(
+                            both '-' from regexp_replace(
+                                lower(assertion.raw_label),
+                                '[^a-z0-9]+',
+                                '-',
+                                'g'
+                            )
+                        )
+                        OR EXISTS (
+                            SELECT 1
+                            FROM genre_taxonomy_aliases alias
+                            WHERE alias.genre_id = node.id
+                              AND (
+                                  alias.alias_slug = trim(
+                                      both '-' from regexp_replace(
+                                          lower(assertion.raw_label),
+                                          '[^a-z0-9]+',
+                                          '-',
+                                          'g'
+                                      )
+                                  )
+                                  OR lower(alias.alias_name) = lower(assertion.raw_label)
+                              )
+                        )
+                    )
+              )
+            """
+        ),
+        {"taxonomy_id": CORE_TAXONOMY_ID},
+    )
+    counts = (
+        session.execute(
+            text(
+                """
+                SELECT
+                    COUNT(*)::integer AS assertion_count,
+                    COUNT(DISTINCT (entity_type, global_entity_uid))::integer
+                        AS affected_entity_count
+                FROM crate_stale_genre_alias_assertions
+                """
+            )
+        )
+        .mappings()
+        .one()
+    )
+    assertion_count = int(counts["assertion_count"] or 0)
+    affected_entity_count = int(counts["affected_entity_count"] or 0)
+    if assertion_count == 0:
+        return {"assertions": 0, "entities": 0}
+
+    session.execute(
+        text(
+            """
+            UPDATE global_catalog_genre_assertions assertion
+            SET invalidated_at = NOW()
+            FROM crate_stale_genre_alias_assertions stale
+            WHERE assertion.id = stale.assertion_id
+              AND assertion.invalidated_at IS NULL
+            """
+        )
+    )
+    session.execute(
+        text(
+            """
+            DELETE FROM global_catalog_entity_genres membership
+            USING (
+                SELECT DISTINCT entity_type, global_entity_uid
+                FROM crate_stale_genre_alias_assertions
+            ) affected
+            WHERE membership.entity_type = affected.entity_type
+              AND membership.global_entity_uid = affected.global_entity_uid
+            """
+        )
+    )
+    session.execute(
+        text(
+            """
+            INSERT INTO global_catalog_entity_genres (
+                entity_type,
+                global_entity_uid,
+                global_genre_uid,
+                direct_score,
+                aggregate_score,
+                supporting_source_count,
+                supporting_node_count,
+                preferred_for_display,
+                computed_at
+            )
+            SELECT
+                source.entity_type,
+                source.global_entity_uid,
+                assertion.global_genre_uid,
+                LEAST(
+                    1.0,
+                    SUM(
+                        CASE WHEN assertion.is_direct
+                            THEN assertion.weight * assertion.confidence
+                            ELSE 0
+                        END
+                    )
+                ) AS direct_score,
+                LEAST(1.0, SUM(assertion.weight * assertion.confidence))
+                    AS aggregate_score,
+                COUNT(DISTINCT source.id)::integer AS supporting_source_count,
+                COUNT(DISTINCT COALESCE(source.node_uid::text, 'local'))::integer
+                    AS supporting_node_count,
+                BOOL_OR(source.preferred_for_display) AS preferred_for_display,
+                NOW()
+            FROM global_catalog_genre_assertions assertion
+            JOIN global_catalog_sources source ON source.id = assertion.source_id
+            JOIN (
+                SELECT DISTINCT entity_type, global_entity_uid
+                FROM crate_stale_genre_alias_assertions
+            ) affected
+              ON affected.entity_type = source.entity_type
+             AND affected.global_entity_uid = source.global_entity_uid
+            WHERE assertion.invalidated_at IS NULL
+              AND assertion.global_genre_uid IS NOT NULL
+              AND source.source_deleted_at IS NULL
+              AND NOT source.source_stale
+            GROUP BY
+                source.entity_type,
+                source.global_entity_uid,
+                assertion.global_genre_uid
+            ON CONFLICT (entity_type, global_entity_uid, global_genre_uid)
+            DO UPDATE SET
+                direct_score = EXCLUDED.direct_score,
+                aggregate_score = EXCLUDED.aggregate_score,
+                supporting_source_count = EXCLUDED.supporting_source_count,
+                supporting_node_count = EXCLUDED.supporting_node_count,
+                preferred_for_display = EXCLUDED.preferred_for_display,
+                computed_at = EXCLUDED.computed_at
+            """
+        )
+    )
+    return {
+        "assertions": assertion_count,
+        "entities": affected_entity_count,
+    }
+
+
 def refresh_global_catalog_genre_snapshots() -> None:
     """Publish matching taxonomy and global genre-list snapshots for Go reads."""
     from crate.db.queries.global_catalog import list_global_catalog_genres
@@ -322,7 +496,9 @@ def _lookup_local_core_genre(session, raw_label: str) -> str | None:
                 """
                 SELECT node.global_genre_uid::text AS global_genre_uid
                 FROM genre_taxonomy_nodes node
-                LEFT JOIN genre_taxonomy_aliases alias ON alias.genre_id = node.id
+                LEFT JOIN genre_taxonomy_aliases alias
+                  ON alias.genre_id = node.id
+                 AND alias.origin <> 'legacy'
                 WHERE node.taxonomy_id = :taxonomy_id
                   AND (
                     node.slug = :normalized_slug

--- a/app/crate/db/migrations/versions/078_repair_global_genre_alias_assertions.py
+++ b/app/crate/db/migrations/versions/078_repair_global_genre_alias_assertions.py
@@ -1,0 +1,152 @@
+"""Repair stale global genre assertions after alias provenance cleanup.
+
+Revision ID: 078
+Revises: 077
+"""
+
+from collections.abc import Sequence
+
+from alembic import op
+
+
+revision = "078"
+down_revision = "077"
+branch_labels: Sequence[str] | None = None
+depends_on: Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.execute(
+        """
+        CREATE TEMP TABLE crate_stale_genre_alias_assertions
+        ON COMMIT DROP AS
+        SELECT
+            assertion.id AS assertion_id,
+            source.entity_type,
+            source.global_entity_uid
+        FROM global_catalog_genre_assertions assertion
+        JOIN global_catalog_sources source ON source.id = assertion.source_id
+        WHERE assertion.invalidated_at IS NULL
+          AND assertion.global_genre_uid IS NOT NULL
+          AND assertion.mapping_method IN ('local_alias', 'receiver_mapping')
+          AND source.source_deleted_at IS NULL
+          AND NOT source.source_stale
+          AND NOT EXISTS (
+              SELECT 1
+              FROM genre_taxonomy_nodes node
+              WHERE node.taxonomy_id = 'crate-core'
+                AND node.global_genre_uid = assertion.global_genre_uid
+                AND (
+                    node.slug = trim(
+                        both '-' from regexp_replace(
+                            lower(assertion.raw_label),
+                            '[^a-z0-9]+',
+                            '-',
+                            'g'
+                        )
+                    )
+                    OR EXISTS (
+                        SELECT 1
+                        FROM genre_taxonomy_aliases alias
+                        WHERE alias.genre_id = node.id
+                          AND (
+                              alias.alias_slug = trim(
+                                  both '-' from regexp_replace(
+                                      lower(assertion.raw_label),
+                                      '[^a-z0-9]+',
+                                      '-',
+                                      'g'
+                                  )
+                              )
+                              OR lower(alias.alias_name) = lower(assertion.raw_label)
+                          )
+                    )
+                )
+          )
+        """
+    )
+    op.execute(
+        """
+        UPDATE global_catalog_genre_assertions assertion
+        SET invalidated_at = NOW()
+        FROM crate_stale_genre_alias_assertions stale
+        WHERE assertion.id = stale.assertion_id
+          AND assertion.invalidated_at IS NULL
+        """
+    )
+    op.execute(
+        """
+        DELETE FROM global_catalog_entity_genres membership
+        USING (
+            SELECT DISTINCT entity_type, global_entity_uid
+            FROM crate_stale_genre_alias_assertions
+        ) affected
+        WHERE membership.entity_type = affected.entity_type
+          AND membership.global_entity_uid = affected.global_entity_uid
+        """
+    )
+    op.execute(
+        """
+        INSERT INTO global_catalog_entity_genres (
+            entity_type,
+            global_entity_uid,
+            global_genre_uid,
+            direct_score,
+            aggregate_score,
+            supporting_source_count,
+            supporting_node_count,
+            preferred_for_display,
+            computed_at
+        )
+        SELECT
+            source.entity_type,
+            source.global_entity_uid,
+            assertion.global_genre_uid,
+            LEAST(
+                1.0,
+                SUM(
+                    CASE WHEN assertion.is_direct
+                        THEN assertion.weight * assertion.confidence
+                        ELSE 0
+                    END
+                )
+            ) AS direct_score,
+            LEAST(1.0, SUM(assertion.weight * assertion.confidence))
+                AS aggregate_score,
+            COUNT(DISTINCT source.id)::integer AS supporting_source_count,
+            COUNT(DISTINCT COALESCE(source.node_uid::text, 'local'))::integer
+                AS supporting_node_count,
+            BOOL_OR(source.preferred_for_display) AS preferred_for_display,
+            NOW()
+        FROM global_catalog_genre_assertions assertion
+        JOIN global_catalog_sources source ON source.id = assertion.source_id
+        JOIN (
+            SELECT DISTINCT entity_type, global_entity_uid
+            FROM crate_stale_genre_alias_assertions
+        ) affected
+          ON affected.entity_type = source.entity_type
+         AND affected.global_entity_uid = source.global_entity_uid
+        WHERE assertion.invalidated_at IS NULL
+          AND assertion.global_genre_uid IS NOT NULL
+          AND source.source_deleted_at IS NULL
+          AND NOT source.source_stale
+        GROUP BY
+            source.entity_type,
+            source.global_entity_uid,
+            assertion.global_genre_uid
+        ON CONFLICT (entity_type, global_entity_uid, global_genre_uid)
+        DO UPDATE SET
+            direct_score = EXCLUDED.direct_score,
+            aggregate_score = EXCLUDED.aggregate_score,
+            supporting_source_count = EXCLUDED.supporting_source_count,
+            supporting_node_count = EXCLUDED.supporting_node_count,
+            preferred_for_display = EXCLUDED.preferred_for_display,
+            computed_at = EXCLUDED.computed_at
+        """
+    )
+
+
+def downgrade() -> None:
+    # Invalidated mappings referenced aliases that no longer exist. Restoring
+    # those assertions would reintroduce the corrupt genre memberships.
+    pass

--- a/app/crate/genre_taxonomy.py
+++ b/app/crate/genre_taxonomy.py
@@ -1494,6 +1494,12 @@ def seed_genre_taxonomy(session) -> None:
     manual and inferred aliases are preserved.
     """
     from crate.db.jobs.genre_taxonomy import seed_genre_taxonomy_definitions
+    from crate.db.jobs.global_catalog_genres import repair_stale_alias_assertions
 
-    seed_genre_taxonomy_definitions(session, _GENRE_DEFINITIONS)
+    removed_legacy_aliases = seed_genre_taxonomy_definitions(
+        session,
+        _GENRE_DEFINITIONS,
+    )
+    if removed_legacy_aliases:
+        repair_stale_alias_assertions(session)
     invalidate_runtime_taxonomy_cache_after_commit(session)

--- a/app/tests/test_federation_migration_matrix.py
+++ b/app/tests/test_federation_migration_matrix.py
@@ -306,7 +306,7 @@ def _seed_063_legacy_state() -> dict[str, str]:
 
 
 def _assert_hardened_state(ids: dict[str, str]) -> None:
-    assert _scalar("SELECT version_num FROM alembic_version") == "077"
+    assert _scalar("SELECT version_num FROM alembic_version") == "078"
     assert (
         _scalar(
             "SELECT status FROM federation_local_keys WHERE node_uid = %s",
@@ -356,7 +356,7 @@ def test_empty_database_migrates_from_base_to_head(pg_db):
 
     _migrate("head")
 
-    assert _scalar("SELECT version_num FROM alembic_version") == "077"
+    assert _scalar("SELECT version_num FROM alembic_version") == "078"
     for table in (
         "federation_local_keys",
         "federation_catalog_changes",
@@ -378,7 +378,7 @@ def test_real_main_049_snapshot_upgrades_without_user_data_loss(pg_db):
 
     _migrate("head")
 
-    assert _scalar("SELECT version_num FROM alembic_version") == "077"
+    assert _scalar("SELECT version_num FROM alembic_version") == "078"
     assert _scalar("SELECT email FROM users WHERE id = %s", (ids["user_id"],)) == (
         "legacy@example.test"
     )

--- a/app/tests/test_global_catalog_genres.py
+++ b/app/tests/test_global_catalog_genres.py
@@ -73,6 +73,309 @@ def test_local_genre_assignment_projects_attributed_global_membership(pg_db):
     }
 
 
+def test_legacy_alias_does_not_project_global_membership(pg_db):
+    from crate.db.tx import read_scope, transaction_scope
+    from crate.federation.global_reconciliation import reconcile_dirty_catalog_sources
+
+    artist_uid = str(uuid.uuid4())
+    pg_db.upsert_artist({"name": "Legacy Alias Artist", "entity_uid": artist_uid})
+    with transaction_scope() as session:
+        rock_id = session.execute(
+            text(
+                """
+                SELECT id
+                FROM genre_taxonomy_nodes
+                WHERE taxonomy_id = 'crate-core' AND slug = 'rock'
+                """
+            )
+        ).scalar_one()
+        session.execute(
+            text(
+                """
+                INSERT INTO genre_taxonomy_aliases (
+                    alias_slug, alias_name, genre_id, origin, confidence
+                )
+                VALUES ('scene-country', 'scene country', :genre_id, 'legacy', NULL)
+                """
+            ),
+            {"genre_id": rock_id},
+        )
+    pg_db.set_artist_genres(
+        "Legacy Alias Artist",
+        [("scene country", 1.0, "test")],
+    )
+
+    assert reconcile_dirty_catalog_sources(limit=10)["completed"] == 1
+
+    with read_scope() as session:
+        assertion = (
+            session.execute(
+                text(
+                    """
+                    SELECT
+                        assertion.global_genre_uid,
+                        assertion.mapping_method
+                    FROM global_catalog_genre_assertions assertion
+                    JOIN global_catalog_sources source ON source.id = assertion.source_id
+                    WHERE source.local_entity_uid = CAST(:artist_uid AS uuid)
+                      AND assertion.invalidated_at IS NULL
+                    """
+                ),
+                {"artist_uid": artist_uid},
+            )
+            .mappings()
+            .one()
+        )
+        memberships = session.execute(
+            text(
+                """
+                SELECT COUNT(*)
+                FROM global_catalog_entity_genres membership
+                JOIN global_catalog_sources source
+                  ON source.entity_type = membership.entity_type
+                 AND source.global_entity_uid = membership.global_entity_uid
+                WHERE source.local_entity_uid = CAST(:artist_uid AS uuid)
+                """
+            ),
+            {"artist_uid": artist_uid},
+        ).scalar_one()
+
+    assert assertion == {
+        "global_genre_uid": None,
+        "mapping_method": "unmapped",
+    }
+    assert memberships == 0
+
+
+def test_repair_stale_alias_assertions_recomputes_affected_entity(pg_db):
+    from crate.db.jobs.global_catalog_genres import repair_stale_alias_assertions
+    from crate.db.tx import read_scope, transaction_scope
+    from crate.federation.global_reconciliation import reconcile_dirty_catalog_sources
+
+    artist_uid = str(uuid.uuid4())
+    pg_db.upsert_artist({"name": "Removed Alias Artist", "entity_uid": artist_uid})
+    with transaction_scope() as session:
+        rock_id = session.execute(
+            text(
+                """
+                SELECT id
+                FROM genre_taxonomy_nodes
+                WHERE taxonomy_id = 'crate-core' AND slug = 'rock'
+                """
+            )
+        ).scalar_one()
+        session.execute(
+            text(
+                """
+                INSERT INTO genre_taxonomy_aliases (
+                    alias_slug, alias_name, genre_id, origin, confidence
+                )
+                VALUES ('temporary-scene', 'temporary scene', :genre_id, 'manual', 1.0)
+                """
+            ),
+            {"genre_id": rock_id},
+        )
+    pg_db.set_artist_genres(
+        "Removed Alias Artist",
+        [("temporary scene", 1.0, "test")],
+    )
+    assert reconcile_dirty_catalog_sources(limit=10)["completed"] == 1
+
+    with transaction_scope() as session:
+        session.execute(
+            text(
+                "DELETE FROM genre_taxonomy_aliases WHERE alias_slug = 'temporary-scene'"
+            )
+        )
+        repaired = repair_stale_alias_assertions(session)
+
+    assert repaired == {"assertions": 1, "entities": 1}
+    with read_scope() as session:
+        active_assertions = session.execute(
+            text(
+                """
+                SELECT COUNT(*)
+                FROM global_catalog_genre_assertions assertion
+                JOIN global_catalog_sources source ON source.id = assertion.source_id
+                WHERE source.local_entity_uid = CAST(:artist_uid AS uuid)
+                  AND assertion.invalidated_at IS NULL
+                """
+            ),
+            {"artist_uid": artist_uid},
+        ).scalar_one()
+        memberships = session.execute(
+            text(
+                """
+                SELECT COUNT(*)
+                FROM global_catalog_entity_genres membership
+                JOIN global_catalog_sources source
+                  ON source.entity_type = membership.entity_type
+                 AND source.global_entity_uid = membership.global_entity_uid
+                WHERE source.local_entity_uid = CAST(:artist_uid AS uuid)
+                """
+            ),
+            {"artist_uid": artist_uid},
+        ).scalar_one()
+
+    assert active_assertions == 0
+    assert memberships == 0
+
+
+def test_repair_waits_until_a_legacy_alias_is_removed(pg_db):
+    from crate.db.jobs.global_catalog_genres import repair_stale_alias_assertions
+    from crate.db.tx import read_scope, transaction_scope
+    from crate.federation.global_reconciliation import reconcile_dirty_catalog_sources
+
+    artist_uid = str(uuid.uuid4())
+    pg_db.upsert_artist({"name": "Pending Seed Artist", "entity_uid": artist_uid})
+    with transaction_scope() as session:
+        rock_id = session.execute(
+            text(
+                """
+                SELECT id
+                FROM genre_taxonomy_nodes
+                WHERE taxonomy_id = 'crate-core' AND slug = 'rock'
+                """
+            )
+        ).scalar_one()
+        session.execute(
+            text(
+                """
+                INSERT INTO genre_taxonomy_aliases (
+                    alias_slug, alias_name, genre_id, origin, confidence
+                )
+                VALUES ('pending-seed', 'pending seed', :genre_id, 'manual', 1.0)
+                """
+            ),
+            {"genre_id": rock_id},
+        )
+    pg_db.set_artist_genres(
+        "Pending Seed Artist",
+        [("pending seed", 1.0, "test")],
+    )
+    assert reconcile_dirty_catalog_sources(limit=10)["completed"] == 1
+
+    with transaction_scope() as session:
+        session.execute(
+            text(
+                """
+                UPDATE genre_taxonomy_aliases
+                SET origin = 'legacy', confidence = NULL
+                WHERE alias_slug = 'pending-seed'
+                """
+            )
+        )
+        repaired = repair_stale_alias_assertions(session)
+
+    assert repaired == {"assertions": 0, "entities": 0}
+    with read_scope() as session:
+        active_assertions = session.execute(
+            text(
+                """
+                SELECT COUNT(*)
+                FROM global_catalog_genre_assertions assertion
+                JOIN global_catalog_sources source ON source.id = assertion.source_id
+                WHERE source.local_entity_uid = CAST(:artist_uid AS uuid)
+                  AND assertion.invalidated_at IS NULL
+                """
+            ),
+            {"artist_uid": artist_uid},
+        ).scalar_one()
+        memberships = session.execute(
+            text(
+                """
+                SELECT COUNT(*)
+                FROM global_catalog_entity_genres membership
+                JOIN global_catalog_sources source
+                  ON source.entity_type = membership.entity_type
+                 AND source.global_entity_uid = membership.global_entity_uid
+                WHERE source.local_entity_uid = CAST(:artist_uid AS uuid)
+                """
+            ),
+            {"artist_uid": artist_uid},
+        ).scalar_one()
+
+    assert active_assertions == 1
+    assert memberships == 1
+
+
+def test_taxonomy_seed_repairs_assertions_for_removed_legacy_aliases(pg_db):
+    from crate.db.tx import read_scope, transaction_scope
+    from crate.federation.global_reconciliation import reconcile_dirty_catalog_sources
+    from crate.genre_taxonomy import seed_genre_taxonomy
+
+    artist_uid = str(uuid.uuid4())
+    pg_db.upsert_artist({"name": "Seed Repair Artist", "entity_uid": artist_uid})
+    with transaction_scope() as session:
+        rock_id = session.execute(
+            text(
+                """
+                SELECT id
+                FROM genre_taxonomy_nodes
+                WHERE taxonomy_id = 'crate-core' AND slug = 'rock'
+                """
+            )
+        ).scalar_one()
+        session.execute(
+            text(
+                """
+                INSERT INTO genre_taxonomy_aliases (
+                    alias_slug, alias_name, genre_id, origin, confidence
+                )
+                VALUES ('removed-by-seed', 'removed by seed', :genre_id, 'manual', 1.0)
+                """
+            ),
+            {"genre_id": rock_id},
+        )
+    pg_db.set_artist_genres(
+        "Seed Repair Artist",
+        [("removed by seed", 1.0, "test")],
+    )
+    assert reconcile_dirty_catalog_sources(limit=10)["completed"] == 1
+
+    with transaction_scope() as session:
+        session.execute(
+            text(
+                """
+                UPDATE genre_taxonomy_aliases
+                SET origin = 'legacy', confidence = NULL
+                WHERE alias_slug = 'removed-by-seed'
+                """
+            )
+        )
+        seed_genre_taxonomy(session)
+
+    with read_scope() as session:
+        active_assertions = session.execute(
+            text(
+                """
+                SELECT COUNT(*)
+                FROM global_catalog_genre_assertions assertion
+                JOIN global_catalog_sources source ON source.id = assertion.source_id
+                WHERE source.local_entity_uid = CAST(:artist_uid AS uuid)
+                  AND assertion.invalidated_at IS NULL
+                """
+            ),
+            {"artist_uid": artist_uid},
+        ).scalar_one()
+        memberships = session.execute(
+            text(
+                """
+                SELECT COUNT(*)
+                FROM global_catalog_entity_genres membership
+                JOIN global_catalog_sources source
+                  ON source.entity_type = membership.entity_type
+                 AND source.global_entity_uid = membership.global_entity_uid
+                WHERE source.local_entity_uid = CAST(:artist_uid AS uuid)
+                """
+            ),
+            {"artist_uid": artist_uid},
+        ).scalar_one()
+
+    assert active_assertions == 0
+    assert memberships == 0
+
+
 def test_changing_local_genres_requeues_only_that_catalog_source(pg_db):
     from crate.db.repositories.genres_assignments import set_artist_genres
     from crate.db.tx import read_scope

--- a/app/tests/test_global_genre_alias_repair_migration.py
+++ b/app/tests/test_global_genre_alias_repair_migration.py
@@ -1,0 +1,27 @@
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+MIGRATION_PATH = (
+    ROOT
+    / "app/crate/db/migrations/versions/078_repair_global_genre_alias_assertions.py"
+)
+
+
+def test_global_genre_alias_repair_migration_is_revision_078() -> None:
+    migration = MIGRATION_PATH.read_text()
+
+    assert 'revision = "078"' in migration
+    assert 'down_revision = "077"' in migration
+
+
+def test_global_genre_alias_repair_migration_is_scoped_and_set_based() -> None:
+    migration = MIGRATION_PATH.read_text()
+
+    assert "mapping_method IN ('local_alias', 'receiver_mapping')" in migration
+    assert "alias.origin <> 'legacy'" not in migration
+    assert "UPDATE global_catalog_genre_assertions" in migration
+    assert "DELETE FROM global_catalog_entity_genres" in migration
+    assert "INSERT INTO global_catalog_entity_genres" in migration
+    assert "CREATE TEMP TABLE crate_stale_genre_alias_assertions" in migration
+    assert "SELECT DISTINCT entity_type, global_entity_uid" in migration

--- a/app/tests/test_postgres_test_database.py
+++ b/app/tests/test_postgres_test_database.py
@@ -32,7 +32,7 @@ def test_pg_db_uses_an_isolated_clone_of_the_initialized_template(pg_db) -> None
 
     assert database_name != TEST_DB_NAME
     assert database_name.startswith(f"{TEST_DB_NAME}_case_")
-    assert revision == "077"
+    assert revision == "078"
     assert admin_count >= 1
     assert os.environ["CRATE_POSTGRES_DB"] == database_name
 


### PR DESCRIPTION
## Summary

- prevent global genre projections from consuming unclassified legacy aliases
- repair stale alias-based assertions and rebuild only affected memberships
- add Alembic revision 078 for existing installations
- run the repair after taxonomy seeding only when legacy aliases were removed

## Root cause

Revision 077 introduced alias provenance and startup removed aliases classified as
`legacy`, but previously materialized `global_catalog_genre_assertions` and
`global_catalog_entity_genres` were left active. That made unrelated artists
appear in broad genre rooms; for example, the raw label `spanish` kept mapping
Viva Belgrado into `rock`.

The repair deliberately waits until an alias is absent. This preserves valid
aliases during chained 076 → 078 upgrades, where Alembic runs before the taxonomy
seed reclassifies the shipped aliases.

## Data and operational impact

- invalidates only active `local_alias`/`receiver_mapping` assertions whose
  canonical slug or current alias no longer resolves to the asserted genre
- deletes and rebuilds memberships only for affected canonical entities
- serializes runtime repair with a transaction-scoped advisory lock
- avoids a full repair scan on normal boots by running it only when the seed
  actually removed legacy aliases
- downgrade is intentionally data-preserving: it does not reactivate invalid
  mappings

## Validation

- 169 relevant backend tests passed
- migration matrix passed from empty, schema 049 and schema 063 snapshots
- regression coverage includes projection rejection, scoped repair, chained
  upgrade ordering and seed-triggered cleanup
- Ruff check/format passed
- Pyright passed for all changed modules
