### PR TITLE
chore: remove remaining Navidrome references

### DIFF
--- a/app/site/src/components/Comparison.tsx
+++ b/app/site/src/components/Comparison.tsx
@@ -3,7 +3,6 @@ import { Check, Minus } from "lucide-react";
 interface Row {
   label: string;
   crate: boolean | "partial";
-  navidrome: boolean | "partial";
   plex: boolean | "partial";
   jellyfin: boolean | "partial";
 }
@@ -12,91 +11,78 @@ const ROWS: Row[] = [
   {
     label: "Multi-source enrichment (8+)",
     crate: true,
-    navidrome: false,
     plex: true,
     jellyfin: false,
   },
   {
     label: "Audio analysis (BPM, key, mood)",
     crate: true,
-    navidrome: false,
     plex: true,
     jellyfin: false,
   },
   {
     label: "Adaptive EQ per track",
     crate: true,
-    navidrome: false,
     plex: false,
     jellyfin: false,
   },
   {
     label: "Bliss-based similarity radio",
     crate: true,
-    navidrome: false,
     plex: false,
     jellyfin: false,
   },
   {
     label: "Genre taxonomy with inheritance",
     crate: true,
-    navidrome: false,
     plex: false,
     jellyfin: false,
   },
   {
     label: "Upcoming shows + setlists",
     crate: true,
-    navidrome: false,
     plex: false,
     jellyfin: false,
   },
   {
     label: "Subsonic API",
     crate: true,
-    navidrome: true,
     plex: false,
     jellyfin: false,
   },
   {
     label: "Native mobile app",
     crate: true,
-    navidrome: false,
     plex: true,
     jellyfin: true,
   },
   {
     label: "Synced lyrics with seek-by-line",
     crate: true,
-    navidrome: false,
     plex: true,
     jellyfin: false,
   },
   {
     label: "Offline downloads",
     crate: true,
-    navidrome: false,
     plex: true,
     jellyfin: true,
   },
   {
     label: "Low-resource footprint",
     crate: false,
-    navidrome: true,
     plex: "partial",
     jellyfin: "partial",
   },
   {
     label: "Comfortable on very small servers",
     crate: false,
-    navidrome: true,
     plex: "partial",
     jellyfin: "partial",
   },
   {
     label: "Open source",
     crate: true,
-    navidrome: true,
     plex: false,
     jellyfin: true,
   },
@@ -122,7 +108,6 @@ function Cell({ value }: { value: boolean | "partial" }) {
 
 const COLS = [
   { key: "crate" as const, label: "Crate", highlight: true },
-  { key: "navidrome" as const, label: "Navidrome", highlight: false },
   { key: "plex" as const, label: "Plex", highlight: false },
   { key: "jellyfin" as const, label: "Jellyfin", highlight: false },
 ];
@@ -141,11 +126,9 @@ export function Comparison() {
           Crate asks for more machine.
         </h2>
         <p className="mt-4 text-base leading-7 text-white/60 sm:text-lg">
-          If you want a small music server that mostly stays out of the way,
-          Navidrome may be a better fit. Crate does more background work:
-          enrichment, audio analysis, acquisition, cache generation, admin
-          views, and a separate listening app. That costs CPU, memory, and disk
-          I/O.
+          Crate does extensive background work: enrichment, audio analysis,
+          acquisition, cache generation, admin views, and a separate listening
+          app. That costs CPU, memory, and disk I/O.
         </p>
         <p className="mt-5 border-l border-cyan-300/35 pl-4 text-[14.5px] leading-7 text-white/52">
           Reducing that footprint is active work, especially around workers,
@@ -158,11 +141,10 @@ export function Comparison() {
       <div className="overflow-x-auto rounded-[20px] border border-white/8">
         <table className="w-full table-fixed text-left">
           <colgroup>
-            <col className="w-[40%]" />
-            <col className="w-[15%]" />
-            <col className="w-[15%]" />
-            <col className="w-[15%]" />
-            <col className="w-[15%]" />
+            <col className="w-[46%]" />
+            <col className="w-[18%]" />
+            <col className="w-[18%]" />
+            <col className="w-[18%]" />
           </colgroup>
           <thead>
             <tr className="border-b border-white/8">

--- a/app/tests/test_navidrome_runtime_removal.py
+++ b/app/tests/test_navidrome_runtime_removal.py
@@ -7,6 +7,7 @@ RUNTIME_FILES = (
     ROOT / "app/crate/db/queries/user_library_history.py",
     ROOT / "app/crate/db/repositories/user_library_shared.py",
     ROOT / "app/readplane/internal/catalog/store.go",
+    ROOT / "app/site/src/components/Comparison.tsx",
 )
 MIGRATION = (
     ROOT / "app/crate/db/migrations/versions/081_remove_navidrome_compatibility.py"


### PR DESCRIPTION
## Summary
- remove Navidrome from the public comparison component
- simplify the comparison layout after removing the column
- extend the runtime-removal guard to cover the public site

## Validation
- `.venv/bin/python -m pytest app/tests/test_navidrome_runtime_removal.py -q`
- `npm run build` in `app/site`
- `.venv/bin/pre-commit run --files app/site/src/components/Comparison.tsx app/tests/test_navidrome_runtime_removal.py`

The only remaining references are the Alembic migration and regression tests required to remove the legacy database column safely during upgrades.