### PR TITLE
fix: bound readplane catalog queries

### DIFF
--- a/app/readplane/internal/catalog/artist_store.go
+++ b/app/readplane/internal/catalog/artist_store.go
@@ -10,6 +10,57 @@ import (
 	"github.com/thecrateapp/crate/app/readplane/internal/postgres"
 )
 
+const artistAlbumsSQL = `
+		WITH artist_albums AS (
+			SELECT
+				id,
+				entity_uid,
+				slug,
+				name,
+				track_count,
+				formats_json,
+				total_size,
+				year,
+				has_cover,
+				musicbrainz_albumid,
+				popularity,
+				popularity_score,
+				popularity_confidence
+			FROM library_albums
+			WHERE lower(artist) = lower($1)
+			  AND quarantined_at IS NULL
+		),
+		album_quality AS (
+			SELECT
+				t.album_id,
+				MAX(t.bit_depth) AS bit_depth,
+				MAX(t.sample_rate) AS sample_rate
+			FROM library_tracks t
+			JOIN artist_albums aa ON aa.id = t.album_id
+			WHERE t.format IS NOT NULL
+			GROUP BY t.album_id
+		)
+		SELECT
+			a.id,
+			a.entity_uid::text AS entity_uid,
+			a.slug,
+			a.name,
+			a.track_count AS tracks,
+			a.formats_json AS formats,
+			q.bit_depth,
+			q.sample_rate,
+			a.total_size,
+			a.year,
+			a.has_cover,
+			a.musicbrainz_albumid,
+			a.popularity,
+			a.popularity_score,
+			a.popularity_confidence
+		FROM artist_albums a
+		LEFT JOIN album_quality q ON q.album_id = a.id
+		ORDER BY a.year, a.name
+	`
+
 func (s *Store) ArtistArtworkKeyByID(ctx context.Context, artistID int64) (string, error) {
 	return s.artistArtworkKey(ctx, "id = $1", artistID)
 }
@@ -128,21 +179,7 @@ func (s *Store) artistPayload(ctx context.Context, artist map[string]any) (map[s
 	name := stringValue(artist["name"])
 	ctx, cancel := postgres.WithTimeout(ctx, s.queryTimeout)
 	defer cancel()
-	albums, err := rowsToMaps(s.pool.Query(ctx, `
-		SELECT a.id, a.entity_uid::text AS entity_uid, a.slug, a.name, a.track_count AS tracks,
-		       a.formats_json AS formats, q.bit_depth, q.sample_rate, a.total_size,
-		       a.year, a.has_cover, a.musicbrainz_albumid, a.popularity,
-		       a.popularity_score, a.popularity_confidence
-		FROM library_albums a
-		LEFT JOIN (
-			SELECT album_id, MAX(bit_depth) AS bit_depth, MAX(sample_rate) AS sample_rate
-			FROM library_tracks
-			WHERE format IS NOT NULL
-			GROUP BY album_id
-		) q ON q.album_id = a.id
-		WHERE lower(a.artist) = lower($1) AND a.quarantined_at IS NULL
-		ORDER BY a.year, a.name
-	`, name))
+	albums, err := rowsToMaps(s.pool.Query(ctx, artistAlbumsSQL, name))
 	if err != nil {
 		return nil, err
 	}

--- a/app/readplane/internal/catalog/genre.go
+++ b/app/readplane/internal/catalog/genre.go
@@ -145,14 +145,7 @@ func nilIfZero(value int64) any {
 	return value
 }
 
-func (s *Store) relatedGenres(ctx context.Context, canonicalSlug string, limit int) ([]map[string]any, error) {
-	slug := strings.TrimSpace(canonicalSlug)
-	if slug == "" {
-		return []map[string]any{}, nil
-	}
-	queryCtx, cancel := postgres.WithTimeout(ctx, s.queryTimeout)
-	defer cancel()
-	rows, err := rowsToMaps(s.pool.Query(queryCtx, `
+const relatedGenresSQL = `
 		WITH target AS (
 			SELECT id, slug
 			FROM genre_taxonomy_nodes
@@ -248,6 +241,78 @@ func (s *Store) relatedGenres(ctx context.Context, canonicalSlug string, limit i
 			SELECT slug, relation_type
 			FROM ranked_relations
 			WHERE relation_rank = 1
+		),
+		candidate_nodes AS (
+			SELECT
+				n.id,
+				n.slug,
+				n.name,
+				n.description,
+				n.external_description,
+				n.cover_path,
+				c.relation_type
+			FROM candidate_relations c
+			JOIN genre_taxonomy_nodes n ON n.slug = c.slug
+		),
+		taxonomy_artist_counts AS (
+			SELECT
+				gta.genre_id AS taxonomy_id,
+				COUNT(DISTINCT ag.artist_name)::BIGINT AS artist_count
+			FROM genre_taxonomy_aliases gta
+			JOIN candidate_nodes n ON n.id = gta.genre_id
+			JOIN genres g ON g.slug = gta.alias_slug
+			JOIN artist_genres ag ON ag.genre_id = g.id
+			GROUP BY gta.genre_id
+		),
+		taxonomy_album_counts AS (
+			SELECT
+				gta.genre_id AS taxonomy_id,
+				COUNT(DISTINCT alg.album_id)::BIGINT AS album_count
+			FROM genre_taxonomy_aliases gta
+			JOIN candidate_nodes n ON n.id = gta.genre_id
+			JOIN genres g ON g.slug = gta.alias_slug
+			JOIN album_genres alg ON alg.genre_id = g.id
+			GROUP BY gta.genre_id
+		),
+		genre_artist_counts AS (
+			SELECT
+				ag.genre_id,
+				COUNT(DISTINCT ag.artist_name)::BIGINT AS artist_count
+			FROM artist_genres ag
+			GROUP BY ag.genre_id
+		),
+		genre_album_counts AS (
+			SELECT
+				alg.genre_id,
+				COUNT(DISTINCT alg.album_id)::BIGINT AS album_count
+			FROM album_genres alg
+			GROUP BY alg.genre_id
+		),
+		alias_counts AS (
+			SELECT
+				n.id AS taxonomy_id,
+				g.slug AS page_slug,
+				g.name AS page_name,
+				COALESCE(ac.artist_count, 0) AS artist_count,
+				COALESCE(alc.album_count, 0) AS album_count
+			FROM candidate_nodes n
+			LEFT JOIN genre_taxonomy_aliases gta ON gta.genre_id = n.id
+			LEFT JOIN genres g ON g.slug = gta.alias_slug
+			LEFT JOIN genre_artist_counts ac ON ac.genre_id = g.id
+			LEFT JOIN genre_album_counts alc ON alc.genre_id = g.id
+		),
+		best_pages AS (
+			SELECT DISTINCT ON (taxonomy_id)
+				taxonomy_id,
+				page_slug,
+				page_name
+			FROM alias_counts
+			WHERE page_slug IS NOT NULL
+			ORDER BY
+				taxonomy_id,
+				artist_count DESC,
+				album_count DESC,
+				page_slug ASC
 		)
 		SELECT
 			n.slug,
@@ -255,36 +320,18 @@ func (s *Store) relatedGenres(ctx context.Context, canonicalSlug string, limit i
 			n.description,
 			n.external_description,
 			n.cover_path AS canonical_cover_path,
-			c.relation_type,
-			COUNT(DISTINCT ag.artist_name)::BIGINT AS artist_count,
-			COUNT(DISTINCT alg.album_id)::BIGINT AS album_count,
+			n.relation_type,
+			COALESCE(tac.artist_count, 0) AS artist_count,
+			COALESCE(talc.album_count, 0) AS album_count,
 			page.page_slug,
 			page.page_name,
 			top_artist.top_artist_id,
 			top_artist.top_artist_slug,
 			top_artist.top_artist_name
-		FROM candidate_relations c
-		JOIN genre_taxonomy_nodes n ON n.slug = c.slug
-		LEFT JOIN genre_taxonomy_aliases gta ON gta.genre_id = n.id
-		LEFT JOIN genres g ON g.slug = gta.alias_slug
-		LEFT JOIN artist_genres ag ON ag.genre_id = g.id
-		LEFT JOIN album_genres alg ON alg.genre_id = g.id
-		LEFT JOIN LATERAL (
-			SELECT
-				gp.slug AS page_slug,
-				gp.name AS page_name
-			FROM genre_taxonomy_aliases gta_page
-			JOIN genres gp ON gp.slug = gta_page.alias_slug
-			LEFT JOIN artist_genres ag_page ON ag_page.genre_id = gp.id
-			LEFT JOIN album_genres alg_page ON alg_page.genre_id = gp.id
-			WHERE gta_page.genre_id = n.id
-			GROUP BY gp.id, gp.slug, gp.name
-			ORDER BY
-				COUNT(DISTINCT ag_page.artist_name) DESC,
-				COUNT(DISTINCT alg_page.album_id) DESC,
-				gp.slug ASC
-			LIMIT 1
-		) page ON true
+		FROM candidate_nodes n
+		LEFT JOIN taxonomy_artist_counts tac ON tac.taxonomy_id = n.id
+		LEFT JOIN taxonomy_album_counts talc ON talc.taxonomy_id = n.id
+		LEFT JOIN best_pages page ON page.taxonomy_id = n.id
 		LEFT JOIN LATERAL (
 			SELECT
 				la.id AS top_artist_id,
@@ -303,20 +350,16 @@ func (s *Store) relatedGenres(ctx context.Context, canonicalSlug string, limit i
 				la.name ASC
 			LIMIT 1
 		) top_artist ON true
-		GROUP BY
-			n.id,
-			n.slug,
-			n.name,
-			n.description,
-			n.external_description,
-			n.cover_path,
-			c.relation_type,
-			page.page_slug,
-			page.page_name,
-			top_artist.top_artist_id,
-			top_artist.top_artist_slug,
-			top_artist.top_artist_name
-	`, slug))
+	`
+
+func (s *Store) relatedGenres(ctx context.Context, canonicalSlug string, limit int) ([]map[string]any, error) {
+	slug := strings.TrimSpace(canonicalSlug)
+	if slug == "" {
+		return []map[string]any{}, nil
+	}
+	queryCtx, cancel := postgres.WithTimeout(ctx, s.queryTimeout)
+	defer cancel()
+	rows, err := rowsToMaps(s.pool.Query(queryCtx, relatedGenresSQL, slug))
 	if err != nil {
 		return nil, err
 	}

--- a/app/readplane/internal/catalog/query_latency_test.go
+++ b/app/readplane/internal/catalog/query_latency_test.go
@@ -1,0 +1,89 @@
+package catalog
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestListenCatalogQueriesBoundAggregationWork(t *testing.T) {
+	tests := []struct {
+		name       string
+		query      string
+		contains   []string
+		excludes   []string
+		maxJoins   int
+		joinTarget string
+	}{
+		{
+			name:  "genre catalog preaggregates memberships",
+			query: genresSQL,
+			contains: []string{
+				"artist_counts AS",
+				"album_counts AS",
+				"COALESCE(ac.artist_count, 0)",
+				"COALESCE(alc.album_count, 0)",
+			},
+			excludes: []string{
+				"LEFT JOIN artist_genres ag ON g.id = ag.genre_id",
+				"LEFT JOIN album_genres alg ON g.id = alg.genre_id",
+			},
+		},
+		{
+			name:  "genre summary scopes counts to target",
+			query: genreSummarySQL,
+			contains: []string{
+				"target_genre AS",
+				"artist_counts AS",
+				"album_counts AS",
+				"JOIN target_genre",
+			},
+			excludes: []string{
+				"LEFT JOIN artist_genres",
+				"LEFT JOIN album_genres",
+			},
+		},
+		{
+			name:  "related genres preaggregate each membership domain",
+			query: relatedGenresSQL,
+			contains: []string{
+				"taxonomy_artist_counts AS",
+				"taxonomy_album_counts AS",
+				"genre_artist_counts AS",
+				"genre_album_counts AS",
+			},
+			excludes: []string{
+				"LEFT JOIN artist_genres ag ON",
+				"LEFT JOIN album_genres alg ON",
+				"LEFT JOIN artist_genres ag_page ON",
+				"LEFT JOIN album_genres alg_page ON",
+			},
+		},
+		{
+			name:  "artist albums aggregate quality after artist filter",
+			query: artistAlbumsSQL,
+			contains: []string{
+				"artist_albums AS",
+				"album_quality AS",
+				"JOIN artist_albums aa ON aa.id = t.album_id",
+			},
+			maxJoins:   1,
+			joinTarget: "library_tracks",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			for _, fragment := range tt.contains {
+				assert.Contains(t, tt.query, fragment)
+			}
+			for _, fragment := range tt.excludes {
+				assert.NotContains(t, tt.query, fragment)
+			}
+			if tt.joinTarget != "" {
+				assert.LessOrEqual(t, strings.Count(tt.query, tt.joinTarget), tt.maxJoins)
+			}
+		})
+	}
+}

--- a/app/readplane/internal/catalog/store.go
+++ b/app/readplane/internal/catalog/store.go
@@ -629,18 +629,28 @@ func (s *Store) PlayHistory(ctx context.Context, userID int64, limit int) ([]map
 	return rows, nil
 }
 
-// Genres returns all genres with artist/album counts and taxonomy metadata.
-func (s *Store) Genres(ctx context.Context) ([]map[string]any, error) {
-	ctx, cancel := postgres.WithTimeout(ctx, s.queryTimeout)
-	defer cancel()
-	rows, err := rowsToMaps(s.pool.Query(ctx, `
+var genresSQL = `
+		WITH artist_counts AS (
+			SELECT
+				genre_id,
+				COUNT(DISTINCT artist_name)::INTEGER AS artist_count
+			FROM artist_genres
+			GROUP BY genre_id
+		),
+		album_counts AS (
+			SELECT
+				genre_id,
+				COUNT(DISTINCT album_id)::INTEGER AS album_count
+			FROM album_genres
+			GROUP BY genre_id
+		)
 		SELECT
 			g.id,
 			g.entity_uid::text AS entity_uid,
 			g.name,
 			g.slug,
-			COUNT(DISTINCT ag.artist_name)::INTEGER AS artist_count,
-			COUNT(DISTINCT alg.album_id)::INTEGER AS album_count,
+			COALESCE(ac.artist_count, 0) AS artist_count,
+			COALESCE(alc.album_count, 0) AS album_count,
 			tn.slug AS canonical_slug,
 			tn.name AS canonical_name,
 			tn.description AS canonical_description,
@@ -654,32 +664,22 @@ func (s *Store) Genres(ctx context.Context) ([]map[string]any, error) {
 			tl.name AS top_level_name,
 			tl.description AS top_level_description
 		FROM genres g
-		LEFT JOIN artist_genres ag ON g.id = ag.genre_id
-		LEFT JOIN album_genres alg ON g.id = alg.genre_id
+		LEFT JOIN artist_counts ac ON ac.genre_id = g.id
+		LEFT JOIN album_counts alc ON alc.genre_id = g.id
 		LEFT JOIN genre_taxonomy_aliases gta
 		  ON gta.alias_slug = g.slug OR lower(trim(gta.alias_name)) = lower(trim(g.name))
 		LEFT JOIN genre_taxonomy_nodes tn ON tn.id = gta.genre_id
-		LEFT JOIN LATERAL (`+genreTopLevelSQL("tn.slug")+`) tl ON tn.slug IS NOT NULL
-		GROUP BY
-			g.id,
-			g.entity_uid,
-			g.name,
-			g.slug,
-			tn.slug,
-			tn.name,
-			tn.description,
-			tn.external_description,
-			tn.external_description_source,
-			tn.cover_path,
-			tn.musicbrainz_mbid,
-			tn.wikidata_entity_id,
-			tn.wikidata_url,
-			tl.slug,
-			tl.name,
-			tl.description
-		HAVING COUNT(DISTINCT ag.artist_name) > 0 OR COUNT(DISTINCT alg.album_id) > 0
-		ORDER BY COUNT(DISTINCT ag.artist_name) DESC
-	`))
+		LEFT JOIN LATERAL (` + genreTopLevelSQL("tn.slug") + `) tl ON tn.slug IS NOT NULL
+		WHERE COALESCE(ac.artist_count, 0) > 0
+		   OR COALESCE(alc.album_count, 0) > 0
+		ORDER BY COALESCE(ac.artist_count, 0) DESC
+	`
+
+// Genres returns all genres with artist/album counts and taxonomy metadata.
+func (s *Store) Genres(ctx context.Context) ([]map[string]any, error) {
+	ctx, cancel := postgres.WithTimeout(ctx, s.queryTimeout)
+	defer cancel()
+	rows, err := rowsToMaps(s.pool.Query(ctx, genresSQL))
 	if err != nil {
 		return nil, err
 	}
@@ -1065,28 +1065,63 @@ func nonEmptyStrings(values ...string) []string {
 	return items
 }
 
-func (s *Store) genreSummaryBySlug(ctx context.Context, slug string) (map[string]any, error) {
-	queryCtx, cancel := postgres.WithTimeout(ctx, s.queryTimeout)
-	defer cancel()
-	rows, err := rowsToMaps(s.pool.Query(queryCtx, `
+var genreSummarySQL = `
+		WITH target_genre AS (
+			SELECT
+				g.id,
+				g.entity_uid,
+				g.name,
+				g.slug,
+				tn.slug AS canonical_slug,
+				tn.name AS canonical_name,
+				tn.description AS canonical_description,
+				tn.external_description,
+				tn.external_description_source,
+				tn.cover_path AS canonical_cover_path,
+				tn.musicbrainz_mbid,
+				tn.wikidata_entity_id,
+				tn.wikidata_url,
+				tn.eq_gains AS canonical_eq_gains,
+				tn.eq_reasoning
+			FROM genres g
+			LEFT JOIN genre_taxonomy_aliases gta ON gta.alias_slug = g.slug
+			LEFT JOIN genre_taxonomy_nodes tn ON tn.id = gta.genre_id
+			WHERE g.slug = $1
+		),
+		artist_counts AS (
+			SELECT
+				ag.genre_id,
+				COUNT(DISTINCT ag.artist_name)::INTEGER AS artist_count
+			FROM artist_genres ag
+			JOIN target_genre tg ON tg.id = ag.genre_id
+			GROUP BY ag.genre_id
+		),
+		album_counts AS (
+			SELECT
+				alg.genre_id,
+				COUNT(DISTINCT alg.album_id)::INTEGER AS album_count
+			FROM album_genres alg
+			JOIN target_genre tg ON tg.id = alg.genre_id
+			GROUP BY alg.genre_id
+		)
 		SELECT
 			g.id,
 			g.entity_uid::text AS entity_uid,
 			g.name,
 			g.slug,
-			COUNT(DISTINCT ag.artist_name)::INTEGER AS artist_count,
-			COUNT(DISTINCT alg.album_id)::INTEGER AS album_count,
-			tn.slug AS canonical_slug,
-			tn.name AS canonical_name,
-			tn.description AS canonical_description,
-			tn.external_description,
-			tn.external_description_source,
-			tn.cover_path AS canonical_cover_path,
-			tn.musicbrainz_mbid,
-			tn.wikidata_entity_id,
-			tn.wikidata_url,
-			tn.eq_gains AS canonical_eq_gains,
-			tn.eq_reasoning,
+			COALESCE(ac.artist_count, 0) AS artist_count,
+			COALESCE(alc.album_count, 0) AS album_count,
+			g.canonical_slug,
+			g.canonical_name,
+			g.canonical_description,
+			g.external_description,
+			g.external_description_source,
+			g.canonical_cover_path,
+			g.musicbrainz_mbid,
+			g.wikidata_entity_id,
+			g.wikidata_url,
+			g.canonical_eq_gains,
+			g.eq_reasoning,
 			tl.slug AS top_level_slug,
 			tl.name AS top_level_name,
 			tl.description AS top_level_description,
@@ -1094,38 +1129,17 @@ func (s *Store) genreSummaryBySlug(ctx context.Context, slug string) (map[string
 			preset.source AS preset_source,
 			preset.slug AS preset_slug,
 			preset.name AS preset_name
-		FROM genres g
-		LEFT JOIN artist_genres ag ON g.id = ag.genre_id
-		LEFT JOIN album_genres alg ON g.id = alg.genre_id
-		LEFT JOIN genre_taxonomy_aliases gta ON gta.alias_slug = g.slug
-		LEFT JOIN genre_taxonomy_nodes tn ON tn.id = gta.genre_id
-		LEFT JOIN LATERAL (`+genreTopLevelSQL("tn.slug")+`) tl ON tn.slug IS NOT NULL
-		LEFT JOIN LATERAL (`+genrePresetSQL("tn.slug")+`) preset ON tn.slug IS NOT NULL
-		WHERE g.slug = $1
-		GROUP BY
-			g.id,
-			g.entity_uid,
-			g.name,
-			g.slug,
-			tn.slug,
-			tn.name,
-			tn.description,
-			tn.external_description,
-			tn.external_description_source,
-			tn.cover_path,
-			tn.musicbrainz_mbid,
-			tn.wikidata_entity_id,
-			tn.wikidata_url,
-			tn.eq_gains,
-			tn.eq_reasoning,
-			tl.slug,
-			tl.name,
-			tl.description,
-			preset.gains,
-			preset.source,
-			preset.slug,
-			preset.name
-	`, slug))
+		FROM target_genre g
+		LEFT JOIN artist_counts ac ON ac.genre_id = g.id
+		LEFT JOIN album_counts alc ON alc.genre_id = g.id
+		LEFT JOIN LATERAL (` + genreTopLevelSQL("g.canonical_slug") + `) tl ON g.canonical_slug IS NOT NULL
+		LEFT JOIN LATERAL (` + genrePresetSQL("g.canonical_slug") + `) preset ON g.canonical_slug IS NOT NULL
+	`
+
+func (s *Store) genreSummaryBySlug(ctx context.Context, slug string) (map[string]any, error) {
+	queryCtx, cancel := postgres.WithTimeout(ctx, s.queryTimeout)
+	defer cancel()
+	rows, err := rowsToMaps(s.pool.Query(queryCtx, genreSummarySQL, slug))
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Summary

- preaggregate artist and album genre counts independently in the Go readplane
- scope genre detail and related-genre aggregation to the requested taxonomy nodes
- compute artist album quality only for the selected artist instead of scanning the full track library
- add table-driven query-shape regression coverage

## Production evidence

The pre-fix production audit showed FastAPI at 20–83 ms while the equivalent readplane paths took 0.4–1.0 s. The optimized queries were validated against the dev PostgreSQL dataset with identical genre counts, memberships, related genres and album quality; warm readplane responses complete in 0.8–3.7 ms.

## Verification

- `go test ./...`
- `go vet ./...`
- FastAPI/readplane payload parity against the dev PostgreSQL stack
