### PR TITLE
fix(genres): align room ranking and artwork

### DIFF
--- a/app/crate/api/browse.py
+++ b/app/crate/api/browse.py
@@ -1,3 +1,5 @@
+import logging
+
 from fastapi import APIRouter, Request
 
 from crate.api.auth import _require_auth
@@ -8,6 +10,11 @@ from crate.api.curation import curated_playlists
 from crate.api.openapi_responses import AUTH_ERROR_RESPONSES
 from crate.api.schemas import BrowseExplorePageResponse
 from crate.db.cache_store import get_cache, set_cache
+from crate.db.queries.global_catalog import list_global_catalog_genres
+from crate.db.repositories.global_catalog_state import (
+    catalog_serves_global,
+    get_catalog_state,
+)
 
 router = APIRouter()
 router.include_router(artist_router)
@@ -15,6 +22,35 @@ router.include_router(album_router)
 router.include_router(media_router)
 
 _EXPLORE_PAGE_CACHE_TTL_SECONDS = 60
+log = logging.getLogger(__name__)
+
+
+def _explore_genres(local_genres: list[dict]) -> list[dict]:
+    try:
+        if not catalog_serves_global(get_catalog_state()):
+            return local_genres
+        global_genres = list_global_catalog_genres()
+    except Exception:
+        log.warning(
+            "Global genre summaries unavailable; using local Explore genres",
+            exc_info=True,
+        )
+        return local_genres
+
+    payloads = [
+        {
+            "name": genre["canonical_name"],
+            "slug": genre["canonical_slug"],
+            "cnt": int(genre.get("artist_count") or 0),
+            "count": int(genre.get("artist_count") or 0),
+            "description": genre.get("description"),
+            "top_artists": list(genre.get("top_artists") or []),
+            "cover_url": genre.get("cover_url"),
+        }
+        for genre in global_genres
+        if int(genre.get("artist_count") or 0) > 0
+    ]
+    return payloads or local_genres
 
 
 @router.get(
@@ -30,8 +66,10 @@ def api_browse_explore_page(request: Request):
     if cached is not None:
         return cached
 
+    filters = dict(api_browse_filters(request))
+    filters["genres"] = _explore_genres(list(filters.get("genres") or []))
     payload = {
-        "filters": api_browse_filters(request),
+        "filters": filters,
         "playlists": curated_playlists(request)[:8],
         "moods": api_browse_moods(request),
     }

--- a/app/crate/db/queries/global_catalog.py
+++ b/app/crate/db/queries/global_catalog.py
@@ -292,7 +292,11 @@ def list_global_catalog_genres() -> list[dict]:
                             membership.entity_type,
                             membership.global_entity_uid,
                             membership.global_genre_uid,
-                            membership.global_genre_uid AS direct_genre_uid
+                            membership.global_genre_uid AS direct_genre_uid,
+                            membership.direct_score,
+                            membership.aggregate_score,
+                            membership.supporting_source_count,
+                            membership.supporting_node_count
                         FROM global_catalog_entity_genres membership
                         WHERE membership.aggregate_score >= 0.700
                         UNION
@@ -300,7 +304,11 @@ def list_global_catalog_genres() -> list[dict]:
                             inherited.entity_type,
                             inherited.global_entity_uid,
                             parent.global_genre_uid,
-                            inherited.direct_genre_uid
+                            inherited.direct_genre_uid,
+                            inherited.direct_score,
+                            inherited.aggregate_score,
+                            inherited.supporting_source_count,
+                            inherited.supporting_node_count
                         FROM inherited
                         JOIN genre_taxonomy_nodes child
                           ON child.taxonomy_id = 'crate-core'
@@ -310,11 +318,87 @@ def list_global_catalog_genres() -> list[dict]:
                          AND edge.relation_type = 'parent'
                          AND edge.locked
                         JOIN genre_taxonomy_nodes parent ON parent.id = edge.target_genre_id
+                    ),
+                    artist_paths AS (
+                        SELECT
+                            inherited.global_genre_uid,
+                            artist.global_artist_uid,
+                            artist.canonical_name AS artist_name,
+                            artist.local_artist_id,
+                            artist.has_photo,
+                            (
+                                inherited.direct_genre_uid
+                                = inherited.global_genre_uid
+                            ) AS direct_membership,
+                            inherited.direct_score,
+                            inherited.aggregate_score,
+                            inherited.supporting_source_count,
+                            inherited.supporting_node_count,
+                            local_artist.listeners,
+                            local_artist.spotify_popularity,
+                            COALESCE(album_counts.album_count, 0)::integer
+                                AS album_count,
+                            ROW_NUMBER() OVER (
+                                PARTITION BY
+                                    inherited.global_genre_uid,
+                                    artist.global_artist_uid
+                                ORDER BY
+                                    (
+                                        inherited.direct_genre_uid
+                                        = inherited.global_genre_uid
+                                    ) DESC,
+                                    inherited.aggregate_score DESC,
+                                    inherited.direct_score DESC,
+                                    inherited.supporting_source_count DESC,
+                                    inherited.supporting_node_count DESC
+                            ) AS path_rank
+                        FROM inherited
+                        JOIN global_catalog_artists artist
+                          ON artist.global_artist_uid
+                           = inherited.global_entity_uid
+                        LEFT JOIN library_artists local_artist
+                          ON local_artist.id = artist.local_artist_id
+                        LEFT JOIN (
+                            SELECT
+                                global_artist_uid,
+                                COUNT(*)::integer AS album_count
+                            FROM global_catalog_albums
+                            GROUP BY global_artist_uid
+                        ) album_counts
+                          ON album_counts.global_artist_uid
+                           = artist.global_artist_uid
+                        WHERE inherited.entity_type = 'artist'
+                    ),
+                    ranked_artists AS (
+                        SELECT
+                            artist_paths.*,
+                            ROW_NUMBER() OVER (
+                                PARTITION BY global_genre_uid
+                                ORDER BY
+                                    direct_membership DESC,
+                                    aggregate_score DESC,
+                                    direct_score DESC,
+                                    supporting_source_count DESC,
+                                    supporting_node_count DESC,
+                                    listeners DESC NULLS LAST,
+                                    spotify_popularity DESC NULLS LAST,
+                                    album_count DESC,
+                                    artist_name ASC,
+                                    global_artist_uid ASC
+                            ) AS genre_rank
+                        FROM artist_paths
+                        WHERE path_rank = 1
+                          AND direct_membership
                     )
                     SELECT
                         taxonomy.global_genre_uid::text AS global_genre_uid,
                         taxonomy.slug AS canonical_slug,
                         taxonomy.name AS canonical_name,
+                        COALESCE(
+                            NULLIF(taxonomy.description, ''),
+                            NULLIF(taxonomy.external_description, '')
+                        ) AS description,
+                        taxonomy.cover_path,
                         COUNT(DISTINCT (
                             inherited.entity_type::text || ':' || inherited.global_entity_uid::text
                         ))::integer AS entity_count,
@@ -326,13 +410,56 @@ def list_global_catalog_genres() -> list[dict]:
                             AS album_count,
                         COUNT(DISTINCT inherited.global_entity_uid)
                             FILTER (WHERE inherited.entity_type = 'track')::integer
-                            AS track_count
+                            AS track_count,
+                        top_artists.top_artists,
+                        top_artists.top_artist_global_uid,
+                        top_artists.top_artist_id,
+                        top_artists.top_artist_has_photo
                     FROM genre_taxonomy_nodes taxonomy
                     LEFT JOIN inherited
                       ON inherited.global_genre_uid = taxonomy.global_genre_uid
+                    LEFT JOIN LATERAL (
+                        SELECT
+                            ARRAY_AGG(
+                                ranked.artist_name
+                                ORDER BY ranked.genre_rank
+                            ) AS top_artists,
+                            (
+                                ARRAY_AGG(
+                                    ranked.global_artist_uid::text
+                                    ORDER BY ranked.genre_rank
+                                )
+                            )[1] AS top_artist_global_uid,
+                            (
+                                ARRAY_AGG(
+                                    ranked.local_artist_id
+                                    ORDER BY ranked.genre_rank
+                                )
+                            )[1] AS top_artist_id,
+                            (
+                                ARRAY_AGG(
+                                    ranked.has_photo
+                                    ORDER BY ranked.genre_rank
+                                )
+                            )[1] AS top_artist_has_photo
+                        FROM ranked_artists ranked
+                        WHERE ranked.global_genre_uid
+                            = taxonomy.global_genre_uid
+                          AND ranked.genre_rank <= 3
+                    ) top_artists ON TRUE
                     WHERE taxonomy.taxonomy_id = 'crate-core'
                       AND taxonomy.origin = 'core'
-                    GROUP BY taxonomy.global_genre_uid, taxonomy.slug, taxonomy.name
+                    GROUP BY
+                        taxonomy.global_genre_uid,
+                        taxonomy.slug,
+                        taxonomy.name,
+                        taxonomy.description,
+                        taxonomy.external_description,
+                        taxonomy.cover_path,
+                        top_artists.top_artists,
+                        top_artists.top_artist_global_uid,
+                        top_artists.top_artist_id,
+                        top_artists.top_artist_has_photo
                     ORDER BY entity_count DESC, taxonomy.name ASC
                     """
                 )
@@ -340,7 +467,26 @@ def list_global_catalog_genres() -> list[dict]:
             .mappings()
             .all()
         )
-    return [dict(row) for row in rows]
+    payloads = []
+    for row in rows:
+        payload = dict(row)
+        payload["top_artists"] = list(payload.get("top_artists") or [])
+        cover_path = str(payload.pop("cover_path", "") or "").strip()
+        top_artist_has_photo = bool(payload.pop("top_artist_has_photo", False))
+        if cover_path:
+            payload["cover_url"] = genre_cover_public_url(
+                str(payload["canonical_slug"]),
+                size=640,
+            )
+        elif payload.get("top_artist_global_uid") and top_artist_has_photo:
+            payload["cover_url"] = (
+                f"/api/catalog/artists/{payload['top_artist_global_uid']}"
+                "/background?size=640&format=webp"
+            )
+        else:
+            payload["cover_url"] = None
+        payloads.append(payload)
+    return payloads
 
 
 def get_global_genre_detail(slug: str) -> dict | None:
@@ -446,7 +592,10 @@ _GLOBAL_GENRE_ARTISTS_SQL = text(
             membership.global_entity_uid,
             membership.global_genre_uid,
             membership.global_genre_uid AS direct_genre_uid,
-            membership.supporting_source_count
+            membership.direct_score,
+            membership.aggregate_score,
+            membership.supporting_source_count,
+            membership.supporting_node_count
         FROM global_catalog_entity_genres membership
         WHERE membership.entity_type = 'artist'
           AND membership.aggregate_score >= 0.700
@@ -456,7 +605,10 @@ _GLOBAL_GENRE_ARTISTS_SQL = text(
             inherited.global_entity_uid,
             parent.global_genre_uid,
             inherited.direct_genre_uid,
-            inherited.supporting_source_count
+            inherited.direct_score,
+            inherited.aggregate_score,
+            inherited.supporting_source_count,
+            inherited.supporting_node_count
         FROM inherited
         JOIN genre_taxonomy_nodes child
           ON child.taxonomy_id = 'crate-core'
@@ -466,45 +618,97 @@ _GLOBAL_GENRE_ARTISTS_SQL = text(
          AND edge.relation_type = 'parent'
          AND edge.locked
         JOIN genre_taxonomy_nodes parent ON parent.id = edge.target_genre_id
+    ),
+    ranked AS (
+        SELECT
+            artist.global_artist_uid::text AS global_artist_uid,
+            artist.canonical_name AS artist_name,
+            artist.local_artist_id AS artist_id,
+            artist.local_artist_entity_uid::text AS artist_entity_uid,
+            local_artist.slug AS artist_slug,
+            COALESCE(album_counts.album_count, 0)::integer AS album_count,
+            COALESCE(track_counts.track_count, 0)::integer AS track_count,
+            artist.has_photo,
+            CASE WHEN artist.has_photo
+                THEN '/api/catalog/artists/' || artist.global_artist_uid::text || '/photo'
+                ELSE NULL
+            END AS photo_url,
+            local_artist.listeners,
+            local_artist.spotify_popularity,
+            (
+                inherited.direct_genre_uid
+                = inherited.global_genre_uid
+            ) AS direct_membership,
+            inherited.direct_score::double precision AS direct_score,
+            inherited.aggregate_score::double precision AS aggregate_score,
+            inherited.supporting_source_count,
+            inherited.supporting_node_count,
+            ROW_NUMBER() OVER (
+                PARTITION BY artist.global_artist_uid
+                ORDER BY
+                    (
+                        inherited.direct_genre_uid
+                        = inherited.global_genre_uid
+                    ) DESC,
+                    inherited.aggregate_score DESC,
+                    inherited.direct_score DESC,
+                    inherited.supporting_source_count DESC,
+                    inherited.supporting_node_count DESC
+            ) AS path_rank
+        FROM inherited
+        JOIN global_catalog_artists artist
+          ON artist.global_artist_uid = inherited.global_entity_uid
+        LEFT JOIN library_artists local_artist
+          ON local_artist.id = artist.local_artist_id
+        LEFT JOIN (
+            SELECT global_artist_uid, COUNT(*)::integer AS album_count
+            FROM global_catalog_albums
+            GROUP BY global_artist_uid
+        ) album_counts
+          ON album_counts.global_artist_uid = artist.global_artist_uid
+        LEFT JOIN (
+            SELECT global_artist_uid, COUNT(*)::integer AS track_count
+            FROM global_catalog_tracks
+            GROUP BY global_artist_uid
+        ) track_counts
+          ON track_counts.global_artist_uid = artist.global_artist_uid
+        WHERE inherited.global_genre_uid
+            = CAST(:global_genre_uid AS uuid)
     )
-    SELECT DISTINCT ON (artist.global_artist_uid)
-        artist.global_artist_uid::text AS global_artist_uid,
-        artist.canonical_name AS artist_name,
-        artist.local_artist_id AS artist_id,
-        artist.local_artist_entity_uid::text AS artist_entity_uid,
-        local_artist.slug AS artist_slug,
-        COALESCE(album_counts.album_count, 0)::integer AS album_count,
-        COALESCE(track_counts.track_count, 0)::integer AS track_count,
-        artist.has_photo,
-        CASE WHEN artist.has_photo
-            THEN '/api/catalog/artists/' || artist.global_artist_uid::text || '/photo'
-            ELSE NULL
-        END AS photo_url,
-        local_artist.listeners,
+    SELECT
+        global_artist_uid,
+        artist_name,
+        artist_id,
+        artist_entity_uid,
+        artist_slug,
+        album_count,
+        track_count,
+        has_photo,
+        photo_url,
+        listeners,
+        spotify_popularity,
         CASE
-            WHEN inherited.direct_genre_uid = CAST(:global_genre_uid AS uuid)
-            THEN 'direct'
+            WHEN direct_membership THEN 'direct'
             ELSE 'inherited'
         END AS membership,
-        inherited.supporting_source_count
-    FROM inherited
-    JOIN global_catalog_artists artist
-      ON artist.global_artist_uid = inherited.global_entity_uid
-    LEFT JOIN library_artists local_artist ON local_artist.id = artist.local_artist_id
-    LEFT JOIN (
-        SELECT global_artist_uid, COUNT(*)::integer AS album_count
-        FROM global_catalog_albums
-        GROUP BY global_artist_uid
-    ) album_counts ON album_counts.global_artist_uid = artist.global_artist_uid
-    LEFT JOIN (
-        SELECT global_artist_uid, COUNT(*)::integer AS track_count
-        FROM global_catalog_tracks
-        GROUP BY global_artist_uid
-    ) track_counts ON track_counts.global_artist_uid = artist.global_artist_uid
-    WHERE inherited.global_genre_uid = CAST(:global_genre_uid AS uuid)
-    ORDER BY artist.global_artist_uid,
-             (inherited.direct_genre_uid = CAST(:global_genre_uid AS uuid)) DESC,
-             inherited.supporting_source_count DESC
+        direct_score,
+        aggregate_score,
+        aggregate_score AS membership_score,
+        supporting_source_count,
+        supporting_node_count
+    FROM ranked
+    WHERE path_rank = 1
+    ORDER BY
+        direct_membership DESC,
+        aggregate_score DESC,
+        direct_score DESC,
+        supporting_source_count DESC,
+        supporting_node_count DESC,
+        listeners DESC NULLS LAST,
+        spotify_popularity DESC NULLS LAST,
+        album_count DESC,
+        artist_name ASC,
+        global_artist_uid ASC
     """
 )
 
@@ -517,7 +721,10 @@ _GLOBAL_GENRE_ALBUMS_SQL = text(
             membership.global_entity_uid,
             membership.global_genre_uid,
             membership.global_genre_uid AS direct_genre_uid,
-            membership.supporting_source_count
+            membership.direct_score,
+            membership.aggregate_score,
+            membership.supporting_source_count,
+            membership.supporting_node_count
         FROM global_catalog_entity_genres membership
         WHERE membership.entity_type = 'album'
           AND membership.aggregate_score >= 0.700
@@ -527,7 +734,10 @@ _GLOBAL_GENRE_ALBUMS_SQL = text(
             inherited.global_entity_uid,
             parent.global_genre_uid,
             inherited.direct_genre_uid,
-            inherited.supporting_source_count
+            inherited.direct_score,
+            inherited.aggregate_score,
+            inherited.supporting_source_count,
+            inherited.supporting_node_count
         FROM inherited
         JOIN genre_taxonomy_nodes child
           ON child.taxonomy_id = 'crate-core'
@@ -537,40 +747,95 @@ _GLOBAL_GENRE_ALBUMS_SQL = text(
          AND edge.relation_type = 'parent'
          AND edge.locked
         JOIN genre_taxonomy_nodes parent ON parent.id = edge.target_genre_id
+    ),
+    ranked AS (
+        SELECT
+            album.global_album_uid::text AS global_album_uid,
+            album.local_album_id AS album_id,
+            album.local_album_entity_uid::text AS album_entity_uid,
+            local_album.slug AS album_slug,
+            album.artist_name AS artist,
+            artist.local_artist_id AS artist_id,
+            artist.local_artist_entity_uid::text AS artist_entity_uid,
+            local_artist.slug AS artist_slug,
+            album.canonical_name AS name,
+            COALESCE(album.year, '') AS year,
+            COALESCE(album.track_count, 0)::integer AS track_count,
+            album.has_cover,
+            CASE WHEN album.has_cover
+                THEN '/api/catalog/albums/' || album.global_album_uid::text || '/cover'
+                ELSE NULL
+            END AS cover_url,
+            (
+                inherited.direct_genre_uid
+                = inherited.global_genre_uid
+            ) AS direct_membership,
+            inherited.direct_score::double precision AS direct_score,
+            inherited.aggregate_score::double precision AS aggregate_score,
+            inherited.supporting_source_count,
+            inherited.supporting_node_count,
+            local_album.popularity,
+            local_album.lastfm_playcount,
+            ROW_NUMBER() OVER (
+                PARTITION BY album.global_album_uid
+                ORDER BY
+                    (
+                        inherited.direct_genre_uid
+                        = inherited.global_genre_uid
+                    ) DESC,
+                    inherited.aggregate_score DESC,
+                    inherited.direct_score DESC,
+                    inherited.supporting_source_count DESC,
+                    inherited.supporting_node_count DESC
+            ) AS path_rank
+        FROM inherited
+        JOIN global_catalog_albums album
+          ON album.global_album_uid = inherited.global_entity_uid
+        JOIN global_catalog_artists artist
+          ON artist.global_artist_uid = album.global_artist_uid
+        LEFT JOIN library_albums local_album
+          ON local_album.id = album.local_album_id
+        LEFT JOIN library_artists local_artist
+          ON local_artist.id = artist.local_artist_id
+        WHERE inherited.global_genre_uid
+            = CAST(:global_genre_uid AS uuid)
     )
-    SELECT DISTINCT ON (album.global_album_uid)
-        album.global_album_uid::text AS global_album_uid,
-        album.local_album_id AS album_id,
-        album.local_album_entity_uid::text AS album_entity_uid,
-        local_album.slug AS album_slug,
-        album.artist_name AS artist,
-        artist.local_artist_id AS artist_id,
-        artist.local_artist_entity_uid::text AS artist_entity_uid,
-        local_artist.slug AS artist_slug,
-        album.canonical_name AS name,
-        COALESCE(album.year, '') AS year,
-        COALESCE(album.track_count, 0)::integer AS track_count,
-        album.has_cover,
-        CASE WHEN album.has_cover
-            THEN '/api/catalog/albums/' || album.global_album_uid::text || '/cover'
-            ELSE NULL
-        END AS cover_url,
+    SELECT
+        global_album_uid,
+        album_id,
+        album_entity_uid,
+        album_slug,
+        artist,
+        artist_id,
+        artist_entity_uid,
+        artist_slug,
+        name,
+        year,
+        track_count,
+        has_cover,
+        cover_url,
         CASE
-            WHEN inherited.direct_genre_uid = CAST(:global_genre_uid AS uuid)
-            THEN 'direct'
+            WHEN direct_membership THEN 'direct'
             ELSE 'inherited'
         END AS membership,
-        inherited.supporting_source_count
-    FROM inherited
-    JOIN global_catalog_albums album
-      ON album.global_album_uid = inherited.global_entity_uid
-    JOIN global_catalog_artists artist ON artist.global_artist_uid = album.global_artist_uid
-    LEFT JOIN library_albums local_album ON local_album.id = album.local_album_id
-    LEFT JOIN library_artists local_artist ON local_artist.id = artist.local_artist_id
-    WHERE inherited.global_genre_uid = CAST(:global_genre_uid AS uuid)
-    ORDER BY album.global_album_uid,
-             (inherited.direct_genre_uid = CAST(:global_genre_uid AS uuid)) DESC,
-             inherited.supporting_source_count DESC
+        direct_score,
+        aggregate_score,
+        aggregate_score AS membership_score,
+        supporting_source_count,
+        supporting_node_count
+    FROM ranked
+    WHERE path_rank = 1
+    ORDER BY
+        direct_membership DESC,
+        aggregate_score DESC,
+        direct_score DESC,
+        supporting_source_count DESC,
+        supporting_node_count DESC,
+        popularity DESC NULLS LAST,
+        lastfm_playcount DESC NULLS LAST,
+        year DESC,
+        name ASC,
+        global_album_uid ASC
     """
 )
 

--- a/app/listen/src/components/explore/ExploreViews.tsx
+++ b/app/listen/src/components/explore/ExploreViews.tsx
@@ -836,7 +836,7 @@ function buildGenreHeroCoverCandidates(
   const fallbackArtistBackground =
     buildGenreHeroArtistBackgroundFallback(artists);
   const fallback =
-    !generatedArtistCover && fallbackSlug && (url || !fallbackArtistBackground)
+    !generatedArtistCover && url && fallbackSlug
       ? upscaleGenreCoverUrl(undefined, fallbackSlug)
       : null;
 
@@ -853,13 +853,14 @@ function buildGenreHeroArtistBackgroundFallback(
   artists?: GenreDetail["artists"],
 ) {
   if (!artists?.length) return null;
-  const topArtist = artists.find(
-    (artist) =>
-      (artist.artist_id != null || artist.global_artist_uid) &&
-      artist.has_photo,
-  );
+  const topArtist = artists[0];
 
-  if (!topArtist?.artist_id && !topArtist?.global_artist_uid) return null;
+  if (
+    !topArtist?.has_photo ||
+    (!topArtist.artist_id && !topArtist.global_artist_uid)
+  ) {
+    return null;
+  }
 
   const resolved = artistBackgroundApiUrl(
     {

--- a/app/listen/src/pages/Explore.test.tsx
+++ b/app/listen/src/pages/Explore.test.tsx
@@ -463,8 +463,21 @@ describe("Explore", () => {
     }
   });
 
-  it("falls back to the canonical genre cover when cached detail has no cover url", () => {
-    mockGenreDetail({ coverUrl: null });
+  it("uses the first ranked artist when the genre has no curated cover", () => {
+    mockGenreDetail({
+      coverUrl: null,
+      artists: [
+        {
+          artist_id: 111,
+          artist_name: "Top Ranked Artist",
+          artist_slug: "top-ranked-artist",
+          album_count: 3,
+          track_count: 6,
+          has_photo: true,
+          listeners: 120,
+        },
+      ],
+    });
 
     renderWithListenProviders(<Explore />, {
       route: "/explore?genre=hardcore",
@@ -473,7 +486,7 @@ describe("Explore", () => {
 
     expect(screen.getByAltText("hardcore genre cover")).toHaveAttribute(
       "src",
-      "/api/genres/hardcore-punk/cover?size=1280&format=webp",
+      "/api/artists/111/background?size=1280&format=webp",
     );
   });
 
@@ -538,6 +551,39 @@ describe("Explore", () => {
     );
   });
 
+  it("does not skip the first ranked artist when selecting fallback artwork", () => {
+    mockGenreDetail({
+      coverUrl: null,
+      artists: [
+        {
+          artist_id: 111,
+          artist_name: "Top Artist Without Artwork",
+          artist_slug: "top-artist-without-artwork",
+          album_count: 3,
+          track_count: 6,
+          has_photo: false,
+          listeners: 120,
+        },
+        {
+          artist_id: 222,
+          artist_name: "Second Artist With Artwork",
+          artist_slug: "second-artist-with-artwork",
+          album_count: 5,
+          track_count: 9,
+          has_photo: true,
+          listeners: 999,
+        },
+      ],
+    });
+
+    renderWithListenProviders(<Explore />, {
+      route: "/explore?genre=hardcore",
+      path: "/explore",
+    });
+
+    expect(screen.queryByAltText("hardcore genre cover")).toBeNull();
+  });
+
   it("rebuilds cached generated hero URLs through the invalidation-aware helper", () => {
     recordAssetInvalidationScope("artist:222", "artist-artwork-222");
     mockGenreDetail({
@@ -568,15 +614,13 @@ describe("Explore", () => {
     );
   });
 
-  it("unmounts the genre hero after every artwork candidate fails", () => {
+  it("does not probe an absent canonical cover without a ranked artist", () => {
     mockGenreDetail({ coverUrl: null, artists: [] });
 
     renderWithListenProviders(<Explore />, {
       route: "/explore?genre=hardcore",
       path: "/explore",
     });
-
-    fireEvent.error(screen.getByAltText("hardcore genre cover"));
 
     expect(screen.queryByAltText("hardcore genre cover")).toBeNull();
   });

--- a/app/tests/test_catalog_genres_api.py
+++ b/app/tests/test_catalog_genres_api.py
@@ -1,11 +1,161 @@
 import uuid
 
 import pytest
+from sqlalchemy import text
 
 from tests.conftest import PG_AVAILABLE
 
 
 pytestmark = pytest.mark.skipif(not PG_AVAILABLE, reason="PostgreSQL not available")
+
+
+def test_global_genre_surfaces_rank_members_by_score_and_share_top_artwork(pg_db):
+    from crate.db.queries.global_catalog import (
+        get_global_genre_detail,
+        list_global_catalog_genres,
+    )
+    from crate.federation.global_reconciliation import reconcile_dirty_catalog_sources
+
+    pg_db.upsert_artist(
+        {
+            "name": "BLOCKHEADS",
+            "entity_uid": "a830063d-44e2-56a4-a0d8-1918026587f7",
+            "has_photo": 1,
+            "listeners": 34_347,
+        }
+    )
+    pg_db.upsert_artist(
+        {
+            "name": "Death",
+            "entity_uid": "12f95d32-ccbb-58a2-b004-79b88ef7389b",
+            "has_photo": 1,
+            "listeners": 1_031_836,
+        }
+    )
+    pg_db.set_artist_genres("BLOCKHEADS", [("death metal", 0.76, "test")])
+    pg_db.set_artist_genres("Death", [("death metal", 1.0, "test")])
+    assert reconcile_dirty_catalog_sources(limit=10)["completed"] == 2
+
+    detail = get_global_genre_detail("death-metal")
+    summary = next(
+        item
+        for item in list_global_catalog_genres()
+        if item["canonical_slug"] == "death-metal"
+    )
+
+    assert [artist["artist_name"] for artist in detail["artists"][:2]] == [
+        "Death",
+        "BLOCKHEADS",
+    ]
+    assert detail["artists"][0]["aggregate_score"] == 1.0
+    assert detail["artists"][1]["aggregate_score"] == 0.76
+    assert summary["top_artists"][:2] == ["Death", "BLOCKHEADS"]
+    assert summary["top_artist_global_uid"] == detail["artists"][0]["global_artist_uid"]
+    assert summary["cover_url"] == (
+        f"/api/catalog/artists/{detail['artists'][0]['global_artist_uid']}"
+        "/background?size=640&format=webp"
+    )
+
+
+def test_global_genre_summary_prefers_curated_cover_over_top_artist(pg_db):
+    from crate.db.queries.global_catalog import list_global_catalog_genres
+    from crate.db.tx import transaction_scope
+    from crate.federation.global_reconciliation import reconcile_dirty_catalog_sources
+
+    pg_db.upsert_artist(
+        {
+            "name": "Covered Genre Artist",
+            "entity_uid": str(uuid.uuid4()),
+            "has_photo": 1,
+        }
+    )
+    pg_db.set_artist_genres(
+        "Covered Genre Artist",
+        [("post-hardcore", 1.0, "test")],
+    )
+    assert reconcile_dirty_catalog_sources(limit=10)["completed"] == 1
+    with transaction_scope() as session:
+        session.execute(
+            text(
+                """
+                UPDATE genre_taxonomy_nodes
+                SET cover_path = 'post-hardcore.webp'
+                WHERE taxonomy_id = 'crate-core'
+                  AND slug = 'post-hardcore'
+                """
+            )
+        )
+
+    summary = next(
+        item
+        for item in list_global_catalog_genres()
+        if item["canonical_slug"] == "post-hardcore"
+    )
+
+    assert summary["top_artists"] == ["Covered Genre Artist"]
+    assert summary["cover_url"] == (
+        "/api/genres/post-hardcore/cover?size=640&format=webp"
+    )
+
+
+def test_global_genre_detail_ranks_albums_by_membership_not_uuid(pg_db):
+    from crate.db.queries.global_catalog import get_global_genre_detail
+    from crate.db.tx import read_scope
+    from crate.federation.global_reconciliation import reconcile_dirty_catalog_sources
+
+    pg_db.upsert_artist(
+        {
+            "name": "Album Rank Artist",
+            "entity_uid": str(uuid.uuid4()),
+        }
+    )
+    album_ids = [
+        pg_db.upsert_album(
+            {
+                "artist": "Album Rank Artist",
+                "name": name,
+                "entity_uid": str(uuid.uuid4()),
+                "path": f"/music/Album Rank Artist/{name}",
+            }
+        )
+        for name in ("Lower Membership", "Full Membership")
+    ]
+    assert reconcile_dirty_catalog_sources(limit=10)["completed"] == 3
+    with read_scope() as session:
+        rows = (
+            session.execute(
+                text(
+                    """
+                    SELECT local_album_id, global_album_uid::text AS global_album_uid
+                    FROM global_catalog_albums
+                    WHERE local_album_id = ANY(:album_ids)
+                    ORDER BY global_album_uid
+                    """
+                ),
+                {"album_ids": album_ids},
+            )
+            .mappings()
+            .all()
+        )
+    album_name_by_id = dict(zip(album_ids, ("Lower Membership", "Full Membership")))
+    uuid_first_id = int(rows[0]["local_album_id"])
+    uuid_last_id = int(rows[1]["local_album_id"])
+    pg_db.set_album_genres(uuid_first_id, [("death metal", 0.70, "test")])
+    pg_db.set_album_genres(uuid_last_id, [("death metal", 1.0, "test")])
+    assert reconcile_dirty_catalog_sources(limit=10)["completed"] == 2
+
+    detail = get_global_genre_detail("death-metal")
+    ranked = [
+        album
+        for album in detail["albums"]
+        if album["album_id"] in {uuid_first_id, uuid_last_id}
+    ]
+
+    assert [album["name"] for album in ranked] == [
+        album_name_by_id[uuid_last_id],
+        album_name_by_id[uuid_first_id],
+    ]
+    assert [album["aggregate_score"] for album in ranked] == [1.0, 0.7]
 
 
 def test_global_genre_detail_expands_core_parent_hierarchy_at_read_time(pg_db):

--- a/app/tests/test_explore_contracts.py
+++ b/app/tests/test_explore_contracts.py
@@ -107,6 +107,133 @@ class TestExploreFiltersContract:
             assert data["playlists"][0]["name"] == "Playlist 1"
             assert data["moods"][0]["name"] == "energetic"
 
+    def test_explore_page_uses_global_genre_ranking_and_artwork_when_ready(
+        self,
+        test_app,
+        monkeypatch,
+    ):
+        from crate.api import browse
+
+        monkeypatch.setattr(
+            browse,
+            "get_catalog_state",
+            lambda: {"status": "ready", "last_full_reconcile_at": object()},
+            raising=False,
+        )
+        monkeypatch.setattr(
+            browse,
+            "catalog_serves_global",
+            lambda state: state["status"] == "ready",
+            raising=False,
+        )
+        monkeypatch.setattr(
+            browse,
+            "list_global_catalog_genres",
+            lambda: [
+                {
+                    "canonical_name": "Death Metal",
+                    "canonical_slug": "death-metal",
+                    "artist_count": 2,
+                    "description": "Extreme metal rooted in speed and precision.",
+                    "top_artists": ["Death", "BLOCKHEADS"],
+                    "cover_url": (
+                        "/api/catalog/artists/death-global/background"
+                        "?size=640&format=webp"
+                    ),
+                }
+            ],
+            raising=False,
+        )
+
+        with (
+            patch(
+                "crate.api.browse.api_browse_filters",
+                return_value={
+                    "genres": [{"name": "Legacy Genre", "count": 99}],
+                    "countries": [],
+                    "decades": [],
+                    "formats": [],
+                },
+            ),
+            patch("crate.api.browse.curated_playlists", return_value=[]),
+            patch("crate.api.browse.api_browse_moods", return_value=[]),
+            patch("crate.api.browse.get_cache", return_value=None),
+            patch("crate.api.browse.set_cache"),
+        ):
+            response = test_app.get("/api/browse/explore-page")
+
+        assert response.status_code == 200
+        assert response.json()["filters"]["genres"] == [
+            {
+                "name": "Death Metal",
+                "slug": "death-metal",
+                "cnt": 2,
+                "count": 2,
+                "description": "Extreme metal rooted in speed and precision.",
+                "top_artists": ["Death", "BLOCKHEADS"],
+                "cover_url": (
+                    "/api/catalog/artists/death-global/background?size=640&format=webp"
+                ),
+            }
+        ]
+
+    def test_explore_page_keeps_local_genres_during_catalog_warming(
+        self,
+        test_app,
+        monkeypatch,
+    ):
+        from crate.api import browse
+
+        monkeypatch.setattr(
+            browse,
+            "get_catalog_state",
+            lambda: {"status": "backfilling", "last_full_reconcile_at": None},
+            raising=False,
+        )
+        monkeypatch.setattr(
+            browse,
+            "catalog_serves_global",
+            lambda state: False,
+            raising=False,
+        )
+        monkeypatch.setattr(
+            browse,
+            "list_global_catalog_genres",
+            MagicMock(side_effect=AssertionError("global genres must not be read")),
+            raising=False,
+        )
+        local_genres = [{"name": "Local Genre", "count": 4}]
+
+        with (
+            patch(
+                "crate.api.browse.api_browse_filters",
+                return_value={
+                    "genres": local_genres,
+                    "countries": [],
+                    "decades": [],
+                    "formats": [],
+                },
+            ),
+            patch("crate.api.browse.curated_playlists", return_value=[]),
+            patch("crate.api.browse.api_browse_moods", return_value=[]),
+            patch("crate.api.browse.get_cache", return_value=None),
+            patch("crate.api.browse.set_cache"),
+        ):
+            response = test_app.get("/api/browse/explore-page")
+
+        assert response.status_code == 200
+        assert response.json()["filters"]["genres"] == [
+            {
+                "name": "Local Genre",
+                "slug": None,
+                "cnt": None,
+                "count": 4,
+                "description": None,
+                "top_artists": [],
+                "cover_url": None,
+            }
+        ]
+
 
 class TestExploreSearchContract:
     def test_search_short_query_still_returns_tracks_key(self, test_app):


### PR DESCRIPTION
## Qué cambia

- ordena artistas y álbumes de genre rooms por pertenencia, score y señales de calidad, dejando el UUID únicamente como desempate final
- usa el catálogo global en las cards de Explore cuando el read model está listo, con fallback local durante warming
- unifica la selección de artwork entre card y hero: cover curada si existe; si no, imagen del artista #1
- evita saltar al artista #2 o sondear covers que el API ha declarado inexistentes
- añade score y metadatos de ranking al contrato de detalle para hacerlo observable

## Causa raíz

El detalle global eliminaba duplicados con `DISTINCT ON` y terminaba ordenando por UUID. En paralelo, las cards seguían usando el browse local y el hero buscaba el primer artista con foto, no necesariamente el artista #1. Esto producía rankings arbitrarios —por ejemplo BLOCKHEADS antes que Death— e imágenes diferentes entre card y room.

## Impacto

El orden ahora es determinista y semántico. Explore conserva disponibilidad durante reconciliaciones parciales y la política visual es idéntica en web/native.

## Validación

- 57 tests backend relevantes
- 1.525 tests de Listen (4 skipped)
- 23 tests focalizados de Explore
- TypeScript typecheck y ESLint
- Ruff y Pyright en archivos tocados
- Prettier
- build de producción de Listen