### PR TITLE
fix: remove deprecated Navidrome compatibility

### DIFF
--- a/app/crate/db/migrations/versions/081_remove_navidrome_compatibility.py
+++ b/app/crate/db/migrations/versions/081_remove_navidrome_compatibility.py
@@ -1,0 +1,43 @@
+"""Remove deprecated Navidrome track identifiers."""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "081"
+down_revision = "080"
+branch_labels = None
+depends_on = None
+
+
+def _has_navidrome_id_column() -> bool:
+    return bool(
+        op.get_bind()
+        .execute(
+            sa.text(
+                """
+                SELECT EXISTS (
+                    SELECT 1
+                    FROM information_schema.columns
+                    WHERE table_schema = current_schema()
+                      AND table_name = 'library_tracks'
+                      AND column_name = 'navidrome_id'
+                )
+                """
+            )
+        )
+        .scalar_one()
+    )
+
+
+def upgrade() -> None:
+    if _has_navidrome_id_column():
+        op.drop_column("library_tracks", "navidrome_id")
+
+
+def downgrade() -> None:
+    if not _has_navidrome_id_column():
+        op.add_column(
+            "library_tracks",
+            sa.Column("navidrome_id", sa.Text(), nullable=True),
+        )

--- a/app/crate/db/queries/user_library_history.py
+++ b/app/crate/db/queries/user_library_history.py
@@ -2,10 +2,7 @@ from __future__ import annotations
 
 from sqlalchemy import text
 
-from crate.db.queries.user_library_shared import (
-    has_legacy_stream_id_column,
-    relative_track_path,
-)
+from crate.db.queries.user_library_shared import relative_track_path
 from crate.db.tx import read_scope
 
 
@@ -17,7 +14,6 @@ def get_play_history_rows(
     user_id: int,
     *,
     limit: int,
-    has_legacy_stream_id_column: bool,
     allow_global_catalog: bool | None = None,
 ) -> list[dict]:
     if allow_global_catalog is None:
@@ -88,32 +84,12 @@ def get_play_history_rows(
                 WHERE upe.track_id IS NULL
                   AND upe.track_entity_uid IS NOT NULL
                   AND matched.entity_uid = upe.track_entity_uid
-    """
-    if has_legacy_stream_id_column:
-        query_sql += """
-                UNION ALL
-                SELECT matched.id, 3
-                FROM library_tracks matched
-                WHERE upe.track_id IS NULL
-                  AND COALESCE(upe.track_path, '') <> ''
-                  AND matched.navidrome_id = upe.track_path
-                UNION ALL
-                SELECT matched.id, 4
-                FROM library_tracks matched
-                WHERE upe.track_id IS NULL
-                  AND COALESCE(upe.track_path, '') <> ''
-                  AND matched.path = upe.track_path
-        """
-    else:
-        query_sql += """
                 UNION ALL
                 SELECT matched.id, 3
                 FROM library_tracks matched
                 WHERE upe.track_id IS NULL
                   AND COALESCE(upe.track_path, '') <> ''
                   AND matched.path = upe.track_path
-        """
-    query_sql += """
             ) matches
             JOIN library_tracks candidate ON candidate.id = matches.track_id
             ORDER BY matches.match_priority
@@ -273,7 +249,6 @@ def get_play_history(user_id: int, limit: int = 50) -> list[dict]:
     rows_raw = get_play_history_rows(
         user_id,
         limit=limit,
-        has_legacy_stream_id_column=has_legacy_stream_id_column(),
     )
     rows: list[dict] = []
     needs_title_fallback: list[tuple[int, str, str]] = []

--- a/app/crate/db/queries/user_library_shared.py
+++ b/app/crate/db/queries/user_library_shared.py
@@ -4,10 +4,7 @@ from datetime import datetime, timedelta, timezone
 from functools import lru_cache
 from pathlib import Path
 
-from sqlalchemy import text
-
 from crate.config import load_config
-from crate.db.tx import read_scope
 
 _STATS_WINDOWS: dict[str, int | None] = {
     "7d": 7,
@@ -48,27 +45,6 @@ def relative_track_path(track_path: str) -> str:
     return ""
 
 
-@lru_cache(maxsize=1)
-def has_legacy_stream_id_column() -> bool:
-    with read_scope() as session:
-        row = (
-            session.execute(
-                text(
-                    """
-                SELECT 1
-                FROM information_schema.columns
-                WHERE table_name = 'library_tracks'
-                  AND column_name = 'navidrome_id'
-                LIMIT 1
-                """
-                )
-            )
-            .mappings()
-            .first()
-        )
-    return row is not None
-
-
 def window_day_cutoff(window: str) -> str | None:
     normalized = normalize_stats_window(window)
     days = _STATS_WINDOWS[normalized]
@@ -79,7 +55,6 @@ def window_day_cutoff(window: str) -> str | None:
 
 __all__ = [
     "_STATS_WINDOWS",
-    "has_legacy_stream_id_column",
     "library_root",
     "normalize_stats_window",
     "relative_track_path",

--- a/app/crate/db/repositories/user_library_shared.py
+++ b/app/crate/db/repositories/user_library_shared.py
@@ -8,7 +8,7 @@ from sqlalchemy import text
 
 from crate.config import load_config
 from crate.db.domain_events import append_domain_event
-from crate.db.tx import read_scope, transaction_scope
+from crate.db.tx import read_scope
 
 _STATS_WINDOWS: dict[str, int | None] = {
     "7d": 7,
@@ -40,27 +40,6 @@ def relative_track_path(track_path: str) -> str:
     if not normalized.startswith("/"):
         return normalized
     return ""
-
-
-@lru_cache(maxsize=1)
-def has_legacy_stream_id_column() -> bool:
-    with transaction_scope() as session:
-        row = (
-            session.execute(
-                text(
-                    """
-                SELECT 1
-                FROM information_schema.columns
-                WHERE table_name = 'library_tracks'
-                  AND column_name = 'navidrome_id'
-                LIMIT 1
-                """
-                )
-            )
-            .mappings()
-            .first()
-        )
-    return row is not None
 
 
 def resolve_track_id(
@@ -101,71 +80,36 @@ def resolve_track_id(
     absolute_candidate = f"{root}/{rel_path}" if root and rel_path else track_path
     music_candidate = f"/music/{rel_path}" if rel_path else track_path
 
-    should_match_external_id = "/" not in track_path and "\\" not in track_path
-    if should_match_external_id and has_legacy_stream_id_column():
-        row = (
-            session.execute(
-                text(
-                    """
-                SELECT id
-                FROM library_tracks
-                WHERE path = :track_path
-                   OR path = :absolute_candidate
-                   OR path = :music_candidate
-                   OR navidrome_id = :navidrome_id
-                ORDER BY CASE
-                    WHEN path = :track_path2 THEN 0
-                    WHEN path = :absolute_candidate2 THEN 1
-                    WHEN path = :music_candidate2 THEN 2
-                    ELSE 3
-                END
-                LIMIT 1
+    row = (
+        session.execute(
+            text(
                 """
-                ),
-                {
-                    "track_path": track_path,
-                    "absolute_candidate": absolute_candidate,
-                    "music_candidate": music_candidate,
-                    "navidrome_id": track_path,
-                    "track_path2": track_path,
-                    "absolute_candidate2": absolute_candidate,
-                    "music_candidate2": music_candidate,
-                },
-            )
-            .mappings()
-            .first()
+            SELECT id
+            FROM library_tracks
+            WHERE path = :track_path
+               OR path = :absolute_candidate
+               OR path = :music_candidate
+            ORDER BY CASE
+                WHEN path = :track_path2 THEN 0
+                WHEN path = :absolute_candidate2 THEN 1
+                WHEN path = :music_candidate2 THEN 2
+                ELSE 3
+            END
+            LIMIT 1
+            """
+            ),
+            {
+                "track_path": track_path,
+                "absolute_candidate": absolute_candidate,
+                "music_candidate": music_candidate,
+                "track_path2": track_path,
+                "absolute_candidate2": absolute_candidate,
+                "music_candidate2": music_candidate,
+            },
         )
-    else:
-        row = (
-            session.execute(
-                text(
-                    """
-                SELECT id
-                FROM library_tracks
-                WHERE path = :track_path
-                   OR path = :absolute_candidate
-                   OR path = :music_candidate
-                ORDER BY CASE
-                    WHEN path = :track_path2 THEN 0
-                    WHEN path = :absolute_candidate2 THEN 1
-                    WHEN path = :music_candidate2 THEN 2
-                    ELSE 3
-                END
-                LIMIT 1
-                """
-                ),
-                {
-                    "track_path": track_path,
-                    "absolute_candidate": absolute_candidate,
-                    "music_candidate": music_candidate,
-                    "track_path2": track_path,
-                    "absolute_candidate2": absolute_candidate,
-                    "music_candidate2": music_candidate,
-                },
-            )
-            .mappings()
-            .first()
-        )
+        .mappings()
+        .first()
+    )
     return row["id"] if row else None
 
 
@@ -245,7 +189,6 @@ def utc_now_iso() -> str:
 __all__ = [
     "_STATS_WINDOWS",
     "emit_user_domain_event",
-    "has_legacy_stream_id_column",
     "library_root",
     "relative_track_path",
     "resolve_track_reference",

--- a/app/readplane/internal/catalog/query_latency_test.go
+++ b/app/readplane/internal/catalog/query_latency_test.go
@@ -89,25 +89,14 @@ func TestListenCatalogQueriesBoundAggregationWork(t *testing.T) {
 }
 
 func TestPlayHistoryQueriesLimitEventsBeforeMetadataResolution(t *testing.T) {
-	tests := []struct {
-		name   string
-		legacy bool
-	}{
-		{name: "current schema", legacy: false},
-		{name: "legacy stream id", legacy: true},
-	}
+	query := playHistorySQL()
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			query := playHistorySQL(tt.legacy)
-
-			assert.Contains(t, query, "recent_events AS MATERIALIZED")
-			assert.Contains(t, query, "FROM recent_events upe")
-			limitIndex := strings.Index(query, "LIMIT $2")
-			resolutionIndex := strings.Index(query, "LEFT JOIN LATERAL")
-			assert.NotEqual(t, -1, limitIndex)
-			assert.NotEqual(t, -1, resolutionIndex)
-			assert.Less(t, limitIndex, resolutionIndex)
-		})
-	}
+	assert.Contains(t, query, "recent_events AS MATERIALIZED")
+	assert.Contains(t, query, "FROM recent_events upe")
+	assert.NotContains(t, strings.ToLower(query), "navidrome")
+	limitIndex := strings.Index(query, "LIMIT $2")
+	resolutionIndex := strings.Index(query, "LEFT JOIN LATERAL")
+	assert.NotEqual(t, -1, limitIndex)
+	assert.NotEqual(t, -1, resolutionIndex)
+	assert.Less(t, limitIndex, resolutionIndex)
 }

--- a/app/readplane/internal/catalog/store.go
+++ b/app/readplane/internal/catalog/store.go
@@ -572,11 +572,7 @@ func (s *Store) IsFollowingArtistID(ctx context.Context, userID int64, artistID 
 
 // PlayHistory returns the user's recent play events with resolved track metadata.
 func (s *Store) PlayHistory(ctx context.Context, userID int64, limit int) ([]map[string]any, error) {
-	hasLegacyStreamID, err := s.hasLegacyStreamIDColumn(ctx)
-	if err != nil {
-		return nil, err
-	}
-	rows, err := s.playHistoryRows(ctx, userID, limit, hasLegacyStreamID)
+	rows, err := s.playHistoryRows(ctx, userID, limit)
 	if err != nil {
 		return nil, err
 	}
@@ -1151,35 +1147,7 @@ func (s *Store) genreSummaryBySlug(ctx context.Context, slug string) (map[string
 	return row, nil
 }
 
-func (s *Store) hasLegacyStreamIDColumn(ctx context.Context) (bool, error) {
-	queryCtx, cancel := postgres.WithTimeout(ctx, s.queryTimeout)
-	defer cancel()
-	rows, err := rowsToMaps(s.pool.Query(queryCtx, `
-		SELECT 1
-		FROM information_schema.columns
-		WHERE table_name = 'library_tracks'
-		  AND column_name = 'navidrome_id'
-		LIMIT 1
-	`))
-	if err != nil {
-		return false, err
-	}
-	return len(rows) > 0, nil
-}
-
-func playHistorySQL(hasLegacyStreamIDColumn bool) string {
-	legacyMatch := ""
-	if hasLegacyStreamIDColumn {
-		legacyMatch = `
-				UNION ALL
-				SELECT matched.id, 3
-				FROM library_tracks matched
-				WHERE upe.track_id IS NULL
-				  AND COALESCE(upe.track_path, '') <> ''
-				  AND matched.navidrome_id = upe.track_path
-		`
-	}
-
+func playHistorySQL() string {
 	return `
 		WITH recent_events AS MATERIALIZED (
 			SELECT *
@@ -1235,9 +1203,8 @@ func playHistorySQL(hasLegacyStreamIDColumn bool) string {
 				WHERE upe.track_id IS NULL
 				  AND upe.track_entity_uid IS NOT NULL
 				  AND matched.entity_uid = upe.track_entity_uid
-				` + legacyMatch + `
 				UNION ALL
-				SELECT matched.id, 4
+				SELECT matched.id, 3
 				FROM library_tracks matched
 				WHERE upe.track_id IS NULL
 				  AND COALESCE(upe.track_path, '') <> ''
@@ -1304,10 +1271,10 @@ func playHistorySQL(hasLegacyStreamIDColumn bool) string {
 	`
 }
 
-func (s *Store) playHistoryRows(ctx context.Context, userID int64, limit int, hasLegacyStreamIDColumn bool) ([]map[string]any, error) {
+func (s *Store) playHistoryRows(ctx context.Context, userID int64, limit int) ([]map[string]any, error) {
 	queryCtx, cancel := postgres.WithTimeout(ctx, s.queryTimeout)
 	defer cancel()
-	return rowsToMaps(s.pool.Query(queryCtx, playHistorySQL(hasLegacyStreamIDColumn), userID, limit))
+	return rowsToMaps(s.pool.Query(queryCtx, playHistorySQL(), userID, limit))
 }
 
 func (s *Store) resolvePlayHistoryAlbumFallback(ctx context.Context, refs []historyFallbackRef) (map[string]map[string]any, error) {

--- a/app/tests/test_federation_migration_matrix.py
+++ b/app/tests/test_federation_migration_matrix.py
@@ -306,7 +306,7 @@ def _seed_063_legacy_state() -> dict[str, str]:
 
 
 def _assert_hardened_state(ids: dict[str, str]) -> None:
-    assert _scalar("SELECT version_num FROM alembic_version") == "080"
+    assert _scalar("SELECT version_num FROM alembic_version") == "081"
     assert (
         _scalar(
             "SELECT status FROM federation_local_keys WHERE node_uid = %s",
@@ -356,7 +356,7 @@ def test_empty_database_migrates_from_base_to_head(pg_db):
 
     _migrate("head")
 
-    assert _scalar("SELECT version_num FROM alembic_version") == "080"
+    assert _scalar("SELECT version_num FROM alembic_version") == "081"
     for table in (
         "federation_local_keys",
         "federation_catalog_changes",
@@ -371,6 +371,54 @@ def test_empty_database_migrates_from_base_to_head(pg_db):
         assert _scalar("SELECT to_regclass(%s) IS NOT NULL", (f"public.{table}",))
 
 
+def test_080_upgrade_removes_deprecated_navidrome_column(pg_db):
+    del pg_db
+    _reset_schema()
+    _migrate("080")
+    connection = _connection()
+    try:
+        with connection.cursor() as cursor:
+            cursor.execute("ALTER TABLE library_tracks ADD COLUMN navidrome_id TEXT")
+        connection.commit()
+    finally:
+        connection.close()
+
+    _migrate("head")
+
+    assert _scalar("SELECT version_num FROM alembic_version") == "081"
+    assert (
+        _scalar(
+            """
+            SELECT EXISTS (
+                SELECT 1
+                FROM information_schema.columns
+                WHERE table_schema = 'public'
+                  AND table_name = 'library_tracks'
+                  AND column_name = 'navidrome_id'
+            )
+            """
+        )
+        is False
+    )
+
+    _migrate("080", downgrade=True)
+
+    assert (
+        _scalar(
+            """
+            SELECT EXISTS (
+                SELECT 1
+                FROM information_schema.columns
+                WHERE table_schema = 'public'
+                  AND table_name = 'library_tracks'
+                  AND column_name = 'navidrome_id'
+            )
+            """
+        )
+        is True
+    )
+
+
 def test_real_main_049_snapshot_upgrades_without_user_data_loss(pg_db):
     del pg_db
     _restore_049_schema_fixture()
@@ -378,7 +426,7 @@ def test_real_main_049_snapshot_upgrades_without_user_data_loss(pg_db):
 
     _migrate("head")
 
-    assert _scalar("SELECT version_num FROM alembic_version") == "080"
+    assert _scalar("SELECT version_num FROM alembic_version") == "081"
     assert _scalar("SELECT email FROM users WHERE id = %s", (ids["user_id"],)) == (
         "legacy@example.test"
     )

--- a/app/tests/test_navidrome_runtime_removal.py
+++ b/app/tests/test_navidrome_runtime_removal.py
@@ -1,0 +1,29 @@
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+RUNTIME_FILES = (
+    ROOT / "app/crate/db/queries/user_library_shared.py",
+    ROOT / "app/crate/db/queries/user_library_history.py",
+    ROOT / "app/crate/db/repositories/user_library_shared.py",
+    ROOT / "app/readplane/internal/catalog/store.go",
+)
+MIGRATION = (
+    ROOT / "app/crate/db/migrations/versions/081_remove_navidrome_compatibility.py"
+)
+
+
+def test_runtime_no_longer_contains_navidrome_compatibility():
+    for path in RUNTIME_FILES:
+        assert "navidrome" not in path.read_text().lower(), path
+
+
+def test_migration_removes_deprecated_navidrome_column_conditionally():
+    migration = MIGRATION.read_text()
+
+    assert 'revision = "081"' in migration
+    assert 'down_revision = "080"' in migration
+    assert "column_name = 'navidrome_id'" in migration
+    assert 'op.drop_column("library_tracks", "navidrome_id")' in migration
+    assert "op.add_column(" in migration
+    assert '"library_tracks",' in migration

--- a/app/tests/test_postgres_test_database.py
+++ b/app/tests/test_postgres_test_database.py
@@ -32,7 +32,7 @@ def test_pg_db_uses_an_isolated_clone_of_the_initialized_template(pg_db) -> None
 
     assert database_name != TEST_DB_NAME
     assert database_name.startswith(f"{TEST_DB_NAME}_case_")
-    assert revision == "080"
+    assert revision == "081"
     assert admin_count >= 1
     assert os.environ["CRATE_POSTGRES_DB"] == database_name
 

--- a/app/tests/test_user_library_queries.py
+++ b/app/tests/test_user_library_queries.py
@@ -809,9 +809,7 @@ class TestPlayHistory:
 
         from crate.db.queries.user_library_history import get_play_history_rows
 
-        rows = get_play_history_rows(
-            TEST_USER_ID, limit=10, has_legacy_stream_id_column=False
-        )
+        rows = get_play_history_rows(TEST_USER_ID, limit=10)
         assert len(rows) == 1
         assert rows[0]["title"] == "Concubine"
         assert rows[0]["artist"] == "Converge"
@@ -940,7 +938,6 @@ class TestPlayHistory:
         history = get_play_history_rows(
             TEST_USER_ID,
             limit=10,
-            has_legacy_stream_id_column=False,
         )
 
         matching = [item for item in history if item["title"] == title]


### PR DESCRIPTION
## Summary

- remove all deprecated Navidrome runtime lookup code from Python and the Go readplane
- simplify local track resolution to canonical IDs, entity UIDs, and paths
- add migration 081 to conditionally drop the obsolete `library_tracks.navidrome_id` column
- keep downgrade reversible by recreating the nullable column without deprecated data
- update migration head contracts and add runtime/schema regression coverage

## Root cause

Production still had the obsolete `navidrome_id` column even though all 111,487 values were empty. Both FastAPI and the readplane enabled a legacy lookup solely from column existence. PostgreSQL then evaluated an unindexed lateral branch for each history row, adding roughly 1.2–1.45 seconds. The readplane exhausted its 800 ms budget and fell back to FastAPI, making `/api/me/history` take roughly 2.3–2.6 seconds.

## Impact

The deprecated branch is gone rather than indexed or preserved. In the development stack after migration 081:

- FastAPI history: ~5–10 ms warm
- readplane history: ~2–3 ms warm
- schema revision: 081
- obsolete column: absent

Production will be revalidated after an exact-SHA deploy with a fresh recovery snapshot.

## Validation

- TDD failures observed before implementation
- 122 targeted Python tests pass
- migration matrix passes base→head, 049→head, 063 rollback/reupgrade, and 080→081→080
- all Go tests pass
- `go vet ./...`
- Ruff and pre-commit hooks pass
- development API/readplane endpoint smoke tests pass
