### PR TITLE
fix: bound cold listen read latency

### DIFF
--- a/app/crate/api/me.py
+++ b/app/crate/api/me.py
@@ -95,8 +95,8 @@ from crate.db.home import (
     get_cached_home_discovery,
     get_home_discovery_debug,
     get_home_playlist,
-    get_home_section,
 )
+from crate.db.home_section_surface import get_cached_home_section
 from crate.db.queries.shows import get_attending_show_ids, get_show_reminders
 from crate.db.queries.user import (
     get_artist_genres_for_names,
@@ -1301,12 +1301,10 @@ def home_section_detail(
     request: Request, section_id: str, limit: int = Query(42, ge=1, le=120)
 ):
     user = _require_auth(request)
-    cache_mode = _listen_global_cache_mode()
-    section = _get_cached_home_endpoint_response(
-        cache_key=f"home_section:v4:{cache_mode}:{user['id']}:{section_id}:{limit}",
-        max_age_seconds=300,
-        ttl=300,
-        compute=lambda: get_home_section(user["id"], section_id, limit=limit),
+    section = get_cached_home_section(
+        user["id"],
+        section_id,
+        limit=limit,
     )
     if not section:
         raise HTTPException(status_code=404, detail="Section not found")

--- a/app/crate/db/home_section_surface.py
+++ b/app/crate/db/home_section_surface.py
@@ -1,0 +1,154 @@
+from __future__ import annotations
+
+import time
+from typing import Any
+
+from crate.db.cache_store import get_cache, set_cache
+from crate.db.home_discovery_surface import get_cached_home_discovery
+from crate.db.home_personalized_discovery import get_home_section
+from crate.db.repositories.tasks import create_task_dedup
+
+_FRESH_MAX_AGE_SECONDS = 300
+_STALE_MAX_AGE_SECONDS = 3600
+_CACHE_TTL_SECONDS = 3600
+_DEFAULT_SECTION_LIMIT = 42
+
+_SECTION_METADATA = {
+    "recently-played": (
+        "Recently played",
+        "Albums, artists and playlists you touched most recently.",
+        "recently_played",
+    ),
+    "custom-mixes": (
+        "Custom mixes",
+        "Dynamic playlists shaped around your own listening profile.",
+        "custom_mixes",
+    ),
+    "suggested-albums": (
+        "Suggested new albums for you",
+        "Recent releases from the artists you already care about.",
+        "suggested_albums",
+    ),
+    "recommended-tracks": (
+        "Recommended new tracks",
+        "Fresh cuts from artists and albums that line up with your taste.",
+        "recommended_tracks",
+    ),
+    "radio-stations": (
+        "Radio stations",
+        "Artist and album radios seeded from the things you replay the most.",
+        "radio_stations",
+    ),
+    "favorite-artists": (
+        "Favorite artists",
+        "Your most played names over the last few months.",
+        "favorite_artists",
+    ),
+    "core-tracks": (
+        "Artist Sets",
+        "Discovery-forward artist sets, ending with familiar anchors.",
+        "essentials",
+    ),
+}
+
+
+def _cache_key(user_id: int, section_id: str, limit: int) -> str:
+    return f"home_section:v4:global:{user_id}:{section_id}:{limit}"
+
+
+def _schedule_home_refresh(user_id: int) -> None:
+    create_task_dedup(
+        "refresh_home_discovery_snapshot",
+        {"user_id": user_id, "include_sections": True},
+        dedup_key=f"home-discovery:{user_id}",
+    )
+
+
+def _pack(payload: dict) -> dict[str, Any]:
+    return {
+        "_home_section_cached_at": time.time(),
+        "_home_section_payload": payload,
+    }
+
+
+def _unpack(value: Any, *, max_age_seconds: int) -> dict | None:
+    if not isinstance(value, dict):
+        return None
+    payload = value.get("_home_section_payload")
+    cached_at = value.get("_home_section_cached_at")
+    if isinstance(payload, dict) and isinstance(cached_at, int | float):
+        if time.time() - float(cached_at) <= max_age_seconds:
+            return payload
+        return None
+    return value
+
+
+def _discovery_fallback(
+    user_id: int,
+    section_id: str,
+    *,
+    limit: int,
+) -> dict | None:
+    metadata = _SECTION_METADATA.get(section_id)
+    if metadata is None:
+        return None
+    title, subtitle, discovery_key = metadata
+    discovery = get_cached_home_discovery(user_id)
+    items = discovery.get(discovery_key) if isinstance(discovery, dict) else None
+    return {
+        "id": section_id,
+        "title": title,
+        "subtitle": subtitle,
+        "items": list(items or [])[:limit],
+    }
+
+
+def get_cached_home_section(
+    user_id: int,
+    section_id: str,
+    *,
+    limit: int = _DEFAULT_SECTION_LIMIT,
+    fresh: bool = False,
+) -> dict | None:
+    if section_id not in _SECTION_METADATA:
+        return None
+
+    key = _cache_key(user_id, section_id, limit)
+    if fresh:
+        section = get_home_section(user_id, section_id, limit)
+        if section is not None:
+            set_cache(key, _pack(section), ttl=_CACHE_TTL_SECONDS)
+        return section
+
+    cached_value = get_cache(key, max_age_seconds=_FRESH_MAX_AGE_SECONDS)
+    cached = _unpack(cached_value, max_age_seconds=_FRESH_MAX_AGE_SECONDS)
+    if cached is not None:
+        return cached
+
+    stale_value = get_cache(key, max_age_seconds=_STALE_MAX_AGE_SECONDS)
+    stale = _unpack(stale_value, max_age_seconds=_STALE_MAX_AGE_SECONDS)
+    _schedule_home_refresh(user_id)
+    if stale is not None:
+        return stale
+    return _discovery_fallback(user_id, section_id, limit=limit)
+
+
+def warm_home_sections(
+    user_id: int,
+    *,
+    limit: int = _DEFAULT_SECTION_LIMIT,
+) -> dict[str, dict]:
+    warmed: dict[str, dict] = {}
+    for section_id in _SECTION_METADATA:
+        section = get_cached_home_section(
+            user_id,
+            section_id,
+            limit=limit,
+            fresh=True,
+        )
+        if section is not None:
+            warmed[section_id] = section
+    return warmed
+
+
+__all__ = ["get_cached_home_section", "warm_home_sections"]

--- a/app/crate/db/queries/genres_library_catalog.py
+++ b/app/crate/db/queries/genres_library_catalog.py
@@ -12,13 +12,27 @@ def get_all_genres() -> list[dict]:
             session.execute(
                 text(
                     """
+                WITH artist_counts AS (
+                    SELECT
+                        genre_id,
+                        COUNT(DISTINCT artist_name)::INTEGER AS artist_count
+                    FROM artist_genres
+                    GROUP BY genre_id
+                ),
+                album_counts AS (
+                    SELECT
+                        genre_id,
+                        COUNT(DISTINCT album_id)::INTEGER AS album_count
+                    FROM album_genres
+                    GROUP BY genre_id
+                )
                 SELECT
                     g.id,
                     g.entity_uid::text AS entity_uid,
                     g.name,
                     g.slug,
-                    COUNT(DISTINCT ag.artist_name)::INTEGER AS artist_count,
-                    COUNT(DISTINCT alg.album_id)::INTEGER AS album_count,
+                    COALESCE(ac.artist_count, 0) AS artist_count,
+                    COALESCE(alc.album_count, 0) AS album_count,
                     tn.slug AS canonical_slug,
                     tn.name AS canonical_name,
                     tn.description AS canonical_description,
@@ -29,26 +43,13 @@ def get_all_genres() -> list[dict]:
                     tn.wikidata_entity_id,
                     tn.wikidata_url
                 FROM genres g
-                LEFT JOIN artist_genres ag ON g.id = ag.genre_id
-                LEFT JOIN album_genres alg ON g.id = alg.genre_id
+                LEFT JOIN artist_counts ac ON ac.genre_id = g.id
+                LEFT JOIN album_counts alc ON alc.genre_id = g.id
                 LEFT JOIN genre_taxonomy_aliases gta ON gta.alias_slug = g.slug
                 LEFT JOIN genre_taxonomy_nodes tn ON tn.id = gta.genre_id
-                GROUP BY
-                    g.id,
-                    g.entity_uid,
-                    g.name,
-                    g.slug,
-                    tn.slug,
-                    tn.name,
-                    tn.description,
-                    tn.external_description,
-                    tn.external_description_source,
-                    tn.cover_path,
-                    tn.musicbrainz_mbid,
-                    tn.wikidata_entity_id,
-                    tn.wikidata_url
-                HAVING COUNT(DISTINCT ag.artist_name) > 0 OR COUNT(DISTINCT alg.album_id) > 0
-                ORDER BY COUNT(DISTINCT ag.artist_name) DESC
+                WHERE COALESCE(ac.artist_count, 0) > 0
+                   OR COALESCE(alc.album_count, 0) > 0
+                ORDER BY COALESCE(ac.artist_count, 0) DESC
                 """
                 )
             )

--- a/app/crate/db/queries/genres_library_detail.py
+++ b/app/crate/db/queries/genres_library_detail.py
@@ -482,6 +482,7 @@ def _augment_global_genre_entities(session, genre: dict) -> None:
                 ) track_counts ON track_counts.global_artist_uid = a.global_artist_uid
                 WHERE src.source_deleted_at IS NULL
                   AND NOT src.source_stale
+                  AND NOT a.has_local
                   AND EXISTS (
                     SELECT 1
                     FROM jsonb_array_elements_text(
@@ -550,6 +551,7 @@ def _augment_global_genre_entities(session, genre: dict) -> None:
                 LEFT JOIN library_artists lar ON lar.id = art.local_artist_id
                 WHERE src.source_deleted_at IS NULL
                   AND NOT src.source_stale
+                  AND NOT a.has_local
                   AND EXISTS (
                     SELECT 1
                     FROM jsonb_array_elements_text(

--- a/app/crate/db/queries/genres_shared.py
+++ b/app/crate/db/queries/genres_shared.py
@@ -75,70 +75,85 @@ def get_genre_summary_by_slug(session, slug: str) -> dict | None:
         session.execute(
             text(
                 """
+            WITH target_genre AS (
+                SELECT
+                    g.id,
+                    g.entity_uid,
+                    g.name,
+                    g.slug,
+                    tn.slug AS canonical_slug,
+                    tn.name AS canonical_name,
+                    tn.description AS canonical_description,
+                    tn.external_description,
+                    tn.external_description_source,
+                    tn.cover_path AS canonical_cover_path,
+                    tn.musicbrainz_mbid,
+                    tn.wikidata_entity_id,
+                    tn.wikidata_url,
+                    tn.eq_gains AS canonical_eq_gains,
+                    tn.eq_reasoning
+                FROM genres g
+                LEFT JOIN genre_taxonomy_aliases gta ON gta.alias_slug = g.slug
+                LEFT JOIN genre_taxonomy_nodes tn ON tn.id = gta.genre_id
+                WHERE g.slug = :slug
+            ),
+            artist_counts AS (
+                SELECT
+                    ag.genre_id,
+                    COUNT(DISTINCT ag.artist_name)::INTEGER AS artist_count
+                FROM artist_genres ag
+                JOIN target_genre tg ON tg.id = ag.genre_id
+                GROUP BY ag.genre_id
+            ),
+            album_counts AS (
+                SELECT
+                    alg.genre_id,
+                    COUNT(DISTINCT alg.album_id)::INTEGER AS album_count
+                FROM album_genres alg
+                JOIN target_genre tg ON tg.id = alg.genre_id
+                GROUP BY alg.genre_id
+            ),
+            matched_albums AS (
+                SELECT alg.genre_id, a.id, COALESCE(a.track_count, 0) AS track_count
+                FROM album_genres alg
+                JOIN target_genre tg ON tg.id = alg.genre_id
+                JOIN library_albums a ON a.id = alg.album_id
+                UNION
+                SELECT ag.genre_id, a.id, COALESCE(a.track_count, 0) AS track_count
+                FROM artist_genres ag
+                JOIN target_genre tg ON tg.id = ag.genre_id
+                JOIN library_albums a ON a.artist = ag.artist_name
+            ),
+            track_counts AS (
+                SELECT
+                    genre_id,
+                    SUM(COALESCE(a.track_count, 0))::INTEGER AS track_count
+                FROM matched_albums a
+                GROUP BY genre_id
+            )
             SELECT
                 g.id,
                 g.entity_uid::text AS entity_uid,
                 g.name,
                 g.slug,
-                COUNT(DISTINCT ag.artist_name)::INTEGER AS artist_count,
-                COUNT(DISTINCT alg.album_id)::INTEGER AS album_count,
-                (
-                    WITH matched_albums AS (
-                        SELECT DISTINCT a.id, COALESCE(a.track_count, 0) AS track_count
-                        FROM library_albums a
-                        LEFT JOIN album_genres alg_track
-                            ON alg_track.album_id = a.id
-                           AND alg_track.genre_id = g.id
-                        LEFT JOIN artist_genres ag_track
-                            ON ag_track.artist_name = a.artist
-                           AND ag_track.genre_id = g.id
-                        WHERE alg_track.genre_id IS NOT NULL
-                           OR ag_track.genre_id IS NOT NULL
-                    ),
-                    matched_track_count AS (
-                        SELECT COUNT(DISTINCT lt.id)::INTEGER AS count
-                        FROM library_tracks lt
-                        JOIN matched_albums ma ON ma.id = lt.album_id
-                    )
-                    SELECT COALESCE(
-                        NULLIF((SELECT count FROM matched_track_count), 0),
-                        (SELECT COALESCE(SUM(track_count), 0)::INTEGER FROM matched_albums),
-                        0
-                    )
-                ) AS track_count,
-                tn.slug AS canonical_slug,
-                tn.name AS canonical_name,
-                tn.description AS canonical_description,
-                tn.external_description,
-                tn.external_description_source,
-                tn.cover_path AS canonical_cover_path,
-                tn.musicbrainz_mbid,
-                tn.wikidata_entity_id,
-                tn.wikidata_url,
-                tn.eq_gains AS canonical_eq_gains,
-                tn.eq_reasoning
-            FROM genres g
-            LEFT JOIN artist_genres ag ON g.id = ag.genre_id
-            LEFT JOIN album_genres alg ON g.id = alg.genre_id
-            LEFT JOIN genre_taxonomy_aliases gta ON gta.alias_slug = g.slug
-            LEFT JOIN genre_taxonomy_nodes tn ON tn.id = gta.genre_id
-            WHERE g.slug = :slug
-            GROUP BY
-                g.id,
-                g.entity_uid,
-                g.name,
-                g.slug,
-                tn.slug,
-                tn.name,
-                tn.description,
-                tn.external_description,
-                tn.external_description_source,
-                tn.cover_path,
-                tn.musicbrainz_mbid,
-                tn.wikidata_entity_id,
-                tn.wikidata_url,
-                tn.eq_gains,
-                tn.eq_reasoning
+                COALESCE(ac.artist_count, 0) AS artist_count,
+                COALESCE(alc.album_count, 0) AS album_count,
+                COALESCE(tc.track_count, 0) AS track_count,
+                g.canonical_slug,
+                g.canonical_name,
+                g.canonical_description,
+                g.external_description,
+                g.external_description_source,
+                g.canonical_cover_path,
+                g.musicbrainz_mbid,
+                g.wikidata_entity_id,
+                g.wikidata_url,
+                g.canonical_eq_gains,
+                g.eq_reasoning
+            FROM target_genre g
+            LEFT JOIN artist_counts ac ON ac.genre_id = g.id
+            LEFT JOIN album_counts alc ON alc.genre_id = g.id
+            LEFT JOIN track_counts tc ON tc.genre_id = g.id
             """
             ),
             {"slug": slug},
@@ -160,6 +175,28 @@ def get_taxonomy_node_stats(session, slugs: list[str]) -> dict[str, dict]:
         session.execute(
             text(
                 """
+            WITH taxonomy_artist_counts AS (
+                SELECT
+                    gta.genre_id AS taxonomy_id,
+                    COUNT(DISTINCT ag.artist_name)::INTEGER AS artist_count
+                FROM genre_taxonomy_aliases gta
+                JOIN genre_taxonomy_nodes n ON n.id = gta.genre_id
+                JOIN genres g ON g.slug = gta.alias_slug
+                JOIN artist_genres ag ON ag.genre_id = g.id
+                WHERE n.slug = ANY(:slugs)
+                GROUP BY gta.genre_id
+            ),
+            taxonomy_album_counts AS (
+                SELECT
+                    gta.genre_id AS taxonomy_id,
+                    COUNT(DISTINCT alg.album_id)::INTEGER AS album_count
+                FROM genre_taxonomy_aliases gta
+                JOIN genre_taxonomy_nodes n ON n.id = gta.genre_id
+                JOIN genres g ON g.slug = gta.alias_slug
+                JOIN album_genres alg ON alg.genre_id = g.id
+                WHERE n.slug = ANY(:slugs)
+                GROUP BY gta.genre_id
+            )
             SELECT
                 n.slug,
                 n.name,
@@ -167,15 +204,12 @@ def get_taxonomy_node_stats(session, slugs: list[str]) -> dict[str, dict]:
                 n.external_description,
                 n.cover_path,
                 n.is_top_level,
-                COUNT(DISTINCT ag.artist_name)::INTEGER AS artist_count,
-                COUNT(DISTINCT alg.album_id)::INTEGER AS album_count
+                COALESCE(tac.artist_count, 0) AS artist_count,
+                COALESCE(alc.album_count, 0) AS album_count
             FROM genre_taxonomy_nodes n
-            LEFT JOIN genre_taxonomy_aliases gta ON gta.genre_id = n.id
-            LEFT JOIN genres g ON g.slug = gta.alias_slug
-            LEFT JOIN artist_genres ag ON ag.genre_id = g.id
-            LEFT JOIN album_genres alg ON alg.genre_id = g.id
+            LEFT JOIN taxonomy_artist_counts tac ON tac.taxonomy_id = n.id
+            LEFT JOIN taxonomy_album_counts alc ON alc.taxonomy_id = n.id
             WHERE n.slug = ANY(:slugs)
-            GROUP BY n.id, n.slug, n.name, n.description, n.external_description, n.cover_path, n.is_top_level
             """
             ),
             {"slugs": slugs},
@@ -194,20 +228,37 @@ def get_taxonomy_node_stats(session, slugs: list[str]) -> dict[str, dict]:
         session.execute(
             text(
                 """
-            WITH alias_counts AS (
+            WITH target_nodes AS (
+                SELECT id, slug
+                FROM genre_taxonomy_nodes
+                WHERE slug = ANY(:slugs)
+            ),
+            genre_artist_counts AS (
+                SELECT
+                    genre_id,
+                    COUNT(DISTINCT artist_name)::INTEGER AS artist_count
+                FROM artist_genres
+                GROUP BY genre_id
+            ),
+            genre_album_counts AS (
+                SELECT
+                    genre_id,
+                    COUNT(DISTINCT album_id)::INTEGER AS album_count
+                FROM album_genres
+                GROUP BY genre_id
+            ),
+            alias_counts AS (
                 SELECT
                     n.slug AS taxonomy_slug,
                     g.slug AS genre_slug,
                     g.name AS genre_name,
-                    COUNT(DISTINCT ag.artist_name)::INTEGER AS artist_count,
-                    COUNT(DISTINCT alg.album_id)::INTEGER AS album_count
-                FROM genre_taxonomy_nodes n
+                    COALESCE(ac.artist_count, 0) AS artist_count,
+                    COALESCE(alc.album_count, 0) AS album_count
+                FROM target_nodes n
                 LEFT JOIN genre_taxonomy_aliases gta ON gta.genre_id = n.id
                 LEFT JOIN genres g ON g.slug = gta.alias_slug
-                LEFT JOIN artist_genres ag ON ag.genre_id = g.id
-                LEFT JOIN album_genres alg ON alg.genre_id = g.id
-                WHERE n.slug = ANY(:slugs)
-                GROUP BY n.id, n.slug, g.id, g.slug, g.name
+                LEFT JOIN genre_artist_counts ac ON ac.genre_id = g.id
+                LEFT JOIN genre_album_counts alc ON alc.genre_id = g.id
             )
             SELECT DISTINCT ON (taxonomy_slug)
                 taxonomy_slug,

--- a/app/crate/worker_handlers/analysis.py
+++ b/app/crate/worker_handlers/analysis.py
@@ -147,11 +147,13 @@ def _handle_refresh_home_discovery_snapshot(
     del task_id, config
     from crate.api.cache_events import broadcast_invalidation
     from crate.db.home import get_cached_home_discovery
+    from crate.db.home_section_surface import warm_home_sections
 
     user_id = int(params.get("user_id") or 0)
     if user_id <= 0:
         return {"ok": False, "error": "Missing user_id"}
     get_cached_home_discovery(user_id, fresh=True)
+    warm_home_sections(user_id)
     broadcast_invalidation("home")
     return {"ok": True, "user_id": user_id}
 

--- a/app/crate/worker_handlers/global_catalog.py
+++ b/app/crate/worker_handlers/global_catalog.py
@@ -71,7 +71,14 @@ def _handle_reconcile_full(task_id: str, params: dict, config: dict) -> dict:
     phase = str(bootstrap.get("phase") or "local")
     cursor = bootstrap.get("cursor")
     try:
-        if state["status"] != "backfilling":
+        if state["status"] == "failed":
+            run_id = begin_global_catalog_reconciliation_run(mode="full")
+            bootstrap = {**bootstrap, "run_id": run_id}
+            transition_catalog_state(
+                "backfilling",
+                bootstrap_cursor_json=bootstrap,
+            )
+        elif state["status"] != "backfilling":
             transition_catalog_state("backfilling")
         if not run_id:
             run_id = begin_global_catalog_reconciliation_run(mode="full")

--- a/app/tests/test_api.py
+++ b/app/tests/test_api.py
@@ -2035,12 +2035,9 @@ class TestHomeEndpointCaching:
 
         with (
             patch(
-                "crate.api.me.get_cache", return_value=cached_section
-            ) as mock_get_cache,
-            patch(
-                "crate.api.me.get_home_section",
-                side_effect=AssertionError("unexpected section rebuild"),
-            ),
+                "crate.api.me.get_cached_home_section",
+                return_value=cached_section,
+            ) as mock_get_section,
         ):
             resp = test_app.get("/api/me/home/sections/custom-mixes")
 
@@ -2048,7 +2045,8 @@ class TestHomeEndpointCaching:
         data = resp.json()
         assert data["id"] == "custom-mixes"
         assert data["title"] == "Custom mixes"
-        assert mock_get_cache.call_args.args[0].startswith("home_section:v4:global:")
+        assert mock_get_section.call_args.args[:2] == (1, "custom-mixes")
+        assert mock_get_section.call_args.kwargs == {"limit": 42}
 
 
 class TestShowsAPI:

--- a/app/tests/test_global_catalog_worker.py
+++ b/app/tests/test_global_catalog_worker.py
@@ -228,6 +228,66 @@ def test_full_worker_resumes_persisted_batches_before_marking_ready(monkeypatch)
     )
 
 
+def test_full_worker_starts_new_run_when_resuming_failed_checkpoint(monkeypatch):
+    from crate.worker_handlers import global_catalog
+
+    transitions: list[tuple[str, dict]] = []
+    recorded_runs: list[str] = []
+    monkeypatch.setattr(
+        global_catalog,
+        "get_catalog_state",
+        lambda: {
+            "status": "failed",
+            "bootstrap_cursor_json": {
+                "phase": "local",
+                "cursor": {"entity_type": "track", "after_id": 250000},
+                "run_id": "failed-run",
+            },
+        },
+    )
+    monkeypatch.setattr(
+        global_catalog,
+        "begin_global_catalog_reconciliation_run",
+        lambda **_kwargs: "retry-run",
+    )
+    monkeypatch.setattr(
+        global_catalog,
+        "transition_catalog_state",
+        lambda status, **kwargs: transitions.append((status, kwargs)),
+    )
+    monkeypatch.setattr(
+        global_catalog,
+        "record_global_catalog_reconciliation_batch",
+        lambda run_id, _batch: recorded_runs.append(run_id),
+    )
+    monkeypatch.setattr(
+        global_catalog,
+        "reconcile_local_catalog_batch",
+        lambda **_kwargs: {
+            "completed": True,
+            "next_cursor": None,
+            "source_rows_seen": 1,
+        },
+    )
+    monkeypatch.setattr(global_catalog, "create_task", lambda *_args, **_kwargs: "next")
+
+    result = global_catalog._handle_reconcile_full("task-retry", {}, {})
+
+    assert result["status"] == "continued"
+    assert recorded_runs == ["retry-run"]
+    assert transitions[0] == (
+        "backfilling",
+        {
+            "bootstrap_cursor_json": {
+                "phase": "local",
+                "cursor": {"entity_type": "track", "after_id": 250000},
+                "run_id": "retry-run",
+            }
+        },
+    )
+    assert transitions[-1][1]["bootstrap_cursor_json"]["run_id"] == "retry-run"
+
+
 def test_full_worker_resumes_a_checkpoint_after_a_previous_task_stops(monkeypatch):
     from crate.worker_handlers import global_catalog
 

--- a/app/tests/test_home_projection_policy.py
+++ b/app/tests/test_home_projection_policy.py
@@ -88,6 +88,7 @@ def test_home_refresh_worker_builds_full_snapshot(monkeypatch):
     from crate.worker_handlers import analysis
 
     calls: list[tuple[int, bool]] = []
+    section_calls: list[int] = []
     invalidations: list[tuple[str, ...]] = []
     monkeypatch.setattr(
         "crate.db.home.get_cached_home_discovery",
@@ -97,6 +98,10 @@ def test_home_refresh_worker_builds_full_snapshot(monkeypatch):
         "crate.api.cache_events.broadcast_invalidation",
         lambda *scopes: invalidations.append(scopes),
     )
+    monkeypatch.setattr(
+        "crate.db.home_section_surface.warm_home_sections",
+        lambda user_id: section_calls.append(user_id) or {},
+    )
 
     result = analysis._handle_refresh_home_discovery_snapshot(
         "task-1", {"user_id": 7}, {}
@@ -104,6 +109,7 @@ def test_home_refresh_worker_builds_full_snapshot(monkeypatch):
 
     assert result == {"ok": True, "user_id": 7}
     assert calls == [(7, True)]
+    assert section_calls == [7]
     assert invalidations == [("home",)]
 
 

--- a/app/tests/test_listen_read_latency_contract.py
+++ b/app/tests/test_listen_read_latency_contract.py
@@ -1,0 +1,164 @@
+from __future__ import annotations
+
+import inspect
+
+
+def test_cold_home_section_uses_discovery_fallback_without_sync_rebuild(monkeypatch):
+    from crate.db import home_section_surface as surface
+
+    queued: list[tuple[str, dict, str]] = []
+    monkeypatch.setattr(surface, "get_cache", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(
+        surface,
+        "get_cached_home_discovery",
+        lambda _user_id: {
+            "custom_mixes": [{"id": "daily-discovery", "name": "Daily Discovery"}]
+        },
+    )
+    monkeypatch.setattr(
+        surface,
+        "get_home_section",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            AssertionError("cold request must not rebuild custom mixes")
+        ),
+    )
+    monkeypatch.setattr(
+        surface,
+        "create_task_dedup",
+        lambda task_type, params, dedup_key: queued.append(
+            (task_type, params, dedup_key)
+        ),
+    )
+
+    section = surface.get_cached_home_section(7, "custom-mixes", limit=42)
+
+    assert section == {
+        "id": "custom-mixes",
+        "title": "Custom mixes",
+        "subtitle": "Dynamic playlists shaped around your own listening profile.",
+        "items": [{"id": "daily-discovery", "name": "Daily Discovery"}],
+    }
+    assert queued == [
+        (
+            "refresh_home_discovery_snapshot",
+            {"user_id": 7, "include_sections": True},
+            "home-discovery:7",
+        )
+    ]
+
+
+def test_stale_home_section_is_served_while_refresh_is_queued(monkeypatch):
+    from crate.db import home_section_surface as surface
+
+    stale = {
+        "id": "custom-mixes",
+        "title": "Custom mixes",
+        "subtitle": "Cached",
+        "items": [{"id": "cached-mix"}],
+    }
+    ages: list[int] = []
+    queued: list[str] = []
+
+    def get_cache(_key: str, *, max_age_seconds: int):
+        ages.append(max_age_seconds)
+        return None if max_age_seconds == 300 else stale
+
+    monkeypatch.setattr(surface, "get_cache", get_cache)
+    monkeypatch.setattr(
+        surface,
+        "create_task_dedup",
+        lambda _task_type, _params, dedup_key: queued.append(dedup_key),
+    )
+    monkeypatch.setattr(
+        surface,
+        "get_home_section",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            AssertionError("stale request must not rebuild synchronously")
+        ),
+    )
+
+    section = surface.get_cached_home_section(7, "custom-mixes", limit=42)
+
+    assert section == stale
+    assert ages == [300, 3600]
+    assert queued == ["home-discovery:7"]
+
+
+def test_home_section_refresh_builds_and_caches_full_payload(monkeypatch):
+    from crate.db import home_section_surface as surface
+
+    expected = {
+        "id": "custom-mixes",
+        "title": "Custom mixes",
+        "subtitle": "Full",
+        "items": [{"id": "mix-1"}, {"id": "mix-2"}],
+    }
+    writes: list[tuple[str, dict, int]] = []
+    monkeypatch.setattr(
+        surface,
+        "get_home_section",
+        lambda user_id, section_id, limit: (
+            expected
+            if (user_id, section_id, limit) == (7, "custom-mixes", 42)
+            else None
+        ),
+    )
+    monkeypatch.setattr(
+        surface,
+        "set_cache",
+        lambda key, value, ttl: writes.append((key, value, ttl)),
+    )
+    monkeypatch.setattr(surface.time, "time", lambda: 1234.0)
+
+    section = surface.get_cached_home_section(7, "custom-mixes", limit=42, fresh=True)
+
+    assert section == expected
+    assert writes == [
+        (
+            "home_section:v4:global:7:custom-mixes:42",
+            {
+                "_home_section_cached_at": 1234.0,
+                "_home_section_payload": expected,
+            },
+            3600,
+        )
+    ]
+
+
+def test_genre_catalog_preaggregates_artist_and_album_counts():
+    from crate.db.queries import genres_library_catalog
+
+    source = inspect.getsource(genres_library_catalog.get_all_genres)
+
+    assert "artist_counts AS" in source
+    assert "album_counts AS" in source
+    assert "COALESCE(ac.artist_count, 0)" in source
+    assert "COALESCE(alc.album_count, 0)" in source
+
+
+def test_genre_summary_does_not_rescan_every_library_track():
+    from crate.db.queries import genres_shared
+
+    source = inspect.getsource(genres_shared.get_genre_summary_by_slug)
+
+    assert "library_tracks" not in source
+    assert "SUM(COALESCE(a.track_count, 0))" in source
+
+
+def test_related_genre_stats_preaggregate_memberships():
+    from crate.db.queries import genres_shared
+
+    source = inspect.getsource(genres_shared.get_taxonomy_node_stats)
+
+    assert "taxonomy_artist_counts AS" in source
+    assert "taxonomy_album_counts AS" in source
+    assert "genre_artist_counts AS" in source
+    assert "genre_album_counts AS" in source
+
+
+def test_global_genre_augmentation_only_scans_remote_only_entities():
+    from crate.db.queries import genres_library_detail
+
+    source = inspect.getsource(genres_library_detail._augment_global_genre_entities)
+
+    assert source.count("AND NOT a.has_local") >= 2


### PR DESCRIPTION
## Summary

- serve expanded Listen home sections from fresh/stale cache or the existing discovery snapshot, never from an expensive synchronous cold rebuild
- warm all expanded sections in the background home projection task
- preaggregate genre artist/album counts and derive track totals from album metadata instead of rescanning 114K library tracks
- avoid decoding global source genre JSON for entities already represented by the local catalog
- start a new reconciliation run when retrying a failed checkpoint instead of leaving Admin pinned to the historical failed run

## Production findings addressed

- custom-mixes exceeded the readplane 3s fallback timeout on a cold cache and returned 502
- /api/genres took about 2s because artist_genres and album_genres formed a Cartesian aggregate
- genre detail and related-genre stats repeated equivalent high-cardinality scans
- a successful checkpoint resume returned the catalog to ready while its already-failed run record could never transition to completed

## Compatibility

- endpoint contracts and v4 cache key remain unchanged
- stale content is bounded to one hour and schedules a deduplicated refresh
- cold responses use the already projected home discovery payload; the worker replaces them with the full 42-item section
- federated augmentation still includes remote-only entities
- failed reconciliation retries preserve their cursor but receive a fresh observable run lifecycle

## Verification

- TDD: latency contracts and failed-run retry contract failed before implementation and now pass
- 50 genre/global catalog tests pass
- 30 reconciliation worker/lifecycle tests pass
- Home/API/genre suites pass
- Pyright: 0 errors
- Ruff and all touched-file pre-commit hooks pass