### PR TITLE
fix(proxy): enable readplane GET and HEAD routes

### DIFF
--- a/app/tests/test_readplane_route_manifest.py
+++ b/app/tests/test_readplane_route_manifest.py
@@ -94,3 +94,14 @@ def test_api_domain_routes_readplane_classes_with_explicit_priority():
         "PathPrefix(`/api/federation/remote/streams/`)"
         in labels["traefik.http.routers.crate-readplane-stream.rule"]
     )
+
+
+def test_traefik_v3_method_matchers_keep_get_and_head_routers_enabled():
+    for compose_name in ("docker-compose.yaml", "docker-compose.home.yaml"):
+        compose = yaml.safe_load((ROOT / compose_name).read_text())
+        labels = compose["services"]["crate-readplane"]["labels"]
+
+        for router_name in ("interactive", "stream"):
+            rule = labels[f"traefik.http.routers.crate-readplane-{router_name}.rule"]
+            assert "Method(`GET`, `HEAD`)" not in rule
+            assert "(Method(`GET`) || Method(`HEAD`))" in rule

--- a/docker-compose.home.yaml
+++ b/docker-compose.home.yaml
@@ -349,7 +349,7 @@ services:
     labels:
       traefik.enable: true
       traefik.docker.network: crate
-      traefik.http.routers.crate-readplane-interactive.rule: Host(`api.${DOMAIN:-localhost}`) && Method(`GET`, `HEAD`) && (PathPrefix(`/api/catalog/`) || PathPrefix(`/api/me/home/`) || PathPrefix(`/api/me/albums`) || PathPrefix(`/api/me/follows`) || PathPrefix(`/api/genres`) || PathPrefix(`/api/artists/`) || PathPrefix(`/api/artist-slugs/`) || PathPrefix(`/api/albums/`) || Path(`/api/auth/me`) || Path(`/api/me`) || Path(`/api/me/history`) || Path(`/api/me/likes`) || Path(`/api/me/stats/dashboard`) || Path(`/api/search`) || Path(`/api/favorites`))
+      traefik.http.routers.crate-readplane-interactive.rule: Host(`api.${DOMAIN:-localhost}`) && (Method(`GET`) || Method(`HEAD`)) && (PathPrefix(`/api/catalog/`) || PathPrefix(`/api/me/home/`) || PathPrefix(`/api/me/albums`) || PathPrefix(`/api/me/follows`) || PathPrefix(`/api/genres`) || PathPrefix(`/api/artists/`) || PathPrefix(`/api/artist-slugs/`) || PathPrefix(`/api/albums/`) || Path(`/api/auth/me`) || Path(`/api/me`) || Path(`/api/me/history`) || Path(`/api/me/likes`) || Path(`/api/me/stats/dashboard`) || Path(`/api/search`) || Path(`/api/favorites`))
       traefik.http.routers.crate-readplane-interactive.entryPoints: ${TRAEFIK_SECURE_ENTRYPOINT:-websecure}
       traefik.http.routers.crate-readplane-interactive.middlewares: crate-api-compress@docker
       traefik.http.routers.crate-readplane-interactive.priority: 100
@@ -362,7 +362,7 @@ services:
       traefik.http.routers.crate-readplane-sse.service: crate-readplane-sse@file
       traefik.http.routers.crate-readplane-sse.tls: ${TRAEFIK_TLS_ENABLED:-true}
       traefik.http.routers.crate-readplane-sse.tls.certresolver: ${TRAEFIK_CERT_RESOLVER-}
-      traefik.http.routers.crate-readplane-stream.rule: Host(`api.${DOMAIN:-localhost}`) && Method(`GET`, `HEAD`) && (PathPrefix(`/api/federation/remote/streams/`) || PathPrefix(`/api/tracks/`))
+      traefik.http.routers.crate-readplane-stream.rule: Host(`api.${DOMAIN:-localhost}`) && (Method(`GET`) || Method(`HEAD`)) && (PathPrefix(`/api/federation/remote/streams/`) || PathPrefix(`/api/tracks/`))
       traefik.http.routers.crate-readplane-stream.entryPoints: ${TRAEFIK_SECURE_ENTRYPOINT:-websecure}
       traefik.http.routers.crate-readplane-stream.priority: 110
       traefik.http.routers.crate-readplane-stream.tls: ${TRAEFIK_TLS_ENABLED:-true}

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -440,7 +440,7 @@ services:
     labels:
       traefik.enable: true
       traefik.docker.network: crate
-      traefik.http.routers.crate-readplane-interactive.rule: Host(`api.${DOMAIN}`) && Method(`GET`, `HEAD`) && (PathPrefix(`/api/catalog/`) || PathPrefix(`/api/me/home/`) || PathPrefix(`/api/me/albums`) || PathPrefix(`/api/me/follows`) || PathPrefix(`/api/genres`) || PathPrefix(`/api/artists/`) || PathPrefix(`/api/artist-slugs/`) || PathPrefix(`/api/albums/`) || Path(`/api/auth/me`) || Path(`/api/me`) || Path(`/api/me/history`) || Path(`/api/me/likes`) || Path(`/api/me/stats/dashboard`) || Path(`/api/search`) || Path(`/api/favorites`))
+      traefik.http.routers.crate-readplane-interactive.rule: Host(`api.${DOMAIN}`) && (Method(`GET`) || Method(`HEAD`)) && (PathPrefix(`/api/catalog/`) || PathPrefix(`/api/me/home/`) || PathPrefix(`/api/me/albums`) || PathPrefix(`/api/me/follows`) || PathPrefix(`/api/genres`) || PathPrefix(`/api/artists/`) || PathPrefix(`/api/artist-slugs/`) || PathPrefix(`/api/albums/`) || Path(`/api/auth/me`) || Path(`/api/me`) || Path(`/api/me/history`) || Path(`/api/me/likes`) || Path(`/api/me/stats/dashboard`) || Path(`/api/search`) || Path(`/api/favorites`))
       traefik.http.routers.crate-readplane-interactive.entryPoints: websecure
       traefik.http.routers.crate-readplane-interactive.middlewares: crate-api-compress@docker
       traefik.http.routers.crate-readplane-interactive.priority: 100
@@ -453,7 +453,7 @@ services:
       traefik.http.routers.crate-readplane-sse.service: crate-readplane-sse@file
       traefik.http.routers.crate-readplane-sse.tls: true
       traefik.http.routers.crate-readplane-sse.tls.certresolver: letsencrypt
-      traefik.http.routers.crate-readplane-stream.rule: Host(`api.${DOMAIN}`) && Method(`GET`, `HEAD`) && (PathPrefix(`/api/federation/remote/streams/`) || PathPrefix(`/api/tracks/`))
+      traefik.http.routers.crate-readplane-stream.rule: Host(`api.${DOMAIN}`) && (Method(`GET`) || Method(`HEAD`)) && (PathPrefix(`/api/federation/remote/streams/`) || PathPrefix(`/api/tracks/`))
       traefik.http.routers.crate-readplane-stream.entryPoints: websecure
       traefik.http.routers.crate-readplane-stream.priority: 110
       traefik.http.routers.crate-readplane-stream.tls: true


### PR DESCRIPTION
## Qué cambia

- adapta los matchers `Method` de Traefik 3 a un argumento por matcher
- reactiva los routers interactivo y stream para GET y HEAD
- aplica el mismo contrato a producción y al compose home
- añade un test que impide reintroducir la sintaxis inválida

## Causa raíz

Traefik 3.7 rechaza `Method(`GET`, `HEAD`)`. Ambos routers aparecían como `disabled`, por lo que catálogo, artwork y streaming caían a FastAPI aunque el readplane estuviera healthy.

## Impacto

El listado global de géneros pasa del fallback FastAPI (~2,9 s) al snapshot del readplane (~6 ms internos), y se restaura el data plane previsto para playback/artwork.

## Validación

- test TDD rojo/verde para sintaxis Traefik v3
- 19 tests de routing, catálogo y recovery verdes
- Ruff, Prettier y hooks verdes
- diagnóstico en producción mediante Traefik API: router disabled por matcher inválido