### PR TITLE
fix: stabilize catalog reconciliation and projected reads

### DIFF
--- a/app/crate/api/__init__.py
+++ b/app/crate/api/__init__.py
@@ -118,6 +118,38 @@ def _queue_artwork_variant_backfill() -> None:
     )
 
 
+def _queue_stats_dashboard_backfill() -> None:
+    """Prewarm the canonical dashboard projection for every active user."""
+    from crate.db.user_stats_dashboard_surface import (
+        queue_missing_stats_dashboard_snapshots,
+    )
+
+    queued = queue_missing_stats_dashboard_snapshots()
+    if queued:
+        log.info("Queued %s missing user stats dashboard snapshots", queued)
+
+
+def _queue_artist_top_track_ranking_backfill() -> None:
+    """Refresh persisted remote ranks after ranking semantics change."""
+    from crate.db.cache_settings import get_setting
+    from crate.db.repositories.tasks import create_task_dedup
+    from crate.popularity import ARTIST_TOP_TRACK_RANKING_VERSION
+
+    if (
+        get_setting("artist_top_track_ranking_version")
+        == ARTIST_TOP_TRACK_RANKING_VERSION
+    ):
+        return
+    create_task_dedup(
+        "compute_popularity",
+        {
+            "triggered_by": "api_startup",
+            "ranking_version": ARTIST_TOP_TRACK_RANKING_VERSION,
+        },
+        dedup_key=(f"bootstrap:artist-top-tracks:v{ARTIST_TOP_TRACK_RANKING_VERSION}"),
+    )
+
+
 async def _repair_musicbrainz_cache_ttls() -> int:
     from crate.db.cache_musicbrainz import repair_mb_cache_ttls
 
@@ -133,6 +165,8 @@ async def lifespan(app: FastAPI):
     _bootstrap_federation_identity()
     _queue_global_catalog_bootstrap()
     _queue_artwork_variant_backfill()
+    _queue_stats_dashboard_backfill()
+    _queue_artist_top_track_ranking_backfill()
     from crate.utils import init_musicbrainz
 
     init_musicbrainz()

--- a/app/crate/api/browse.py
+++ b/app/crate/api/browse.py
@@ -15,21 +15,42 @@ from crate.db.repositories.global_catalog_state import (
     catalog_serves_global,
     get_catalog_state,
 )
+from crate.db.ui_snapshot_reads import get_ui_snapshot
+from crate.db.ui_snapshot_shared import decorate_snapshot
 
 router = APIRouter()
 router.include_router(artist_router)
 router.include_router(album_router)
 router.include_router(media_router)
 
-_EXPLORE_PAGE_CACHE_TTL_SECONDS = 60
+_EXPLORE_PAGE_CACHE_TTL_SECONDS = 600
+_GLOBAL_GENRES_SNAPSHOT_MAX_AGE_SECONDS = 86_400
 log = logging.getLogger(__name__)
+
+
+def _global_genres_snapshot_items() -> list[dict] | None:
+    try:
+        snapshot = get_ui_snapshot(
+            "global-catalog-genres",
+            "crate-core",
+            max_age_seconds=_GLOBAL_GENRES_SNAPSHOT_MAX_AGE_SECONDS,
+        )
+    except Exception:
+        log.debug("Global genre snapshot unavailable", exc_info=True)
+        return None
+    if not snapshot:
+        return None
+    items = decorate_snapshot(snapshot).get("items")
+    return list(items) if isinstance(items, list) else None
 
 
 def _explore_genres(local_genres: list[dict]) -> list[dict]:
     try:
         if not catalog_serves_global(get_catalog_state()):
             return local_genres
-        global_genres = list_global_catalog_genres()
+        global_genres = _global_genres_snapshot_items()
+        if global_genres is None:
+            global_genres = list_global_catalog_genres()
     except Exception:
         log.warning(
             "Global genre summaries unavailable; using local Explore genres",

--- a/app/crate/api/me.py
+++ b/app/crate/api/me.py
@@ -1066,11 +1066,11 @@ def stats_dashboard(
     request: Request,
     window: str = Query("30d"),
     month: str | None = Query(None, pattern=r"^\d{4}-\d{2}$"),
-    tracks_limit: int = Query(10, ge=1, le=100),
-    artists_limit: int = Query(8, ge=1, le=100),
-    albums_limit: int = Query(8, ge=1, le=100),
-    genres_limit: int = Query(8, ge=1, le=100),
-    replay_limit: int = Query(30, ge=1, le=100),
+    tracks_limit: int = Query(12, ge=1, le=100),
+    artists_limit: int = Query(10, ge=1, le=100),
+    albums_limit: int = Query(12, ge=1, le=100),
+    genres_limit: int = Query(10, ge=1, le=100),
+    replay_limit: int = Query(36, ge=1, le=100),
 ):
     user = _require_auth(request)
     try:

--- a/app/crate/db/home_discovery_surface.py
+++ b/app/crate/db/home_discovery_surface.py
@@ -38,7 +38,7 @@ def _merge_recently_played(user_id: int, payload: dict) -> dict:
 def _cold_home_payload(user_id: int) -> dict:
     return {
         "hero": None,
-        "recently_played": get_home_recently_played(user_id),
+        "recently_played": [],
         "custom_mixes": [],
         "suggested_albums": [],
         "recommended_tracks": [],

--- a/app/crate/db/jobs/global_catalog_reconciliation.py
+++ b/app/crate/db/jobs/global_catalog_reconciliation.py
@@ -900,6 +900,13 @@ def _reconcile_local_batch_sources(
                     "global_artist_uid",
                     global_uid,
                 )
+                source_id = _rebind_source_before_canonical_upsert(
+                    session,
+                    source,
+                    global_uid,
+                    preferred=True,
+                    target_exists=existed,
+                )
                 _upsert_artist(session, source, global_uid)
             elif entity_type == "album":
                 artist_uid = _find_artist_uid(
@@ -919,6 +926,13 @@ def _reconcile_local_batch_sources(
                     "global_catalog_albums",
                     "global_album_uid",
                     global_uid,
+                )
+                source_id = _rebind_source_before_canonical_upsert(
+                    session,
+                    source,
+                    global_uid,
+                    preferred=True,
+                    target_exists=existed,
                 )
                 _upsert_album(session, source, global_uid, artist_uid)
             else:
@@ -949,8 +963,21 @@ def _reconcile_local_batch_sources(
                     "global_track_uid",
                     global_uid,
                 )
+                source_id = _rebind_source_before_canonical_upsert(
+                    session,
+                    source,
+                    global_uid,
+                    preferred=True,
+                    target_exists=existed,
+                )
                 _upsert_track(session, source, global_uid, artist_uid, album_uid)
-            source_id = _upsert_source(session, source, global_uid, preferred=True)
+            if source_id is None:
+                source_id = _upsert_source(
+                    session,
+                    source,
+                    global_uid,
+                    preferred=True,
+                )
             _project_source_genres(session, source, global_uid, source_id)
             _refresh_source_count(session, entity_type, global_uid)
             _count_result(result, existed)
@@ -975,8 +1002,15 @@ def _reconcile_remote_batch_sources(
                 existed = _canonical_exists(
                     session, "global_catalog_artists", "global_artist_uid", target_uid
                 )
-                _upsert_remote_artist(session, source, target_uid)
                 preferred = not _canonical_has_local(session, "artist", target_uid)
+                source_id = _rebind_source_before_canonical_upsert(
+                    session,
+                    source,
+                    target_uid,
+                    preferred=preferred,
+                    target_exists=existed,
+                )
+                _upsert_remote_artist(session, source, target_uid)
                 refresh_artist_photo = True
             elif entity_type == "album":
                 artist_uid = _find_artist_uid(
@@ -994,8 +1028,15 @@ def _reconcile_remote_batch_sources(
                 existed = _canonical_exists(
                     session, "global_catalog_albums", "global_album_uid", target_uid
                 )
-                _upsert_remote_album(session, source, target_uid, artist_uid)
                 preferred = not _canonical_has_local(session, "album", target_uid)
+                source_id = _rebind_source_before_canonical_upsert(
+                    session,
+                    source,
+                    target_uid,
+                    preferred=preferred,
+                    target_exists=existed,
+                )
+                _upsert_remote_album(session, source, target_uid, artist_uid)
                 refresh_artist_photo = False
             else:
                 payload = source["source_payload"]
@@ -1017,10 +1058,23 @@ def _reconcile_remote_batch_sources(
                 existed = _canonical_exists(
                     session, "global_catalog_tracks", "global_track_uid", target_uid
                 )
-                _upsert_remote_track(session, source, target_uid, artist_uid, album_uid)
                 preferred = not _canonical_has_local(session, "track", target_uid)
+                source_id = _rebind_source_before_canonical_upsert(
+                    session,
+                    source,
+                    target_uid,
+                    preferred=preferred,
+                    target_exists=existed,
+                )
+                _upsert_remote_track(session, source, target_uid, artist_uid, album_uid)
                 refresh_artist_photo = False
-            source_id = _upsert_source(session, source, target_uid, preferred=preferred)
+            if source_id is None:
+                source_id = _upsert_source(
+                    session,
+                    source,
+                    target_uid,
+                    preferred=preferred,
+                )
             _project_source_genres(session, source, target_uid, source_id)
             if refresh_artist_photo:
                 _refresh_artist_has_photo(session, target_uid)
@@ -2505,6 +2559,27 @@ def _upsert_source(
             target_global_uid=global_entity_uid,
         )
     return int(source_id)
+
+
+def _rebind_source_before_canonical_upsert(
+    session,
+    source: dict[str, Any],
+    global_entity_uid: str,
+    *,
+    preferred: bool,
+    target_exists: bool,
+) -> int | None:
+    if not target_exists:
+        return None
+    previous_global_uid = _existing_source_target(session, source)
+    if not previous_global_uid or previous_global_uid == global_entity_uid:
+        return None
+    return _upsert_source(
+        session,
+        source,
+        global_entity_uid,
+        preferred=preferred,
+    )
 
 
 def _cleanup_rebound_canonical(

--- a/app/crate/db/migrations/versions/080_user_listening_hotpath_indexes.py
+++ b/app/crate/db/migrations/versions/080_user_listening_hotpath_indexes.py
@@ -1,0 +1,31 @@
+"""Index deterministic global-track metadata fallbacks."""
+
+from alembic import op
+
+
+revision = "080"
+down_revision = "079"
+branch_labels = None
+depends_on = None
+
+
+INDEX_NAME = "idx_global_tracks_lower_artist_title_album"
+
+
+def upgrade() -> None:
+    with op.get_context().autocommit_block():
+        op.execute(
+            f"""
+            CREATE INDEX CONCURRENTLY IF NOT EXISTS {INDEX_NAME}
+            ON global_catalog_tracks (
+                LOWER(artist_name),
+                LOWER(canonical_title),
+                LOWER(COALESCE(album_name, ''))
+            )
+            """
+        )
+
+
+def downgrade() -> None:
+    with op.get_context().autocommit_block():
+        op.execute("DROP INDEX IF EXISTS idx_global_tracks_lower_artist_title_album")

--- a/app/crate/db/queries/user_library_history.py
+++ b/app/crate/db/queries/user_library_history.py
@@ -69,44 +69,88 @@ def get_play_history_rows(
             alb.slug AS album_slug,
             upe.ended_at AS played_at
         FROM user_play_events upe
-        LEFT JOIN library_tracks lt
-          ON lt.id = upe.track_id
-    """
-    query_sql += """
-          OR (upe.track_id IS NULL AND upe.track_entity_uid IS NOT NULL AND lt.entity_uid = upe.track_entity_uid)
+        LEFT JOIN LATERAL (
+            SELECT candidate.*
+            FROM (
+                SELECT matched.id AS track_id, 1 AS match_priority
+                FROM library_tracks matched
+                WHERE matched.id = upe.track_id
+                UNION ALL
+                SELECT matched.id, 2
+                FROM library_tracks matched
+                WHERE upe.track_id IS NULL
+                  AND upe.track_entity_uid IS NOT NULL
+                  AND matched.entity_uid = upe.track_entity_uid
     """
     if has_legacy_stream_id_column:
         query_sql += """
-          OR (upe.track_id IS NULL AND COALESCE(upe.track_path, '') <> '' AND lt.navidrome_id = upe.track_path)
-          OR (upe.track_id IS NULL AND COALESCE(upe.track_path, '') <> '' AND lt.path = upe.track_path)
+                UNION ALL
+                SELECT matched.id, 3
+                FROM library_tracks matched
+                WHERE upe.track_id IS NULL
+                  AND COALESCE(upe.track_path, '') <> ''
+                  AND matched.navidrome_id = upe.track_path
+                UNION ALL
+                SELECT matched.id, 4
+                FROM library_tracks matched
+                WHERE upe.track_id IS NULL
+                  AND COALESCE(upe.track_path, '') <> ''
+                  AND matched.path = upe.track_path
         """
     else:
         query_sql += """
-          OR (upe.track_id IS NULL AND COALESCE(upe.track_path, '') <> '' AND lt.path = upe.track_path)
+                UNION ALL
+                SELECT matched.id, 3
+                FROM library_tracks matched
+                WHERE upe.track_id IS NULL
+                  AND COALESCE(upe.track_path, '') <> ''
+                  AND matched.path = upe.track_path
         """
     query_sql += """
-        LEFT JOIN global_catalog_tracks gct
-          ON :allow_global_catalog
-          AND (
-            gct.global_track_uid = upe.global_track_uid
-            OR (
-              upe.global_track_uid IS NULL
-              AND lt.entity_uid IS NOT NULL
-              AND gct.local_track_entity_uid = lt.entity_uid
-            )
-            OR (
-              upe.global_track_uid IS NULL
-              AND lt.id IS NULL
-              AND COALESCE(NULLIF(TRIM(upe.artist), ''), '') <> ''
-              AND COALESCE(NULLIF(TRIM(upe.title), ''), '') <> ''
-              AND LOWER(gct.artist_name) = LOWER(upe.artist)
-              AND LOWER(gct.canonical_title) = LOWER(upe.title)
-              AND (
-                COALESCE(NULLIF(TRIM(upe.album), ''), '') = ''
-                OR LOWER(COALESCE(gct.album_name, '')) = LOWER(upe.album)
-              )
-            )
-          )
+            ) matches
+            JOIN library_tracks candidate ON candidate.id = matches.track_id
+            ORDER BY matches.match_priority
+            LIMIT 1
+        ) lt ON TRUE
+        LEFT JOIN LATERAL (
+            SELECT candidate.*
+            FROM (
+                SELECT matched.global_track_uid, 1 AS match_priority
+                FROM global_catalog_tracks matched
+                WHERE :allow_global_catalog
+                  AND matched.global_track_uid = upe.global_track_uid
+                UNION ALL
+                SELECT matched.global_track_uid, 2
+                FROM global_catalog_tracks matched
+                WHERE :allow_global_catalog
+                  AND upe.global_track_uid IS NULL
+                  AND lt.entity_uid IS NOT NULL
+                  AND matched.local_track_entity_uid = lt.entity_uid
+                UNION ALL
+                SELECT matched.global_track_uid, 3
+                FROM global_catalog_tracks matched
+                WHERE :allow_global_catalog
+                  AND upe.global_track_uid IS NULL
+                  AND lt.id IS NULL
+                  AND COALESCE(NULLIF(TRIM(upe.artist), ''), '') <> ''
+                  AND COALESCE(NULLIF(TRIM(upe.title), ''), '') <> ''
+                  AND LOWER(matched.artist_name) = LOWER(upe.artist)
+                  AND LOWER(matched.canonical_title) = LOWER(upe.title)
+                  AND (
+                    COALESCE(NULLIF(TRIM(upe.album), ''), '') = ''
+                    OR LOWER(COALESCE(matched.album_name, '')) = LOWER(upe.album)
+                  )
+            ) matches
+            JOIN global_catalog_tracks candidate
+              ON candidate.global_track_uid = matches.global_track_uid
+            ORDER BY
+                matches.match_priority,
+                candidate.has_local DESC,
+                candidate.has_remote DESC,
+                candidate.source_count DESC,
+                candidate.global_track_uid
+            LIMIT 1
+        ) gct ON TRUE
         LEFT JOIN global_catalog_albums gca
           ON :allow_global_catalog
          AND gca.global_album_uid = gct.global_album_uid

--- a/app/crate/db/queries/user_library_stats_month.py
+++ b/app/crate/db/queries/user_library_stats_month.py
@@ -204,40 +204,69 @@ def get_month_top_tracks(user_id: int, month: str, limit: int = 20) -> list[dict
                             upe.played_seconds,
                             upe.ended_at
                         FROM user_play_events upe
-                        LEFT JOIN library_tracks lt
-                          ON lt.id = upe.track_id
-                          OR (
-                            upe.track_id IS NULL
-                            AND upe.track_entity_uid IS NOT NULL
-                            AND lt.entity_uid = upe.track_entity_uid
-                          )
-                          OR (
-                            upe.track_id IS NULL
-                            AND COALESCE(upe.track_path, '') <> ''
-                            AND lt.path = upe.track_path
-                          )
-                        LEFT JOIN global_catalog_tracks gct
-                          ON :allow_global_catalog
-                          AND (
-                            gct.global_track_uid = upe.global_track_uid
-                            OR (
-                              upe.global_track_uid IS NULL
-                              AND lt.entity_uid IS NOT NULL
-                              AND gct.local_track_entity_uid = lt.entity_uid
-                            )
-                            OR (
-                              upe.global_track_uid IS NULL
-                              AND lt.id IS NULL
-                              AND COALESCE(NULLIF(TRIM(upe.artist), ''), '') <> ''
-                              AND COALESCE(NULLIF(TRIM(upe.title), ''), '') <> ''
-                              AND LOWER(gct.artist_name) = LOWER(upe.artist)
-                              AND LOWER(gct.canonical_title) = LOWER(upe.title)
-                              AND (
-                                COALESCE(NULLIF(TRIM(upe.album), ''), '') = ''
-                                OR LOWER(COALESCE(gct.album_name, '')) = LOWER(upe.album)
-                              )
-                            )
-                          )
+                        LEFT JOIN LATERAL (
+                            SELECT candidate.*
+                            FROM (
+                                SELECT matched.id AS track_id, 1 AS match_priority
+                                FROM library_tracks matched
+                                WHERE matched.id = upe.track_id
+                                UNION ALL
+                                SELECT matched.id, 2
+                                FROM library_tracks matched
+                                WHERE upe.track_id IS NULL
+                                  AND upe.track_entity_uid IS NOT NULL
+                                  AND matched.entity_uid = upe.track_entity_uid
+                                UNION ALL
+                                SELECT matched.id, 3
+                                FROM library_tracks matched
+                                WHERE upe.track_id IS NULL
+                                  AND COALESCE(upe.track_path, '') <> ''
+                                  AND matched.path = upe.track_path
+                            ) matches
+                            JOIN library_tracks candidate
+                              ON candidate.id = matches.track_id
+                            ORDER BY matches.match_priority
+                            LIMIT 1
+                        ) lt ON TRUE
+                        LEFT JOIN LATERAL (
+                            SELECT candidate.*
+                            FROM (
+                                SELECT matched.global_track_uid, 1 AS match_priority
+                                FROM global_catalog_tracks matched
+                                WHERE :allow_global_catalog
+                                  AND matched.global_track_uid = upe.global_track_uid
+                                UNION ALL
+                                SELECT matched.global_track_uid, 2
+                                FROM global_catalog_tracks matched
+                                WHERE :allow_global_catalog
+                                  AND upe.global_track_uid IS NULL
+                                  AND lt.entity_uid IS NOT NULL
+                                  AND matched.local_track_entity_uid = lt.entity_uid
+                                UNION ALL
+                                SELECT matched.global_track_uid, 3
+                                FROM global_catalog_tracks matched
+                                WHERE :allow_global_catalog
+                                  AND upe.global_track_uid IS NULL
+                                  AND lt.id IS NULL
+                                  AND COALESCE(NULLIF(TRIM(upe.artist), ''), '') <> ''
+                                  AND COALESCE(NULLIF(TRIM(upe.title), ''), '') <> ''
+                                  AND LOWER(matched.artist_name) = LOWER(upe.artist)
+                                  AND LOWER(matched.canonical_title) = LOWER(upe.title)
+                                  AND (
+                                    COALESCE(NULLIF(TRIM(upe.album), ''), '') = ''
+                                    OR LOWER(COALESCE(matched.album_name, '')) = LOWER(upe.album)
+                                  )
+                            ) matches
+                            JOIN global_catalog_tracks candidate
+                              ON candidate.global_track_uid = matches.global_track_uid
+                            ORDER BY
+                                matches.match_priority,
+                                candidate.has_local DESC,
+                                candidate.has_remote DESC,
+                                candidate.source_count DESC,
+                                candidate.global_track_uid
+                            LIMIT 1
+                        ) gct ON TRUE
                         LEFT JOIN library_artists art ON art.name = COALESCE(lt.artist, gct.artist_name, upe.artist)
                         LEFT JOIN library_albums alb_by_id ON alb_by_id.id = lt.album_id
                         LEFT JOIN library_albums alb_by_name

--- a/app/crate/db/queries/user_library_stats_tops.py
+++ b/app/crate/db/queries/user_library_stats_tops.py
@@ -316,31 +316,61 @@ def get_replay_mix(user_id: int, window: str = "30d", limit: int = 30) -> dict:
                             ORDER BY uts.play_count DESC, uts.minutes_listened DESC, uts.last_played_at DESC
                         ) AS artist_rank
                     FROM user_track_stats uts
-                    LEFT JOIN library_tracks lt
-                      ON lt.id = uts.track_id
-                      OR (uts.track_id IS NULL AND uts.track_entity_uid IS NOT NULL AND lt.entity_uid = uts.track_entity_uid)
-                    LEFT JOIN global_catalog_tracks gct
-                      ON :allow_global_catalog
-                      AND (
-                        gct.global_track_uid = uts.global_track_uid
-                        OR (
-                          uts.global_track_uid IS NULL
-                          AND lt.entity_uid IS NOT NULL
-                          AND gct.local_track_entity_uid = lt.entity_uid
-                        )
-                        OR (
-                          uts.global_track_uid IS NULL
-                          AND lt.id IS NULL
-                          AND COALESCE(NULLIF(TRIM(uts.artist), ''), '') <> ''
-                          AND COALESCE(NULLIF(TRIM(uts.title), ''), '') <> ''
-                          AND LOWER(gct.artist_name) = LOWER(uts.artist)
-                          AND LOWER(gct.canonical_title) = LOWER(uts.title)
-                          AND (
-                            COALESCE(NULLIF(TRIM(uts.album), ''), '') = ''
-                            OR LOWER(COALESCE(gct.album_name, '')) = LOWER(uts.album)
-                          )
-                        )
-                      )
+                    LEFT JOIN LATERAL (
+                        SELECT candidate.*
+                        FROM (
+                            SELECT track_by_id.*, 1 AS resolution_priority
+                            FROM library_tracks track_by_id
+                            WHERE uts.track_id IS NOT NULL
+                              AND track_by_id.id = uts.track_id
+                            UNION ALL
+                            SELECT track_by_entity.*, 2 AS resolution_priority
+                            FROM library_tracks track_by_entity
+                            WHERE uts.track_id IS NULL
+                              AND uts.track_entity_uid IS NOT NULL
+                              AND track_by_entity.entity_uid = uts.track_entity_uid
+                        ) candidate
+                        ORDER BY candidate.resolution_priority, candidate.id
+                        LIMIT 1
+                    ) lt ON TRUE
+                    LEFT JOIN LATERAL (
+                        SELECT candidate.*
+                        FROM (
+                            SELECT track_by_uid.*, 1 AS resolution_priority
+                            FROM global_catalog_tracks track_by_uid
+                            WHERE :allow_global_catalog
+                              AND uts.global_track_uid IS NOT NULL
+                              AND track_by_uid.global_track_uid = uts.global_track_uid
+                            UNION ALL
+                            SELECT track_by_entity.*, 2 AS resolution_priority
+                            FROM global_catalog_tracks track_by_entity
+                            WHERE :allow_global_catalog
+                              AND uts.global_track_uid IS NULL
+                              AND lt.entity_uid IS NOT NULL
+                              AND track_by_entity.local_track_entity_uid = lt.entity_uid
+                            UNION ALL
+                            SELECT track_by_metadata.*, 3 AS resolution_priority
+                            FROM global_catalog_tracks track_by_metadata
+                            WHERE :allow_global_catalog
+                              AND uts.global_track_uid IS NULL
+                              AND lt.id IS NULL
+                              AND COALESCE(NULLIF(TRIM(uts.artist), ''), '') <> ''
+                              AND COALESCE(NULLIF(TRIM(uts.title), ''), '') <> ''
+                              AND LOWER(track_by_metadata.artist_name) = LOWER(uts.artist)
+                              AND LOWER(track_by_metadata.canonical_title) = LOWER(uts.title)
+                              AND (
+                                COALESCE(NULLIF(TRIM(uts.album), ''), '') = ''
+                                OR LOWER(COALESCE(track_by_metadata.album_name, '')) = LOWER(uts.album)
+                              )
+                        ) candidate
+                        ORDER BY
+                            candidate.resolution_priority,
+                            candidate.has_local DESC,
+                            candidate.has_remote DESC,
+                            candidate.source_count DESC,
+                            candidate.global_track_uid
+                        LIMIT 1
+                    ) gct ON TRUE
                     LEFT JOIN library_albums alb_by_id ON alb_by_id.id = lt.album_id
                     LEFT JOIN library_albums alb_by_name
                       ON alb_by_id.id IS NULL

--- a/app/crate/db/user_stats_dashboard_surface.py
+++ b/app/crate/db/user_stats_dashboard_surface.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from typing import Any
 
+from sqlalchemy import text
+
 from crate.db.queries.user_library import (
     get_replay_mix,
     get_stats_overview,
@@ -25,6 +27,7 @@ from crate.db.queries.user_library_stats_month import (
     month_period_key,
 )
 from crate.db.repositories.tasks import create_task_dedup
+from crate.db.tx import read_scope
 from crate.db.ui_snapshot_reads import get_ui_snapshot
 from crate.db.ui_snapshot_shared import decorate_snapshot
 from crate.db.ui_snapshot_writes import upsert_ui_snapshot
@@ -32,11 +35,11 @@ from crate.db.ui_snapshot_writes import upsert_ui_snapshot
 _MAX_AGE_SECONDS = 300
 _STALE_MAX_AGE_SECONDS = 86_400
 _DEFAULT_LIMITS = {
-    "tracks_limit": 10,
-    "artists_limit": 8,
-    "albums_limit": 8,
-    "genres_limit": 8,
-    "replay_limit": 30,
+    "tracks_limit": 12,
+    "artists_limit": 10,
+    "albums_limit": 12,
+    "genres_limit": 10,
+    "replay_limit": 36,
 }
 
 
@@ -201,11 +204,11 @@ def get_user_stats_dashboard(
     *,
     window: str = "30d",
     month: str | None = None,
-    tracks_limit: int = 10,
-    artists_limit: int = 8,
-    albums_limit: int = 8,
-    genres_limit: int = 8,
-    replay_limit: int = 30,
+    tracks_limit: int = 12,
+    artists_limit: int = 10,
+    albums_limit: int = 12,
+    genres_limit: int = 10,
+    replay_limit: int = 36,
 ) -> dict[str, Any]:
     params = _projection_params(
         user_id,
@@ -237,11 +240,11 @@ def refresh_user_stats_dashboard_snapshot(
     *,
     window: str = "30d",
     month: str | None = None,
-    tracks_limit: int = 10,
-    artists_limit: int = 8,
-    albums_limit: int = 8,
-    genres_limit: int = 8,
-    replay_limit: int = 30,
+    tracks_limit: int = 12,
+    artists_limit: int = 10,
+    albums_limit: int = 12,
+    genres_limit: int = 10,
+    replay_limit: int = 36,
 ) -> dict[str, Any]:
     params = _projection_params(
         user_id,
@@ -269,9 +272,51 @@ def refresh_user_stats_dashboard_snapshots(user_id: int) -> int:
     return 1
 
 
+def _list_stats_dashboard_user_ids() -> list[int]:
+    with read_scope() as session:
+        rows = (
+            session.execute(
+                text(
+                    """
+                SELECT id
+                FROM users
+                WHERE status = 'active'
+                  AND deleted_at IS NULL
+                ORDER BY id
+                """
+                )
+            )
+            .scalars()
+            .all()
+        )
+    return [int(user_id) for user_id in rows]
+
+
+def queue_missing_stats_dashboard_snapshots() -> int:
+    queued = 0
+    for user_id in _list_stats_dashboard_user_ids():
+        params = _projection_params(
+            user_id,
+            window="30d",
+            month=None,
+            **_DEFAULT_LIMITS,
+        )
+        subject_key = stats_dashboard_subject_key(**params)
+        if get_ui_snapshot(
+            "stats:dashboard",
+            subject_key,
+            max_age_seconds=_STALE_MAX_AGE_SECONDS,
+        ):
+            continue
+        _schedule_projection(params, subject_key)
+        queued += 1
+    return queued
+
+
 __all__ = [
     "build_user_stats_dashboard",
     "get_user_stats_dashboard",
+    "queue_missing_stats_dashboard_snapshots",
     "refresh_user_stats_dashboard_snapshot",
     "refresh_user_stats_dashboard_snapshots",
     "stats_dashboard_subject_key",

--- a/app/crate/popularity.py
+++ b/app/crate/popularity.py
@@ -47,6 +47,7 @@ LASTFM_BASE = "http://ws.audioscrobbler.com/2.0/"
 LASTFM_TOP_TRACK_LIMIT = 250
 LASTFM_RANK_MAX = 250
 SPOTIFY_RANK_MAX = 10
+ARTIST_TOP_TRACK_RANKING_VERSION = "2"
 
 
 def _api_key() -> str | None:

--- a/app/crate/worker_handlers/analysis.py
+++ b/app/crate/worker_handlers/analysis.py
@@ -145,12 +145,14 @@ def _handle_refresh_home_discovery_snapshot(
     task_id: str, params: dict, config: dict
 ) -> dict:
     del task_id, config
+    from crate.api.cache_events import broadcast_invalidation
     from crate.db.home import get_cached_home_discovery
 
     user_id = int(params.get("user_id") or 0)
     if user_id <= 0:
         return {"ok": False, "error": "Missing user_id"}
     get_cached_home_discovery(user_id, fresh=True)
+    broadcast_invalidation("home")
     return {"ok": True, "user_id": user_id}
 
 
@@ -171,11 +173,11 @@ def _handle_refresh_user_stats_dashboard_snapshot(
         user_id,
         window=window,
         month=params.get("month"),
-        tracks_limit=int(params.get("tracks_limit") or 10),
-        artists_limit=int(params.get("artists_limit") or 8),
-        albums_limit=int(params.get("albums_limit") or 8),
-        genres_limit=int(params.get("genres_limit") or 8),
-        replay_limit=int(params.get("replay_limit") or 30),
+        tracks_limit=int(params.get("tracks_limit") or 12),
+        artists_limit=int(params.get("artists_limit") or 10),
+        albums_limit=int(params.get("albums_limit") or 12),
+        genres_limit=int(params.get("genres_limit") or 10),
+        replay_limit=int(params.get("replay_limit") or 36),
     )
     broadcast_invalidation("history")
     return {"ok": True, "user_id": user_id, "window": window}
@@ -459,7 +461,7 @@ def _try_complete_parent(parent_task_id: str, child_task_type: str = "") -> None
     }
 
     finalize_fn = _PARENT_FINALIZERS.get(child_task_type)
-    if finalize_fn:
+    if finalize_fn and status["failed"] == 0:
         try:
             extra = finalize_fn()
             if extra:
@@ -469,6 +471,8 @@ def _try_complete_parent(parent_task_id: str, child_task_type: str = "") -> None
                 "Finalization failed for parent %s", parent_task_id, exc_info=True
             )
             result["finalization_error"] = True
+    elif finalize_fn:
+        result["finalization_skipped"] = True
 
     update_task(parent_task_id, status="completed", result=result)
     emit_task_event(
@@ -541,9 +545,27 @@ def _handle_bliss_chunk(task_id: str, params: dict, config: dict) -> dict:
 
 def _popularity_finalize() -> dict | None:
     """Post-processing after all popularity chunks complete."""
-    from crate.popularity import recompute_track_popularity_scores
+    from crate.api.cache_events import broadcast_invalidation
+    from crate.db.cache_settings import set_setting
+    from crate.db.cache_store import delete_cache_prefix
+    from crate.popularity import (
+        ARTIST_TOP_TRACK_RANKING_VERSION,
+        recompute_track_popularity_scores,
+    )
 
     scored = recompute_track_popularity_scores()
+    set_setting(
+        "artist_top_track_ranking_version",
+        ARTIST_TOP_TRACK_RANKING_VERSION,
+    )
+    for prefix in (
+        "listen:artist_top_tracks:v1:",
+        "listen:artist_top_tracks:v2:",
+        "listen:artist_top_tracks:v3:",
+        "listen:artist_page:v6:",
+    ):
+        delete_cache_prefix(prefix)
+    broadcast_invalidation("catalog", "home")
     return {"tracks_scored": scored.get("tracks_scored", 0)}
 
 
@@ -556,9 +578,12 @@ def _handle_compute_popularity(task_id: str, params: dict, config: dict) -> dict
     if params.get("artists"):
         return _handle_popularity_chunk(task_id, params, config)
 
-    return _chunk_coordinator(
+    result = _chunk_coordinator(
         task_id, params, config, "compute_popularity", _handle_popularity_chunk
     )
+    if result.get("chunks") == 0:
+        result.update(_popularity_finalize() or {})
+    return result
 
 
 def _handle_popularity_chunk(task_id: str, params: dict, config: dict) -> dict:

--- a/app/readplane/internal/routes/catalog.go
+++ b/app/readplane/internal/routes/catalog.go
@@ -210,7 +210,7 @@ func (s *Server) artistSlugRoute(w http.ResponseWriter, r *http.Request) {
 		if !s.requireCatalogAuth(w, r) {
 			return
 		}
-		s.writeArtistTopTracksBySlug(w, r, parts[0], boundedQueryInt(r, "count", 20, 1, 50))
+		s.writeArtistTopTracks(w, r)
 		return
 	}
 	if len(parts) == 3 && parts[1] == "albums" {
@@ -227,17 +227,11 @@ func (s *Server) artistSlugRoute(w http.ResponseWriter, r *http.Request) {
 	s.fallbackOrRouteMiss(w, r)
 }
 
-func (s *Server) writeArtistTopTracksBySlug(w http.ResponseWriter, r *http.Request, slug string, count int) {
-	store := s.artistTopTracks
-	if store == nil {
-		store = s.catalog
-	}
-	if store == nil {
-		s.catalogUnavailable(w, r, "Readplane catalog unavailable")
+func (s *Server) writeArtistTopTracks(w http.ResponseWriter, r *http.Request) {
+	if s.tryFallback(w, r) {
 		return
 	}
-	payload, err := store.ArtistTopTracksBySlug(r.Context(), slug, count)
-	s.writeCatalogPayloadOrFallbackNotFound(w, r, payload, err, "Artist top tracks unavailable", "Not found")
+	s.catalogUnavailable(w, r, "Artist top tracks unavailable")
 }
 
 func (s *Server) artistRoute(w http.ResponseWriter, r *http.Request) {
@@ -279,7 +273,7 @@ func (s *Server) artistRoute(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if len(parts) == 2 && parts[1] == "top-tracks" {
-		artistID, ok := parsePositiveInt64(parts[0])
+		_, ok := parsePositiveInt64(parts[0])
 		if !ok {
 			s.fallbackOrRouteMiss(w, r)
 			return
@@ -287,8 +281,7 @@ func (s *Server) artistRoute(w http.ResponseWriter, r *http.Request) {
 		if !s.requireCatalogAuth(w, r) {
 			return
 		}
-		payload, err := s.catalog.ArtistTopTracksByID(r.Context(), artistID, boundedQueryInt(r, "count", 20, 1, 50))
-		s.writeCatalogPayload(w, r, payload, err, "Artist top tracks unavailable", "Not found")
+		s.writeArtistTopTracks(w, r)
 		return
 	}
 	if len(parts) == 2 && parts[0] == "by-entity" && isRouteUUID(parts[1]) {
@@ -303,8 +296,7 @@ func (s *Server) artistRoute(w http.ResponseWriter, r *http.Request) {
 		if !s.requireCatalogAuth(w, r) {
 			return
 		}
-		payload, err := s.catalog.ArtistTopTracksByEntityUID(r.Context(), parts[1], boundedQueryInt(r, "count", 20, 1, 50))
-		s.writeCatalogPayload(w, r, payload, err, "Artist top tracks unavailable", "Not found")
+		s.writeArtistTopTracks(w, r)
 		return
 	}
 	s.fallbackOrRouteMiss(w, r)

--- a/app/readplane/internal/routes/catalog_test.go
+++ b/app/readplane/internal/routes/catalog_test.go
@@ -1,7 +1,6 @@
 package routes
 
 import (
-	"context"
 	"io"
 	"log/slog"
 	"net/http"
@@ -13,17 +12,6 @@ import (
 	"github.com/thecrateapp/crate/app/readplane/internal/config"
 	"github.com/thecrateapp/crate/app/readplane/internal/httpx"
 )
-
-type stubArtistTopTracksCatalog struct {
-	calls   int
-	payload []map[string]any
-	err     error
-}
-
-func (s *stubArtistTopTracksCatalog) ArtistTopTracksBySlug(context.Context, string, int) ([]map[string]any, error) {
-	s.calls++
-	return s.payload, s.err
-}
 
 func TestRouteParts(t *testing.T) {
 	t.Run("decodes URL segments", func(t *testing.T) {
@@ -188,7 +176,53 @@ func TestArtistTopTracksSlugFallsBackToFastAPIForGlobalResolution(t *testing.T) 
 	assert.Equal(t, "fallback", rec.Header().Get("X-Crate-Readplane"))
 }
 
-func TestArtistTopTracksSlugConsultsCatalogBeforeFallback(t *testing.T) {
+func TestArtistTopTracksIdentityRoutesUseAuthoritativeFastAPIRanking(t *testing.T) {
+	const artistEntityUID = "123e4567-e89b-12d3-a456-426614174000"
+	tests := []struct {
+		path  string
+		write func(*Server, http.ResponseWriter, *http.Request)
+	}{
+		{
+			path: "/api/artists/7/top-tracks?count=50",
+			write: func(server *Server, w http.ResponseWriter, r *http.Request) {
+				server.writeArtistTopTracks(w, r)
+			},
+		},
+		{
+			path: "/api/artists/by-entity/" + artistEntityUID + "/top-tracks?count=50",
+			write: func(server *Server, w http.ResponseWriter, r *http.Request) {
+				server.writeArtistTopTracks(w, r)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.path, func(t *testing.T) {
+			backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				assert.Equal(t, tt.path, r.URL.RequestURI())
+				assert.Equal(t, "1", r.Header.Get("X-Crate-Readplane-Fallback"))
+				httpx.WriteJSON(w, http.StatusOK, []map[string]any{{"title": "Choose To Lose"}})
+			}))
+			defer backend.Close()
+
+			fallback, err := httpx.NewFallbackProxy(true, backend.URL, "test")
+			assert.NoError(t, err)
+			server := &Server{
+				fallback: fallback,
+				logger:   slog.New(slog.NewTextHandler(io.Discard, nil)),
+			}
+
+			req := httptest.NewRequest(http.MethodGet, tt.path, nil)
+			rec := httptest.NewRecorder()
+			tt.write(server, rec, req)
+
+			assert.Equal(t, http.StatusOK, rec.Code)
+			assert.Equal(t, "fallback", rec.Header().Get("X-Crate-Readplane"))
+		})
+	}
+}
+
+func TestArtistTopTracksSlugUsesAuthoritativeFastAPIRanking(t *testing.T) {
 	fallbackCalls := 0
 	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		fallbackCalls++
@@ -197,23 +231,18 @@ func TestArtistTopTracksSlugConsultsCatalogBeforeFallback(t *testing.T) {
 	defer backend.Close()
 	fallback, err := httpx.NewFallbackProxy(true, backend.URL, "test")
 	assert.NoError(t, err)
-	store := &stubArtistTopTracksCatalog{
-		payload: []map[string]any{{"title": "Catalog track"}},
-	}
 	server := &Server{
-		artistTopTracks: store,
-		fallback:        fallback,
-		logger:          slog.New(slog.NewTextHandler(io.Discard, nil)),
+		fallback: fallback,
+		logger:   slog.New(slog.NewTextHandler(io.Discard, nil)),
 	}
 	req := httptest.NewRequest(http.MethodGet, "/api/artist-slugs/high-vis/top-tracks?count=50", nil)
 	rec := httptest.NewRecorder()
 
-	server.writeArtistTopTracksBySlug(rec, req, "high-vis", 50)
+	server.writeArtistTopTracks(rec, req)
 
 	assert.Equal(t, http.StatusOK, rec.Code)
-	assert.Equal(t, "hit", rec.Header().Get("X-Crate-Readplane"))
-	assert.Equal(t, 1, store.calls)
-	assert.Equal(t, 0, fallbackCalls)
+	assert.Equal(t, "fallback", rec.Header().Get("X-Crate-Readplane"))
+	assert.Equal(t, 1, fallbackCalls)
 }
 
 func TestCanonicalCatalogCatchAllFallsBackToFastAPI(t *testing.T) {

--- a/app/readplane/internal/routes/server.go
+++ b/app/readplane/internal/routes/server.go
@@ -34,7 +34,6 @@ type Server struct {
 	redis           *redis.Client
 	auth            *auth.Authenticator
 	catalog         *catalog.Store
-	artistTopTracks artistTopTracksCatalog
 	localMedia      localMediaCatalog
 	artworkCatalog  artworkCatalog
 	artworkResolver *media.ArtworkResolver
@@ -43,10 +42,6 @@ type Server struct {
 	fallback        *httpx.FallbackProxy
 	federationProxy *readplanefederation.Proxy
 	logger          *slog.Logger
-}
-
-type artistTopTracksCatalog interface {
-	ArtistTopTracksBySlug(context.Context, string, int) ([]map[string]any, error)
 }
 
 type localMediaCatalog interface {
@@ -87,7 +82,6 @@ func NewServer(
 		logger:          logger,
 	}
 	if catalogStore != nil {
-		server.artistTopTracks = catalogStore
 		server.localMedia = catalogStore
 		server.artworkCatalog = catalogStore
 	}

--- a/app/readplane/internal/routes/stats_dashboard.go
+++ b/app/readplane/internal/routes/stats_dashboard.go
@@ -17,11 +17,11 @@ var statsDashboardLimits = []struct {
 	name         string
 	defaultValue int
 }{
-	{name: "tracks_limit", defaultValue: 10},
-	{name: "artists_limit", defaultValue: 8},
-	{name: "albums_limit", defaultValue: 8},
-	{name: "genres_limit", defaultValue: 8},
-	{name: "replay_limit", defaultValue: 30},
+	{name: "tracks_limit", defaultValue: 12},
+	{name: "artists_limit", defaultValue: 10},
+	{name: "albums_limit", defaultValue: 12},
+	{name: "genres_limit", defaultValue: 10},
+	{name: "replay_limit", defaultValue: 36},
 }
 
 func statsDashboardSubjectKey(userID int64, query url.Values) (string, error) {

--- a/app/readplane/internal/routes/stats_dashboard_test.go
+++ b/app/readplane/internal/routes/stats_dashboard_test.go
@@ -20,7 +20,7 @@ func TestStatsDashboardSubjectKey(t *testing.T) {
 			name:   "defaults",
 			userID: 17,
 			query:  url.Values{},
-			want:   "user:17:30d:default:10:8:8:8:30",
+			want:   "user:17:30d:default:12:10:12:10:36",
 		},
 		{
 			name:   "custom window and limits",
@@ -39,7 +39,7 @@ func TestStatsDashboardSubjectKey(t *testing.T) {
 			name:   "month overrides period",
 			userID: 9,
 			query:  url.Values{"month": {"2026-04"}},
-			want:   "user:9:month:2026-04:2026-04:10:8:8:8:30",
+			want:   "user:9:month:2026-04:2026-04:12:10:12:10:36",
 		},
 		{
 			name:    "invalid month",

--- a/app/tests/test_explore_contracts.py
+++ b/app/tests/test_explore_contracts.py
@@ -177,6 +177,67 @@ class TestExploreFiltersContract:
             }
         ]
 
+    def test_explore_page_reads_persisted_global_genre_snapshot(
+        self,
+        test_app,
+        monkeypatch,
+    ):
+        from crate.api import browse
+
+        monkeypatch.setattr(
+            browse,
+            "get_catalog_state",
+            lambda: {"status": "ready", "last_full_reconcile_at": object()},
+        )
+        monkeypatch.setattr(browse, "catalog_serves_global", lambda _state: True)
+        monkeypatch.setattr(
+            browse,
+            "get_ui_snapshot",
+            lambda scope, subject_key, **_kwargs: {
+                "scope": scope,
+                "subject_key": subject_key,
+                "payload_json": {
+                    "items": [
+                        {
+                            "canonical_name": "Death Metal",
+                            "canonical_slug": "death-metal",
+                            "artist_count": 2,
+                            "description": "Extreme metal.",
+                            "top_artists": ["Death"],
+                            "cover_url": "/api/genres/death-metal/cover",
+                        }
+                    ]
+                },
+                "version": 4,
+            },
+            raising=False,
+        )
+        monkeypatch.setattr(
+            browse,
+            "list_global_catalog_genres",
+            MagicMock(side_effect=AssertionError("live genre query must stay cold")),
+        )
+
+        with (
+            patch(
+                "crate.api.browse.api_browse_filters",
+                return_value={
+                    "genres": [{"name": "Legacy Genre", "count": 99}],
+                    "countries": [],
+                    "decades": [],
+                    "formats": [],
+                },
+            ),
+            patch("crate.api.browse.curated_playlists", return_value=[]),
+            patch("crate.api.browse.api_browse_moods", return_value=[]),
+            patch("crate.api.browse.get_cache", return_value=None),
+            patch("crate.api.browse.set_cache"),
+        ):
+            response = test_app.get("/api/browse/explore-page")
+
+        assert response.status_code == 200
+        assert response.json()["filters"]["genres"][0]["name"] == "Death Metal"
+
     def test_explore_page_keeps_local_genres_during_catalog_warming(
         self,
         test_app,

--- a/app/tests/test_federation_migration_matrix.py
+++ b/app/tests/test_federation_migration_matrix.py
@@ -306,7 +306,7 @@ def _seed_063_legacy_state() -> dict[str, str]:
 
 
 def _assert_hardened_state(ids: dict[str, str]) -> None:
-    assert _scalar("SELECT version_num FROM alembic_version") == "079"
+    assert _scalar("SELECT version_num FROM alembic_version") == "080"
     assert (
         _scalar(
             "SELECT status FROM federation_local_keys WHERE node_uid = %s",
@@ -356,7 +356,7 @@ def test_empty_database_migrates_from_base_to_head(pg_db):
 
     _migrate("head")
 
-    assert _scalar("SELECT version_num FROM alembic_version") == "079"
+    assert _scalar("SELECT version_num FROM alembic_version") == "080"
     for table in (
         "federation_local_keys",
         "federation_catalog_changes",
@@ -378,7 +378,7 @@ def test_real_main_049_snapshot_upgrades_without_user_data_loss(pg_db):
 
     _migrate("head")
 
-    assert _scalar("SELECT version_num FROM alembic_version") == "079"
+    assert _scalar("SELECT version_num FROM alembic_version") == "080"
     assert _scalar("SELECT email FROM users WHERE id = %s", (ids["user_id"],)) == (
         "legacy@example.test"
     )

--- a/app/tests/test_global_catalog_reconciliation.py
+++ b/app/tests/test_global_catalog_reconciliation.py
@@ -124,6 +124,188 @@ def test_reconcile_local_catalog_is_idempotent(pg_db):
     }
 
 
+def test_full_match_recompute_rebinds_recording_mbid_without_unique_violation(
+    pg_db,
+):
+    from crate.db.tx import read_scope, transaction_scope
+    from crate.federation.global_reconciliation import (
+        reconcile_local_catalog,
+        reconcile_local_catalog_batch,
+    )
+
+    pg_db.upsert_artist(
+        {
+            "name": "Pulp",
+            "entity_uid": str(uuid.uuid4()),
+        }
+    )
+    original_album_id = pg_db.upsert_album(
+        {
+            "artist": "Pulp",
+            "name": "Different Class",
+            "path": "/music/Pulp/Different Class",
+            "entity_uid": str(uuid.uuid4()),
+            "year": "1995",
+            "track_count": 1,
+        }
+    )
+    deluxe_album_id = pg_db.upsert_album(
+        {
+            "artist": "Pulp",
+            "name": "Different Class (Deluxe Edition)",
+            "path": "/music/Pulp/Different Class (Deluxe Edition)",
+            "entity_uid": str(uuid.uuid4()),
+            "year": "1995",
+            "track_count": 1,
+        }
+    )
+    original_track_path = "/music/Pulp/Different Class/01 - Mis-Shapes.flac"
+    pg_db.upsert_track(
+        {
+            "album_id": original_album_id,
+            "artist": "Pulp",
+            "album": "Different Class",
+            "filename": "01 - Mis-Shapes.flac",
+            "title": "Mis-Shapes",
+            "path": original_track_path,
+            "entity_uid": str(uuid.uuid4()),
+            "duration": 227.0,
+            "disc_number": 1,
+            "track_number": 1,
+        }
+    )
+    deluxe_track_path = (
+        "/music/Pulp/Different Class (Deluxe Edition)/01 - Mis-Shapes.flac"
+    )
+    pg_db.upsert_track(
+        {
+            "album_id": deluxe_album_id,
+            "artist": "Pulp",
+            "album": "Different Class (Deluxe Edition)",
+            "filename": "01 - Mis-Shapes.flac",
+            "title": "Mis-Shapes",
+            "path": deluxe_track_path,
+            "entity_uid": str(uuid.uuid4()),
+            "musicbrainz_trackid": "recording-mbid",
+            "duration": 235.0,
+            "disc_number": 1,
+            "track_number": 1,
+        }
+    )
+    with read_scope() as session:
+        track_ids = (
+            session.execute(
+                text(
+                    """
+                    SELECT id
+                    FROM library_tracks
+                    WHERE path = ANY(:paths)
+                    ORDER BY path
+                    """
+                ),
+                {"paths": [original_track_path, deluxe_track_path]},
+            )
+            .scalars()
+            .all()
+        )
+    original_track_id, deluxe_track_id = sorted(track_ids)
+    reconcile_local_catalog()
+
+    with read_scope() as session:
+        initial_sources = (
+            session.execute(
+                text(
+                    """
+                    SELECT
+                        local_id,
+                        global_entity_uid::text AS global_entity_uid
+                    FROM global_catalog_sources
+                    WHERE entity_type = 'track'
+                      AND local_id = ANY(:track_ids)
+                    ORDER BY local_id
+                    """
+                ),
+                {"track_ids": [original_track_id, deluxe_track_id]},
+            )
+            .mappings()
+            .all()
+        )
+    assert len({row["global_entity_uid"] for row in initial_sources}) == 2
+
+    replacement_entity_uid = str(uuid.uuid4())
+    with transaction_scope() as session:
+        session.execute(
+            text(
+                """
+                UPDATE library_tracks
+                SET duration = 227,
+                    entity_uid = CAST(:entity_uid AS uuid)
+                WHERE id = :track_id
+                """
+            ),
+            {
+                "entity_uid": replacement_entity_uid,
+                "track_id": deluxe_track_id,
+            },
+        )
+        session.execute(
+            text(
+                """
+                UPDATE global_catalog_sources
+                SET local_entity_uid = CAST(:entity_uid AS uuid)
+                WHERE entity_type = 'track'
+                  AND local_id = :track_id
+                """
+            ),
+            {
+                "entity_uid": replacement_entity_uid,
+                "track_id": deluxe_track_id,
+            },
+        )
+
+    cursor = None
+    while True:
+        batch = reconcile_local_catalog_batch(
+            batch_size=1,
+            cursor=cursor,
+            recompute_matches=True,
+        )
+        if batch["completed"]:
+            break
+        cursor = batch["next_cursor"]
+
+    with read_scope() as session:
+        reconciled_sources = (
+            session.execute(
+                text(
+                    """
+                    SELECT global_entity_uid::text AS global_entity_uid
+                    FROM global_catalog_sources
+                    WHERE entity_type = 'track'
+                      AND local_id = ANY(:track_ids)
+                    ORDER BY local_id
+                    """
+                ),
+                {"track_ids": [original_track_id, deluxe_track_id]},
+            )
+            .scalars()
+            .all()
+        )
+        recording_mbid = session.execute(
+            text(
+                """
+                SELECT musicbrainz_recording_mbid
+                FROM global_catalog_tracks
+                WHERE global_track_uid = CAST(:global_uid AS uuid)
+                """
+            ),
+            {"global_uid": reconciled_sources[0]},
+        ).scalar_one()
+
+    assert len(set(reconciled_sources)) == 1
+    assert recording_mbid == "recording-mbid"
+
+
 def test_full_match_recompute_splits_sources_that_no_longer_match(pg_db):
     from crate.db.tx import read_scope, transaction_scope
     from crate.federation.global_reconciliation import (

--- a/app/tests/test_home_projection_policy.py
+++ b/app/tests/test_home_projection_policy.py
@@ -70,13 +70,15 @@ def test_cold_home_request_returns_schema_valid_minimal_payload(monkeypatch):
     monkeypatch.setattr(
         surface,
         "get_home_recently_played",
-        lambda _user_id: [{"title": "Song"}],
+        lambda _user_id: (_ for _ in ()).throw(
+            AssertionError("cold home must not run history queries")
+        ),
     )
 
     payload = surface.get_cached_home_discovery(7)
 
     assert payload["hero"] is None
-    assert payload["recently_played"] == [{"title": "Song"}]
+    assert payload["recently_played"] == []
     assert payload["custom_mixes"] == []
     assert payload["snapshot"]["pending"] is True
     assert queued == [7]
@@ -86,9 +88,14 @@ def test_home_refresh_worker_builds_full_snapshot(monkeypatch):
     from crate.worker_handlers import analysis
 
     calls: list[tuple[int, bool]] = []
+    invalidations: list[tuple[str, ...]] = []
     monkeypatch.setattr(
         "crate.db.home.get_cached_home_discovery",
         lambda user_id, fresh=False: calls.append((user_id, fresh)) or {"hero": {}},
+    )
+    monkeypatch.setattr(
+        "crate.api.cache_events.broadcast_invalidation",
+        lambda *scopes: invalidations.append(scopes),
     )
 
     result = analysis._handle_refresh_home_discovery_snapshot(
@@ -97,6 +104,7 @@ def test_home_refresh_worker_builds_full_snapshot(monkeypatch):
 
     assert result == {"ok": True, "user_id": 7}
     assert calls == [(7, True)]
+    assert invalidations == [("home",)]
 
 
 def test_expired_stale_after_does_not_hide_snapshot_inside_requested_stale_window(

--- a/app/tests/test_postgres_test_database.py
+++ b/app/tests/test_postgres_test_database.py
@@ -32,7 +32,7 @@ def test_pg_db_uses_an_isolated_clone_of_the_initialized_template(pg_db) -> None
 
     assert database_name != TEST_DB_NAME
     assert database_name.startswith(f"{TEST_DB_NAME}_case_")
-    assert revision == "079"
+    assert revision == "080"
     assert admin_count >= 1
     assert os.environ["CRATE_POSTGRES_DB"] == database_name
 

--- a/app/tests/test_top_track_ranking_bootstrap.py
+++ b/app/tests/test_top_track_ranking_bootstrap.py
@@ -1,0 +1,148 @@
+def test_startup_queues_top_track_ranking_backfill_when_version_is_stale(
+    monkeypatch,
+):
+    from crate import api
+    from crate.db import cache_settings
+    from crate.db.repositories import tasks
+    from crate.popularity import ARTIST_TOP_TRACK_RANKING_VERSION
+
+    queued: list[tuple[str, dict, str]] = []
+    monkeypatch.setattr(cache_settings, "get_setting", lambda _key: None)
+    monkeypatch.setattr(
+        tasks,
+        "create_task_dedup",
+        lambda task_type, params, *, dedup_key: queued.append(
+            (task_type, params, dedup_key)
+        ),
+    )
+
+    api._queue_artist_top_track_ranking_backfill()
+
+    assert queued == [
+        (
+            "compute_popularity",
+            {
+                "triggered_by": "api_startup",
+                "ranking_version": ARTIST_TOP_TRACK_RANKING_VERSION,
+            },
+            f"bootstrap:artist-top-tracks:v{ARTIST_TOP_TRACK_RANKING_VERSION}",
+        )
+    ]
+
+
+def test_startup_skips_current_top_track_ranking_backfill(monkeypatch):
+    from crate import api
+    from crate.db import cache_settings
+    from crate.db.repositories import tasks
+    from crate.popularity import ARTIST_TOP_TRACK_RANKING_VERSION
+
+    monkeypatch.setattr(
+        cache_settings,
+        "get_setting",
+        lambda _key: ARTIST_TOP_TRACK_RANKING_VERSION,
+    )
+    monkeypatch.setattr(
+        tasks,
+        "create_task_dedup",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            AssertionError("current ranking must not queue a backfill")
+        ),
+    )
+
+    api._queue_artist_top_track_ranking_backfill()
+
+
+def test_popularity_finalize_marks_ranking_and_invalidates_artist_surfaces(
+    monkeypatch,
+):
+    from crate.popularity import ARTIST_TOP_TRACK_RANKING_VERSION
+    from crate.worker_handlers import analysis
+
+    settings: list[tuple[str, str]] = []
+    deleted: list[str] = []
+    invalidations: list[tuple[str, ...]] = []
+    monkeypatch.setattr(
+        "crate.popularity.recompute_track_popularity_scores",
+        lambda: {"tracks_scored": 27},
+    )
+    monkeypatch.setattr(
+        "crate.db.cache_settings.set_setting",
+        lambda key, value: settings.append((key, value)),
+    )
+    monkeypatch.setattr(
+        "crate.db.cache_store.delete_cache_prefix",
+        lambda prefix: deleted.append(prefix),
+    )
+    monkeypatch.setattr(
+        "crate.api.cache_events.broadcast_invalidation",
+        lambda *scopes: invalidations.append(scopes),
+    )
+
+    result = analysis._popularity_finalize()
+
+    assert result == {"tracks_scored": 27}
+    assert settings == [
+        ("artist_top_track_ranking_version", ARTIST_TOP_TRACK_RANKING_VERSION)
+    ]
+    assert deleted == [
+        "listen:artist_top_tracks:v1:",
+        "listen:artist_top_tracks:v2:",
+        "listen:artist_top_tracks:v3:",
+        "listen:artist_page:v6:",
+    ]
+    assert invalidations == [("catalog", "home")]
+
+
+def test_failed_popularity_chunk_does_not_mark_ranking_backfill_complete(monkeypatch):
+    from crate.db.repositories import tasks
+    from crate.worker_handlers import analysis
+
+    finalized: list[bool] = []
+    updated: list[dict] = []
+    monkeypatch.setattr(
+        tasks,
+        "check_siblings_complete",
+        lambda _parent_id: {
+            "all_done": True,
+            "total": 2,
+            "completed": 1,
+            "failed": 1,
+        },
+    )
+    monkeypatch.setattr(
+        tasks,
+        "update_task",
+        lambda _task_id, **kwargs: updated.append(kwargs),
+    )
+    monkeypatch.setattr(analysis, "emit_task_event", lambda *_args, **_kwargs: None)
+    monkeypatch.setitem(
+        analysis._PARENT_FINALIZERS,
+        "compute_popularity",
+        lambda: finalized.append(True) or {},
+    )
+
+    analysis._try_complete_parent("parent-1", "compute_popularity")
+
+    assert finalized == []
+    assert updated[0]["result"]["finalization_skipped"] is True
+
+
+def test_empty_popularity_backfill_still_finalizes_ranking_version(monkeypatch):
+    from crate.worker_handlers import analysis
+
+    finalized: list[bool] = []
+    monkeypatch.setattr(
+        analysis,
+        "_chunk_coordinator",
+        lambda *_args, **_kwargs: {"chunks": 0, "artists": 0},
+    )
+    monkeypatch.setattr(
+        analysis,
+        "_popularity_finalize",
+        lambda: finalized.append(True) or {"tracks_scored": 0},
+    )
+
+    result = analysis._handle_compute_popularity("task-1", {}, {})
+
+    assert result == {"chunks": 0, "artists": 0, "tracks_scored": 0}
+    assert finalized == [True]

--- a/app/tests/test_user_library_queries.py
+++ b/app/tests/test_user_library_queries.py
@@ -906,6 +906,47 @@ class TestPlayHistory:
         assert history[0]["artist_id"] is None
         assert history[0]["album_id"] is None
 
+    def test_get_play_history_dedupes_ambiguous_metadata_fallback(self, lib_db):
+        artist = "Ambiguous History Artist"
+        title = "Shared History Song"
+        first = _seed_global_catalog_track(
+            artist_uid="61111111-1111-4111-8111-111111111111",
+            album_uid="62222222-2222-4222-8222-222222222222",
+            track_uid="63333333-3333-4333-8333-333333333333",
+            artist=artist,
+            album="First History Album",
+            title=title,
+        )
+        _seed_global_catalog_track(
+            artist_uid=first["artist_uid"],
+            album_uid="62222222-2222-4222-8222-222222222223",
+            track_uid="63333333-3333-4333-8333-333333333334",
+            artist=artist,
+            album="Second History Album",
+            title=title,
+        )
+        now = datetime.now(timezone.utc)
+        _insert_play_event(
+            TEST_USER_ID,
+            title=title,
+            artist=artist,
+            album="",
+            track_path="",
+            ended_at=now,
+        )
+
+        from crate.db.queries.user_library_history import get_play_history_rows
+
+        history = get_play_history_rows(
+            TEST_USER_ID,
+            limit=10,
+            has_legacy_stream_id_column=False,
+        )
+
+        matching = [item for item in history if item["title"] == title]
+        assert len(matching) == 1
+        assert matching[0]["global_track_uid"] == first["track_uid"]
+
     def test_get_play_history_backfills_legacy_remote_events_from_global_catalog(
         self, lib_db
     ):
@@ -1640,6 +1681,54 @@ class TestStatsTops:
         assert item["global_album_uid"] == catalog["album_uid"]
         assert item["album_id"] is None
 
+    def test_get_replay_mix_uses_one_deterministic_metadata_fallback(self, lib_db):
+        artist = "Ambiguous Replay Artist"
+        title = "Shared Song"
+        first = _seed_global_catalog_track(
+            artist_uid="41111111-1111-4111-8111-111111111111",
+            album_uid="42222222-2222-4222-8222-222222222222",
+            track_uid="43333333-3333-4333-8333-333333333333",
+            artist=artist,
+            album="First Album",
+            title=title,
+        )
+        _seed_global_catalog_track(
+            artist_uid=first["artist_uid"],
+            album_uid="42222222-2222-4222-8222-222222222223",
+            track_uid="43333333-3333-4333-8333-333333333334",
+            artist=artist,
+            album="Second Album",
+            title=title,
+        )
+        with transaction_scope() as session:
+            session.execute(
+                text(
+                    """
+                    INSERT INTO user_track_stats (
+                        user_id, stat_window, entity_key, track_id,
+                        global_track_uid, track_entity_uid, track_path,
+                        title, artist, album,
+                        play_count, complete_play_count, minutes_listened,
+                        first_played_at, last_played_at
+                    )
+                    VALUES (
+                        :user_id, '30d', 'legacy:shared-song', NULL,
+                        NULL, NULL, '',
+                        :title, :artist, '',
+                        4, 4, 12.0, NOW(), NOW()
+                    )
+                    """
+                ),
+                {"user_id": TEST_USER_ID, "artist": artist, "title": title},
+            )
+
+        from crate.db.queries.user_library_stats_tops import get_replay_mix
+
+        mix = get_replay_mix(TEST_USER_ID, window="30d", limit=10)
+
+        assert [item["title"] for item in mix["items"]] == [title]
+        assert mix["items"][0]["global_track_uid"] == first["track_uid"]
+
     def test_get_month_top_tracks_resolves_global_catalog_identity(self, lib_db):
         catalog = _seed_global_catalog_track()
         now = datetime.now(timezone.utc)
@@ -1663,6 +1752,43 @@ class TestStatsTops:
         assert top[0]["global_artist_uid"] == catalog["artist_uid"]
         assert top[0]["global_album_uid"] == catalog["album_uid"]
         assert top[0]["track_id"] is None
+
+    def test_get_month_top_tracks_dedupes_ambiguous_metadata_fallback(self, lib_db):
+        artist = "Ambiguous Monthly Artist"
+        title = "Shared Monthly Song"
+        first = _seed_global_catalog_track(
+            artist_uid="51111111-1111-4111-8111-111111111111",
+            album_uid="52222222-2222-4222-8222-222222222222",
+            track_uid="53333333-3333-4333-8333-333333333333",
+            artist=artist,
+            album="First Monthly Album",
+            title=title,
+        )
+        _seed_global_catalog_track(
+            artist_uid=first["artist_uid"],
+            album_uid="52222222-2222-4222-8222-222222222223",
+            track_uid="53333333-3333-4333-8333-333333333334",
+            artist=artist,
+            album="Second Monthly Album",
+            title=title,
+        )
+        now = datetime.now(timezone.utc)
+        _insert_play_event(
+            TEST_USER_ID,
+            title=title,
+            artist=artist,
+            album="",
+            track_path="",
+            ended_at=now,
+        )
+
+        from crate.db.queries.user_library_stats_month import get_month_top_tracks
+
+        top = get_month_top_tracks(TEST_USER_ID, now.strftime("%Y-%m"), limit=10)
+
+        matching = [item for item in top if item["title"] == title]
+        assert len(matching) == 1
+        assert matching[0]["global_track_uid"] == first["track_uid"]
         assert top[0]["album_id"] is None
 
     def test_get_month_replay_mix_resolves_global_catalog_identity(self, lib_db):

--- a/app/tests/test_user_listening_hotpath_migration.py
+++ b/app/tests/test_user_listening_hotpath_migration.py
@@ -1,0 +1,21 @@
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+MIGRATION = (
+    ROOT / "app/crate/db/migrations/versions/080_user_listening_hotpath_indexes.py"
+)
+
+
+def test_user_listening_hotpath_migration_adds_metadata_fallback_index():
+    migration = MIGRATION.read_text()
+
+    assert 'revision = "080"' in migration
+    assert 'down_revision = "079"' in migration
+    assert "idx_global_tracks_lower_artist_title_album" in migration
+    assert "LOWER(artist_name)" in migration
+    assert "LOWER(canonical_title)" in migration
+    assert "LOWER(COALESCE(album_name, ''))" in migration
+    assert (
+        "DROP INDEX IF EXISTS idx_global_tracks_lower_artist_title_album" in migration
+    )

--- a/app/tests/test_user_stats_dashboard_surface.py
+++ b/app/tests/test_user_stats_dashboard_surface.py
@@ -1,7 +1,7 @@
 def _stats_snapshot(payload: dict) -> dict:
     return {
         "scope": "stats:dashboard",
-        "subject_key": "user:7:30d:default:10:8:8:8:30",
+        "subject_key": "user:7:30d:default:12:10:12:10:36",
         "payload_json": payload,
         "version": 2,
         "built_at": "2026-07-18T10:00:00+00:00",
@@ -59,11 +59,11 @@ def test_cold_stats_dashboard_returns_minimal_payload_and_queues_projection(
             "user_id": 7,
             "window": "30d",
             "month": None,
-            "tracks_limit": 10,
-            "artists_limit": 8,
-            "albums_limit": 8,
-            "genres_limit": 8,
-            "replay_limit": 30,
+            "tracks_limit": 12,
+            "artists_limit": 10,
+            "albums_limit": 12,
+            "genres_limit": 10,
+            "replay_limit": 36,
         }
     ]
 
@@ -113,3 +113,44 @@ def test_stats_refresh_worker_builds_default_dashboard(monkeypatch):
     assert result == {"ok": True, "user_id": 7, "window": "30d"}
     assert calls == [(7, "30d")]
     assert invalidations == [("history",)]
+
+
+def test_stats_bootstrap_queues_only_missing_canonical_snapshots(monkeypatch):
+    from crate.db import user_stats_dashboard_surface as surface
+
+    queued: list[tuple[int, str]] = []
+    monkeypatch.setattr(surface, "_list_stats_dashboard_user_ids", lambda: [7, 8])
+    monkeypatch.setattr(
+        surface,
+        "get_ui_snapshot",
+        lambda _scope, subject_key, **_kwargs: (
+            {"subject_key": subject_key} if subject_key.startswith("user:8:") else None
+        ),
+    )
+    monkeypatch.setattr(
+        surface,
+        "_schedule_projection",
+        lambda params, subject_key: queued.append((params["user_id"], subject_key)),
+    )
+
+    count = surface.queue_missing_stats_dashboard_snapshots()
+
+    assert count == 1
+    assert queued == [(7, "user:7:30d:default:12:10:12:10:36")]
+
+
+def test_api_startup_queues_stats_snapshot_bootstrap(monkeypatch):
+    from crate import api
+    from crate.db import user_stats_dashboard_surface as surface
+
+    calls: list[bool] = []
+    monkeypatch.setattr(
+        surface,
+        "queue_missing_stats_dashboard_snapshots",
+        lambda: calls.append(True) or 2,
+        raising=False,
+    )
+
+    api._queue_stats_dashboard_backfill()
+
+    assert calls == [True]


### PR DESCRIPTION
## Summary

Fixes the production reconciliation failure and removes three sources of
user-visible read latency/regression discovered during the v2.3 federation
rollout.

### Global catalog reconciliation

- Rebinds an existing source to an already-present canonical entity before
  canonical metadata is updated.
- Deletes or refreshes the orphaned canonical inside the same transaction,
  avoiding the `musicbrainz_recording_mbid` unique-index violation seen for
  Pulp / `Mis-Shapes`.
- Covers local and federated artist, album, and track reconciliation paths.

### Artist Top Tracks

- Makes FastAPI the single authoritative ranking implementation for slug,
  numeric-ID, and entity-UID routes.
- Removes the divergent Go readplane ordering that caused artist preview and
  `View all` to disagree.
- Adds a versioned, restart-safe popularity/ranking backfill at startup.
- Only marks the ranking version complete after every chunk succeeds; empty
  libraries finalize correctly.
- Clears all artist Top Tracks/page caches and emits catalog/home invalidation
  after the backfill.

### Stats, Home, and Explore latency

- Aligns FastAPI, projector, worker, and Go readplane Stats defaults with
  Listen's canonical `12/10/12/10/36` request, so prewarmed snapshots are hit.
- Prewarms missing canonical 30-day Stats snapshots for active users and serves
  stale snapshots while refreshing.
- Rewrites replay/month/history resolution joins as deterministic indexed
  lateral lookups (`track ID -> entity UID -> metadata`) so ambiguous releases
  cannot multiply one play event.
- Adds migration `080` with a concurrent functional lookup index for global
  track metadata fallback.
- Reads Explore genres from the persisted global taxonomy snapshot and
  increases its invalidation-backed server cache from 60s to 10m.
- Makes cold Home responses truly non-blocking and broadcasts `home`
  invalidation when the full background projection is ready.

## Production evidence

- Failed reconciliation run `c7f267dd-90e1-49b9-9067-8a3cf4fa9f80` failed
  after 123,874 sources due to a duplicate recording MBID during source
  rebinding.
- Stats 30d build was about 5.6s; replay alone was about 4.25s.
- Home projection was about 12s; recent history and month replay accounted for
  about 9s.
- Explore genre aggregation was about 2.8s despite an existing persisted global
  genre snapshot.

## Verification

- 141 focused PostgreSQL-backed reconciliation/query/snapshot/migration tests
- 63 artist ranking, Stats API, projector, and federation regression tests
- 8 base-to-head / rollback migration matrix tests
- Full Go readplane suite (`go test ./...`)
- Ruff check + format
- Pyright: 0 errors / 0 warnings
- Pre-commit hooks green

## Deploy notes

- Migration 080 creates its index with `CREATE INDEX CONCURRENTLY` to avoid
  blocking production writes.
- API startup resumes the failed full reconciliation, queues missing canonical
  Stats snapshots, and queues the versioned Top Tracks signal refresh.
- Do not publish the release tag until the full reconciliation and ranking
  backfill complete and production smoke checks pass.
