### PR TITLE
fix: restore Android catalog and reconciliation stability

### DIFF
--- a/app/crate/db/jobs/global_catalog_reconciliation.py
+++ b/app/crate/db/jobs/global_catalog_reconciliation.py
@@ -1291,9 +1291,11 @@ def _resolve_artist_target(
         return forced_target, MatchScore(1.0, "manual_force_merge", auto_merge=True)
 
     existing_target = _existing_source_target(session, source)
-    if existing_target and not merge_blocked_for_source(
-        session, source, existing_target
-    ):
+    existing_target_allowed = bool(
+        existing_target
+        and not merge_blocked_for_source(session, source, existing_target)
+    )
+    if existing_target and existing_target_allowed:
         if not recompute_matches:
             return existing_target, _existing_source_score(source)
         revalidated = _revalidate_existing_target(
@@ -1307,6 +1309,16 @@ def _resolve_artist_target(
 
     payload = source["source_payload"]
     rows = _candidate_artists(session, payload)
+    existing_identity_match = (
+        recompute_matches
+        and existing_target is not None
+        and existing_target_allowed
+        and any(
+            row["global_artist_uid"] == existing_target
+            and _has_strong_identity_match("artist", payload, row)
+            for row in rows
+        )
+    )
     if recompute_matches and existing_target:
         rows = [row for row in rows if row["global_artist_uid"] != existing_target]
     best_uid, best_score = _best_match(
@@ -1323,6 +1335,12 @@ def _resolve_artist_target(
                 candidate=True,
             )
         return best_uid, best_score
+    if existing_identity_match and existing_target is not None:
+        return existing_target, MatchScore(
+            1.0,
+            "existing_strong_identity",
+            auto_merge=True,
+        )
     return _global_uid(source), MatchScore(0.0, "new_remote_artist")
 
 
@@ -1352,9 +1370,11 @@ def _resolve_album_target(
         )
 
     existing_target = _existing_source_target(session, source)
-    if existing_target and not merge_blocked_for_source(
-        session, source, existing_target
-    ):
+    existing_target_allowed = bool(
+        existing_target
+        and not merge_blocked_for_source(session, source, existing_target)
+    )
+    if existing_target and existing_target_allowed:
         if not recompute_matches:
             return existing_target, _existing_source_score(source)
         revalidated = _revalidate_existing_target(
@@ -1368,6 +1388,16 @@ def _resolve_album_target(
 
     payload = source["source_payload"]
     rows = _candidate_albums(session, payload, artist_uid)
+    existing_identity_match = (
+        recompute_matches
+        and existing_target is not None
+        and existing_target_allowed
+        and any(
+            row["global_album_uid"] == existing_target
+            and _has_strong_identity_match("album", payload, row)
+            for row in rows
+        )
+    )
     if recompute_matches and existing_target:
         rows = [row for row in rows if row["global_album_uid"] != existing_target]
     best_uid, best_score = _best_match(
@@ -1384,6 +1414,12 @@ def _resolve_album_target(
                 candidate=True,
             )
         return best_uid, best_score
+    if existing_identity_match and existing_target is not None:
+        return existing_target, MatchScore(
+            1.0,
+            "existing_strong_identity",
+            auto_merge=True,
+        )
     return _global_uid(source), best_score or MatchScore(0.0, "new_remote_album")
 
 
@@ -1399,9 +1435,11 @@ def _resolve_track_target(
         return forced_target, MatchScore(1.0, "manual_force_merge", auto_merge=True)
 
     existing_target = _existing_source_target(session, source)
-    if existing_target and not merge_blocked_for_source(
-        session, source, existing_target
-    ):
+    existing_target_allowed = bool(
+        existing_target
+        and not merge_blocked_for_source(session, source, existing_target)
+    )
+    if existing_target and existing_target_allowed:
         if not recompute_matches:
             return existing_target, _existing_source_score(source)
         revalidated = _revalidate_existing_target(
@@ -1415,6 +1453,16 @@ def _resolve_track_target(
 
     payload = source["source_payload"]
     rows = _candidate_tracks(session, payload, artist_uid)
+    existing_identity_match = (
+        recompute_matches
+        and existing_target is not None
+        and existing_target_allowed
+        and any(
+            row["global_track_uid"] == existing_target
+            and _has_strong_identity_match("track", payload, row)
+            for row in rows
+        )
+    )
     if recompute_matches and existing_target:
         rows = [row for row in rows if row["global_track_uid"] != existing_target]
     best_uid, best_score = _best_match(
@@ -1431,6 +1479,12 @@ def _resolve_track_target(
                 candidate=True,
             )
         return best_uid, best_score
+    if existing_identity_match and existing_target is not None:
+        return existing_target, MatchScore(
+            1.0,
+            "existing_strong_identity",
+            auto_merge=True,
+        )
     return _global_uid(source), best_score or MatchScore(0.0, "new_remote_track")
 
 
@@ -1517,6 +1571,26 @@ def _best_match(
             best_uid = row[uid_key]
             best_score = score
     return best_uid, best_score
+
+
+def _has_strong_identity_match(
+    entity_type: str,
+    payload: dict[str, Any],
+    candidate: dict[str, Any],
+) -> bool:
+    identifiers = {
+        "artist": ("musicbrainz_artist_mbid",),
+        "album": (
+            "musicbrainz_release_mbid",
+            "musicbrainz_release_group_mbid",
+            "upc",
+        ),
+        "track": ("musicbrainz_recording_mbid", "isrc"),
+    }[entity_type]
+    return any(
+        payload.get(identifier) and payload.get(identifier) == candidate.get(identifier)
+        for identifier in identifiers
+    )
 
 
 def _existing_source_target(session, source: dict[str, Any]) -> str | None:

--- a/app/listen/src/contexts/use-auth-token-refresh.test.tsx
+++ b/app/listen/src/contexts/use-auth-token-refresh.test.tsx
@@ -1,0 +1,56 @@
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const { getAuthTokenExpiresAtMock, getAuthTokenMock, refreshAuthTokenMock } =
+  vi.hoisted(() => ({
+    getAuthTokenExpiresAtMock: vi.fn<() => string | null>(),
+    getAuthTokenMock: vi.fn<() => string | null>(),
+    refreshAuthTokenMock: vi.fn<() => Promise<boolean>>(),
+  }));
+
+vi.mock("@/lib/api", () => ({
+  AUTH_TOKEN_EVENT: "crate:auth-token-updated",
+  getAuthToken: getAuthTokenMock,
+  getAuthTokenExpiresAt: getAuthTokenExpiresAtMock,
+  refreshAuthToken: refreshAuthTokenMock,
+}));
+
+import { useAuthTokenRefresh } from "@/contexts/use-auth-token-refresh";
+
+describe("useAuthTokenRefresh", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-07-27T10:00:00Z"));
+    getAuthTokenMock.mockReturnValue("short-lived-token");
+    getAuthTokenExpiresAtMock.mockReturnValue("2026-07-27T10:01:00Z");
+    refreshAuthTokenMock.mockResolvedValue(true);
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+    vi.useRealTimers();
+  });
+
+  it("does not refresh a short-lived token every five seconds", async () => {
+    renderHook(() =>
+      useAuthTokenRefresh({
+        id: 1,
+        name: "Listener",
+        email: "listener@example.test",
+        role: "user",
+      }),
+    );
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(6_000);
+    });
+
+    expect(refreshAuthTokenMock).not.toHaveBeenCalled();
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(42_000);
+    });
+
+    expect(refreshAuthTokenMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/app/listen/src/contexts/use-auth-token-refresh.ts
+++ b/app/listen/src/contexts/use-auth-token-refresh.ts
@@ -12,15 +12,24 @@ const REFRESH_MARGIN_MS = 5 * 60 * 1000;
 const FALLBACK_REFRESH_MS = 45 * 60 * 1000;
 const MIN_REFRESH_DELAY_MS = 5_000;
 
+function boundedRefreshMargin(remainingMs: number): number {
+  return Math.min(
+    REFRESH_MARGIN_MS,
+    Math.max(MIN_REFRESH_DELAY_MS, remainingMs * 0.2),
+  );
+}
+
 function nextRefreshDelay(): number | null {
   if (!getAuthToken()) return null;
   const expiresAt = getAuthTokenExpiresAt();
   if (!expiresAt) return FALLBACK_REFRESH_MS;
   const expiresMs = Date.parse(expiresAt);
   if (!Number.isFinite(expiresMs)) return FALLBACK_REFRESH_MS;
+  const remainingMs = expiresMs - Date.now();
+  if (remainingMs <= 0) return MIN_REFRESH_DELAY_MS;
   return Math.max(
     MIN_REFRESH_DELAY_MS,
-    expiresMs - Date.now() - REFRESH_MARGIN_MS,
+    remainingMs - boundedRefreshMargin(remainingMs),
   );
 }
 

--- a/app/listen/src/lib/cache-native.test.ts
+++ b/app/listen/src/lib/cache-native.test.ts
@@ -1,0 +1,68 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { apiBaseMock } = vi.hoisted(() => ({
+  apiBaseMock: vi.fn<() => string>(),
+}));
+
+vi.mock("@/lib/api", () => ({
+  apiSseUrl: vi.fn((path: string) => `${apiBaseMock()}${path}`),
+  getApiBase: apiBaseMock,
+}));
+
+vi.mock("@/lib/platform", () => ({
+  usesConfigurableServer: true,
+}));
+
+vi.mock("@/lib/library-routes", () => ({
+  recordAssetInvalidationScope: vi.fn(),
+}));
+
+vi.mock("@/lib/sse", () => ({
+  markSseChannelOpen: vi.fn(),
+  markSseChannelEvent: vi.fn(),
+  markSseChannelError: vi.fn(),
+  markSseChannelClosed: vi.fn(),
+  onSseChannelState: vi.fn(() => () => {}),
+  onSseReconnect: vi.fn(() => () => {}),
+}));
+
+import { cacheClear, cacheGet, cacheSet } from "@/lib/cache";
+
+function setNativeUser(
+  apiBase: string,
+  serverId: string,
+  userId: number,
+): void {
+  apiBaseMock.mockReturnValue(apiBase);
+  localStorage.setItem("crate-current-server", serverId);
+  localStorage.setItem(
+    `listen-auth-user-id:${encodeURIComponent(apiBase)}`,
+    String(userId),
+  );
+}
+
+describe("native cache identity", () => {
+  beforeEach(() => {
+    cacheClear();
+    localStorage.clear();
+    apiBaseMock.mockReset();
+  });
+
+  it("isolates cached Home data by the server-scoped native user", () => {
+    setNativeUser("https://api-a.example.test", "server-a", 1);
+    cacheSet("/api/me/home/discovery", { hero: "High Vis" });
+
+    setNativeUser("https://api-a.example.test", "server-a", 2);
+
+    expect(cacheGet("/api/me/home/discovery")).toBeNull();
+  });
+
+  it("isolates cached Collection data when the native server changes", () => {
+    setNativeUser("https://api-a.example.test", "server-a", 1);
+    cacheSet("/api/catalog/me/artists", [{ artist_name: "High Vis" }]);
+
+    setNativeUser("https://api-b.example.test", "server-b", 1);
+
+    expect(cacheGet("/api/catalog/me/artists")).toBeNull();
+  });
+});

--- a/app/listen/src/lib/cache.test.ts
+++ b/app/listen/src/lib/cache.test.ts
@@ -20,6 +20,11 @@ vi.mock("@/lib/api", () => ({
   apiSseUrl: vi.fn((path: string) => `https://api.example.test${path}`),
 }));
 
+vi.mock("@/lib/auth-user-storage", () => ({
+  getStoredAuthUserId: () =>
+    localStorage.getItem("listen-auth-user-id") || null,
+}));
+
 vi.mock("@/lib/platform", () => ({
   usesConfigurableServer: false,
 }));
@@ -57,6 +62,8 @@ import {
 } from "./cache";
 
 const STORAGE_KEY = "crate-api-cache:v2";
+const cacheStorageKey = (url: string, context = "web:anonymous"): string =>
+  `${STORAGE_KEY}:${context}:${url}`;
 
 beforeEach(() => {
   cacheClear();
@@ -344,8 +351,10 @@ describe("cacheGet / cacheSet", () => {
       data: { bar: 2 },
       timestamp: Date.now(),
       scopes: ["library"],
+      url: "/api/foo",
+      context: "web:anonymous",
     };
-    localStorage.setItem(`${STORAGE_KEY}:/api/foo`, JSON.stringify(entry));
+    localStorage.setItem(cacheStorageKey("/api/foo"), JSON.stringify(entry));
     expect(cacheGet("/api/foo")).toEqual({ bar: 2 });
   });
 
@@ -364,10 +373,12 @@ describe("cacheGet / cacheSet", () => {
       data: "from-storage",
       timestamp: Date.now(),
       scopes: [],
+      url: "/api/foo",
+      context: "web:anonymous",
     };
-    localStorage.setItem(`${STORAGE_KEY}:/api/foo`, JSON.stringify(entry));
+    localStorage.setItem(cacheStorageKey("/api/foo"), JSON.stringify(entry));
     cacheGet("/api/foo");
-    localStorage.removeItem(`${STORAGE_KEY}:/api/foo`);
+    localStorage.removeItem(cacheStorageKey("/api/foo"));
     expect(cacheGet("/api/foo")).toBe("from-storage");
   });
 
@@ -377,8 +388,10 @@ describe("cacheGet / cacheSet", () => {
       data: { stale: true },
       timestamp: old,
       scopes: [],
+      url: "/api/foo",
+      context: "web:anonymous",
     };
-    localStorage.setItem(`${STORAGE_KEY}:/api/foo`, JSON.stringify(entry));
+    localStorage.setItem(cacheStorageKey("/api/foo"), JSON.stringify(entry));
     expect(cacheGet("/api/foo")).toBeNull();
   });
 
@@ -388,10 +401,12 @@ describe("cacheGet / cacheSet", () => {
       data: { stale: true },
       timestamp: old,
       scopes: [],
+      url: "/api/foo",
+      context: "web:anonymous",
     };
-    localStorage.setItem(`${STORAGE_KEY}:/api/foo`, JSON.stringify(entry));
+    localStorage.setItem(cacheStorageKey("/api/foo"), JSON.stringify(entry));
     cacheGet("/api/foo");
-    expect(localStorage.getItem(`${STORAGE_KEY}:/api/foo`)).toBeNull();
+    expect(localStorage.getItem(cacheStorageKey("/api/foo"))).toBeNull();
   });
 
   it("treats entries within TTL as valid", () => {
@@ -400,13 +415,15 @@ describe("cacheGet / cacheSet", () => {
       data: "fresh",
       timestamp: recent,
       scopes: [],
+      url: "/api/foo",
+      context: "web:anonymous",
     };
-    localStorage.setItem(`${STORAGE_KEY}:/api/foo`, JSON.stringify(entry));
+    localStorage.setItem(cacheStorageKey("/api/foo"), JSON.stringify(entry));
     expect(cacheGet("/api/foo")).toBe("fresh");
   });
 
   it("handles corrupted localStorage JSON gracefully", () => {
-    localStorage.setItem(`${STORAGE_KEY}:/api/foo`, "not-json");
+    localStorage.setItem(cacheStorageKey("/api/foo"), "not-json");
     expect(cacheGet("/api/foo")).toBeNull();
   });
 
@@ -444,13 +461,15 @@ describe("cacheInvalidate", () => {
 
     // Flush the setTimeout(0) that _scheduleStorageWrite uses
     await vi.runAllTimersAsync();
-    expect(localStorage.getItem(`${STORAGE_KEY}:/api/me/likes`)).not.toBeNull();
+    expect(
+      localStorage.getItem(cacheStorageKey("/api/me/likes")),
+    ).not.toBeNull();
 
     cacheInvalidate("likes");
     expect(cacheGet("/api/me/likes")).toBeNull();
     // cacheInvalidate iterates memoryCache and removes matching
     // localStorage keys directly (does NOT use Object.keys()).
-    expect(localStorage.getItem(`${STORAGE_KEY}:/api/me/likes`)).toBeNull();
+    expect(localStorage.getItem(cacheStorageKey("/api/me/likes"))).toBeNull();
 
     vi.useRealTimers();
   });
@@ -513,8 +532,12 @@ describe("cacheClear", () => {
     cacheSet("/api/b", 2);
     await vi.runAllTimersAsync();
 
-    expect(localStorage.getItem(`${STORAGE_KEY}:/api/a`)).not.toBeNull();
-    expect(localStorage.getItem(`${STORAGE_KEY}:/api/b`)).not.toBeNull();
+    expect(
+      localStorage.getItem(`${STORAGE_KEY}:web:anonymous:/api/a`),
+    ).not.toBeNull();
+    expect(
+      localStorage.getItem(`${STORAGE_KEY}:web:anonymous:/api/b`),
+    ).not.toBeNull();
 
     cacheClear();
 
@@ -544,6 +567,40 @@ describe("cacheClear", () => {
     cacheClear();
     expect(cacheGet("/api/a")).toBeNull();
     expect(localStorage.getItem("other-key")).toBe("keep-me");
+  });
+});
+
+describe("cache identity isolation", () => {
+  it("does not reuse user-scoped payloads after the authenticated user changes", () => {
+    localStorage.setItem("listen-auth-user-id", "1");
+    cacheSet("/api/catalog/me/artists", [{ artist_name: "High Vis" }]);
+
+    localStorage.setItem("listen-auth-user-id", "2");
+
+    expect(cacheGet("/api/catalog/me/artists")).toBeNull();
+  });
+
+  it("does not reuse payloads after the active native server changes", () => {
+    localStorage.setItem("listen-auth-user-id", "1");
+    localStorage.setItem("crate-current-server", "server-a");
+    cacheSet("/api/me/home/discovery", { hero: "High Vis" });
+
+    localStorage.setItem("crate-current-server", "server-b");
+
+    expect(cacheGet("/api/me/home/discovery")).toBeNull();
+  });
+
+  it("ignores legacy unscoped payloads from previous app versions", () => {
+    localStorage.setItem(
+      `${STORAGE_KEY}:/api/catalog/me/artists`,
+      JSON.stringify({
+        data: [],
+        timestamp: Date.now(),
+        scopes: ["follows", "library"],
+      }),
+    );
+
+    expect(cacheGet("/api/catalog/me/artists")).toBeNull();
   });
 });
 
@@ -605,14 +662,14 @@ describe("storage write scheduling", () => {
   it("does not write to localStorage synchronously", () => {
     cacheSet("/api/foo", "sync-test");
     expect(cacheGet("/api/foo")).toBe("sync-test");
-    expect(localStorage.getItem(`${STORAGE_KEY}:/api/foo`)).toBeNull();
+    expect(localStorage.getItem(cacheStorageKey("/api/foo"))).toBeNull();
   });
 
   it("writes to localStorage after timer flush", async () => {
     vi.useFakeTimers();
     cacheSet("/api/foo", "delayed-write");
     await vi.runAllTimersAsync();
-    expect(localStorage.getItem(`${STORAGE_KEY}:/api/foo`)).not.toBeNull();
+    expect(localStorage.getItem(cacheStorageKey("/api/foo"))).not.toBeNull();
     vi.useRealTimers();
   });
 
@@ -621,7 +678,9 @@ describe("storage write scheduling", () => {
     cacheSet("/api/me/likes", [1]);
     cacheInvalidate("likes");
     await vi.runAllTimersAsync();
-    expect(localStorage.getItem(`${STORAGE_KEY}:/api/me/likes`)).toBeNull();
+    expect(
+      localStorage.getItem(`${STORAGE_KEY}:web:anonymous:/api/me/likes`),
+    ).toBeNull();
     vi.useRealTimers();
   });
 
@@ -630,7 +689,9 @@ describe("storage write scheduling", () => {
     cacheSet("/api/foo", 1);
     cacheClear();
     await vi.runAllTimersAsync();
-    expect(localStorage.getItem(`${STORAGE_KEY}:/api/foo`)).toBeNull();
+    expect(
+      localStorage.getItem(`${STORAGE_KEY}:web:anonymous:/api/foo`),
+    ).toBeNull();
     vi.useRealTimers();
   });
 
@@ -640,7 +701,9 @@ describe("storage write scheduling", () => {
     cacheSet("/api/foo", 2);
     await vi.runAllTimersAsync();
 
-    const stored = JSON.parse(localStorage.getItem(`${STORAGE_KEY}:/api/foo`)!);
+    const stored = JSON.parse(
+      localStorage.getItem(`${STORAGE_KEY}:web:anonymous:/api/foo`)!,
+    );
     expect(stored.data).toBe(2);
 
     vi.useRealTimers();
@@ -896,11 +959,13 @@ describe("connectCacheEvents", () => {
 describe("cache layer priority", () => {
   it("memory layer wins over localStorage", () => {
     localStorage.setItem(
-      `${STORAGE_KEY}:/api/foo`,
+      cacheStorageKey("/api/foo"),
       JSON.stringify({
         data: "from-storage",
         timestamp: Date.now(),
         scopes: [],
+        url: "/api/foo",
+        context: "web:anonymous",
       }),
     );
     cacheSet("/api/foo", "from-memory");

--- a/app/listen/src/lib/cache.ts
+++ b/app/listen/src/lib/cache.ts
@@ -1,4 +1,5 @@
 import { apiSseUrl } from "@/lib/api";
+import { getStoredAuthUserId } from "@/lib/auth-user-storage";
 import { usesConfigurableServer } from "@/lib/platform";
 import { recordAssetInvalidationScope } from "@/lib/library-routes";
 import {
@@ -17,6 +18,8 @@ interface CacheEntry<T = unknown> {
   data: T;
   timestamp: number;
   scopes: string[];
+  url: string;
+  context: string;
 }
 
 const STORAGE_KEY = "crate-api-cache:v2";
@@ -35,10 +38,28 @@ const pendingStorageWrites = new Map<string, ScheduledStorageWriteHandle>();
 const LOCALSTORAGE_MAX_AGE_MS = 180 * 24 * 60 * 60 * 1000;
 const STORAGE_WRITE_TIMEOUT_MS = 250;
 
-function _cancelPendingStorageWrite(url: string): void {
-  const handle = pendingStorageWrites.get(url);
+function cacheContext(): string {
+  try {
+    const serverId = localStorage.getItem("crate-current-server") || "web";
+    const userId = getStoredAuthUserId() || "anonymous";
+    return `${serverId}:${userId}`;
+  } catch {
+    return "web:anonymous";
+  }
+}
+
+function scopedCacheKey(url: string, context = cacheContext()): string {
+  return `${context}\u0000${url}`;
+}
+
+function storageCacheKey(url: string, context = cacheContext()): string {
+  return `${STORAGE_KEY}:${context}:${url}`;
+}
+
+function _cancelPendingStorageWrite(cacheKey: string): void {
+  const handle = pendingStorageWrites.get(cacheKey);
   if (handle == null) return;
-  pendingStorageWrites.delete(url);
+  pendingStorageWrites.delete(cacheKey);
   if (
     typeof handle === "number" &&
     typeof globalThis.cancelIdleCallback === "function"
@@ -49,38 +70,44 @@ function _cancelPendingStorageWrite(url: string): void {
   globalThis.clearTimeout(handle as ReturnType<typeof setTimeout>);
 }
 
-function _writeEntryToStorage(url: string): void {
-  pendingStorageWrites.delete(url);
-  const entry = memoryCache.get(url);
+function _writeEntryToStorage(cacheKey: string): void {
+  pendingStorageWrites.delete(cacheKey);
+  const entry = memoryCache.get(cacheKey);
   if (!entry) return;
 
   try {
-    localStorage.setItem(`${STORAGE_KEY}:${url}`, JSON.stringify(entry));
+    localStorage.setItem(
+      storageCacheKey(entry.url, entry.context),
+      JSON.stringify(entry),
+    );
   } catch {
     _evictOldest(5);
     try {
-      localStorage.setItem(`${STORAGE_KEY}:${url}`, JSON.stringify(entry));
+      localStorage.setItem(
+        storageCacheKey(entry.url, entry.context),
+        JSON.stringify(entry),
+      );
     } catch {
       /* give up */
     }
   }
 }
 
-function _scheduleStorageWrite(url: string): void {
-  _cancelPendingStorageWrite(url);
+function _scheduleStorageWrite(cacheKey: string): void {
+  _cancelPendingStorageWrite(cacheKey);
 
-  const runWrite = () => _writeEntryToStorage(url);
+  const runWrite = () => _writeEntryToStorage(cacheKey);
 
   if (typeof globalThis.requestIdleCallback === "function") {
     const handle = globalThis.requestIdleCallback(runWrite, {
       timeout: STORAGE_WRITE_TIMEOUT_MS,
     });
-    pendingStorageWrites.set(url, handle);
+    pendingStorageWrites.set(cacheKey, handle);
     return;
   }
 
   const handle = globalThis.setTimeout(runWrite, 0);
-  pendingStorageWrites.set(url, handle);
+  pendingStorageWrites.set(cacheKey, handle);
 }
 
 /** Scope tags for API URLs — determines what invalidation events
@@ -178,20 +205,22 @@ export function scopesForUrl(url: string): string[] {
 
 /** Get cached data for a URL. Returns null if not cached or expired. */
 export function cacheGet<T>(url: string): T | null {
-  const entry = memoryCache.get(url);
+  const context = cacheContext();
+  const cacheKey = scopedCacheKey(url, context);
+  const entry = memoryCache.get(cacheKey);
   if (entry) return entry.data as T;
 
   // Fallback to localStorage with TTL check
   try {
-    const raw = localStorage.getItem(`${STORAGE_KEY}:${url}`);
+    const raw = localStorage.getItem(storageCacheKey(url, context));
     if (raw) {
       const parsed: CacheEntry<T> = JSON.parse(raw);
       // Discard entries older than the safety-net TTL
       if (Date.now() - parsed.timestamp > LOCALSTORAGE_MAX_AGE_MS) {
-        localStorage.removeItem(`${STORAGE_KEY}:${url}`);
+        localStorage.removeItem(storageCacheKey(url, context));
         return null;
       }
-      memoryCache.set(url, parsed);
+      memoryCache.set(cacheKey, parsed);
       return parsed.data;
     }
   } catch {
@@ -203,10 +232,18 @@ export function cacheGet<T>(url: string): T | null {
 
 /** Store data in cache with scope tags. */
 export function cacheSet<T>(url: string, data: T): void {
+  const context = cacheContext();
   const scopes = scopesForUrl(url);
-  const entry: CacheEntry<T> = { data, timestamp: Date.now(), scopes };
-  memoryCache.set(url, entry);
-  _scheduleStorageWrite(url);
+  const entry: CacheEntry<T> = {
+    data,
+    timestamp: Date.now(),
+    scopes,
+    url,
+    context,
+  };
+  const cacheKey = scopedCacheKey(url, context);
+  memoryCache.set(cacheKey, entry);
+  _scheduleStorageWrite(cacheKey);
 }
 
 /** Invalidate all cache entries matching a scope. */
@@ -220,10 +257,13 @@ export function cacheInvalidate(scope: string): void {
   }
 
   for (const key of keysToRemove) {
+    const entry = memoryCache.get(key);
     _cancelPendingStorageWrite(key);
     memoryCache.delete(key);
     try {
-      localStorage.removeItem(`${STORAGE_KEY}:${key}`);
+      if (entry) {
+        localStorage.removeItem(storageCacheKey(entry.url, entry.context));
+      }
     } catch {
       /* ignore */
     }
@@ -232,8 +272,8 @@ export function cacheInvalidate(scope: string): void {
 
 /** Clear entire cache. */
 export function cacheClear(): void {
-  for (const key of pendingStorageWrites.keys()) {
-    _cancelPendingStorageWrite(key);
+  for (const cacheKey of pendingStorageWrites.keys()) {
+    _cancelPendingStorageWrite(cacheKey);
   }
   memoryCache.clear();
   try {
@@ -250,11 +290,11 @@ function _evictOldest(count: number): void {
   const entries = [...memoryCache.entries()]
     .sort((a, b) => a[1].timestamp - b[1].timestamp)
     .slice(0, count);
-  for (const [key] of entries) {
+  for (const [key, entry] of entries) {
     _cancelPendingStorageWrite(key);
     memoryCache.delete(key);
     try {
-      localStorage.removeItem(`${STORAGE_KEY}:${key}`);
+      localStorage.removeItem(storageCacheKey(entry.url, entry.context));
     } catch {
       /* ignore */
     }

--- a/app/readplane/internal/routes/artwork.go
+++ b/app/readplane/internal/routes/artwork.go
@@ -17,7 +17,7 @@ func (s *Server) catalogArtworkRoute(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if len(parts) == 3 && parts[0] == "albums" && parts[2] == "cover" {
-		if !s.requireCatalogAuth(w, r) {
+		if !s.requireCatalogAssetAuth(w, r) {
 			return
 		}
 		key, err := s.artworkCatalog.GlobalAlbumArtworkKey(r.Context(), parts[1])
@@ -25,7 +25,7 @@ func (s *Server) catalogArtworkRoute(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if len(parts) == 3 && parts[0] == "artists" && (parts[2] == "photo" || parts[2] == "background") {
-		if !s.requireCatalogAuth(w, r) {
+		if !s.requireCatalogAssetAuth(w, r) {
 			return
 		}
 		key, err := s.artworkCatalog.GlobalArtistArtworkKey(r.Context(), parts[1])

--- a/app/readplane/internal/routes/artwork_test.go
+++ b/app/readplane/internal/routes/artwork_test.go
@@ -10,9 +10,12 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/thecrateapp/crate/app/readplane/internal/auth"
+	"github.com/thecrateapp/crate/app/readplane/internal/catalog"
 	"github.com/thecrateapp/crate/app/readplane/internal/config"
 	"github.com/thecrateapp/crate/app/readplane/internal/media"
 )
@@ -20,6 +23,25 @@ import (
 type stubArtworkCatalog struct {
 	key string
 	err error
+}
+
+type queryTokenAuthenticator struct{}
+
+func (queryTokenAuthenticator) Authenticate(r *http.Request, allowQueryToken bool) (*auth.User, error) {
+	if allowQueryToken && r.URL.Query().Get("token") == "native-token" {
+		return &auth.User{ID: 1, Email: "native@example.test", Role: "user"}, nil
+	}
+	return nil, auth.ErrUnauthorized
+}
+
+func (queryTokenAuthenticator) AuthenticateProfile(r *http.Request, allowQueryToken bool) (*auth.User, error) {
+	return queryTokenAuthenticator{}.Authenticate(r, allowQueryToken)
+}
+
+func (queryTokenAuthenticator) InvalidateScope(string) {}
+
+func (queryTokenAuthenticator) Stats() auth.IdentityCacheStats {
+	return auth.IdentityCacheStats{}
 }
 
 func writeRouteArtworkFixture(t *testing.T, root, kind, key string) {
@@ -84,4 +106,47 @@ func TestNewServerResolvesArtworkFromCacheRoot(t *testing.T) {
 	expected, err := filepath.EvalSymlinks(filepath.Join(cacheRoot, "artwork-variants", "v1", "album-cover", "album-uid", "rev", "256.webp"))
 	require.NoError(t, err)
 	assert.Equal(t, expected, asset.Path)
+}
+
+func TestAlbumArtworkAcceptsNativeQueryToken(t *testing.T) {
+	cacheRoot := t.TempDir()
+	writeRouteArtworkFixture(t, cacheRoot, "album-cover", "album-uid")
+	server := &Server{
+		cfg:             config.Config{Version: "test"},
+		logger:          slog.New(slog.NewTextHandler(io.Discard, nil)),
+		auth:            queryTokenAuthenticator{},
+		catalog:         catalog.NewStore(nil, time.Second),
+		artworkCatalog:  stubArtworkCatalog{key: "album-uid"},
+		artworkResolver: media.NewArtworkResolver(cacheRoot),
+	}
+	request := httptest.NewRequest(
+		http.MethodGet,
+		"/api/albums/1/cover?size=128&token=native-token",
+		nil,
+	)
+	response := httptest.NewRecorder()
+
+	server.Handler().ServeHTTP(response, request)
+
+	assert.Equal(t, http.StatusOK, response.Code)
+	assert.Equal(t, "webp", response.Body.String())
+}
+
+func TestCatalogJSONRejectsQueryToken(t *testing.T) {
+	server := &Server{
+		cfg:     config.Config{Version: "test"},
+		logger:  slog.New(slog.NewTextHandler(io.Discard, nil)),
+		auth:    queryTokenAuthenticator{},
+		catalog: catalog.NewStore(nil, time.Second),
+	}
+	request := httptest.NewRequest(
+		http.MethodGet,
+		"/api/catalog/search?q=high+vis&token=native-token",
+		nil,
+	)
+	response := httptest.NewRecorder()
+
+	server.Handler().ServeHTTP(response, request)
+
+	assert.Equal(t, http.StatusUnauthorized, response.Code)
 }

--- a/app/readplane/internal/routes/catalog.go
+++ b/app/readplane/internal/routes/catalog.go
@@ -155,14 +155,14 @@ func (s *Server) albumRoute(w http.ResponseWriter, r *http.Request) {
 			s.fallbackOrRouteMiss(w, r)
 			return
 		}
-		if !s.requireCatalogAuth(w, r) {
+		if !s.requireCatalogAssetAuth(w, r) {
 			return
 		}
 		s.serveAlbumArtworkByID(w, r, albumID)
 		return
 	}
 	if len(parts) == 3 && parts[0] == "by-entity" && parts[2] == "cover" && isRouteUUID(parts[1]) {
-		if !s.requireCatalogAuth(w, r) {
+		if !s.requireCatalogAssetAuth(w, r) {
 			return
 		}
 		s.serveAlbumArtworkByEntityUID(w, r, parts[1])
@@ -246,14 +246,14 @@ func (s *Server) artistRoute(w http.ResponseWriter, r *http.Request) {
 			s.fallbackOrRouteMiss(w, r)
 			return
 		}
-		if !s.requireCatalogAuth(w, r) {
+		if !s.requireCatalogAssetAuth(w, r) {
 			return
 		}
 		s.serveArtistArtworkByID(w, r, artistID, parts[1])
 		return
 	}
 	if len(parts) == 3 && parts[0] == "by-entity" && (parts[2] == "photo" || parts[2] == "background") && isRouteUUID(parts[1]) {
-		if !s.requireCatalogAuth(w, r) {
+		if !s.requireCatalogAssetAuth(w, r) {
 			return
 		}
 		s.serveArtistArtworkByEntityUID(w, r, parts[1], parts[2])
@@ -326,7 +326,7 @@ func (s *Server) trackRoute(w http.ResponseWriter, r *http.Request) {
 
 func (s *Server) trackByIDRoute(w http.ResponseWriter, r *http.Request, trackID int64, action string) {
 	if action == "stream" {
-		if !s.requireCatalogAuth(w, r) {
+		if !s.requireCatalogAssetAuth(w, r) {
 			return
 		}
 		s.serveLocalMediaByID(w, r, trackID)
@@ -364,7 +364,7 @@ func (s *Server) trackByIDRoute(w http.ResponseWriter, r *http.Request, trackID 
 
 func (s *Server) trackByEntityRoute(w http.ResponseWriter, r *http.Request, entityUID string, action string) {
 	if action == "stream" {
-		if !s.requireCatalogAuth(w, r) {
+		if !s.requireCatalogAssetAuth(w, r) {
 			return
 		}
 		s.serveLocalMediaByEntityUID(w, r, entityUID)
@@ -480,12 +480,25 @@ func (s *Server) requireCatalogAuth(w http.ResponseWriter, r *http.Request) bool
 	return ok
 }
 
+func (s *Server) requireCatalogAssetAuth(w http.ResponseWriter, r *http.Request) bool {
+	_, ok := s.requireCatalogUserWithQueryToken(w, r, true)
+	return ok
+}
+
 func (s *Server) requireCatalogUser(w http.ResponseWriter, r *http.Request) (*auth.User, bool) {
+	return s.requireCatalogUserWithQueryToken(w, r, false)
+}
+
+func (s *Server) requireCatalogUserWithQueryToken(
+	w http.ResponseWriter,
+	r *http.Request,
+	allowQueryToken bool,
+) (*auth.User, bool) {
 	if s.catalog == nil || s.auth == nil {
 		s.catalogUnavailable(w, r, "Readplane catalog unavailable")
 		return nil, false
 	}
-	user, err := s.auth.Authenticate(r, false)
+	user, err := s.auth.Authenticate(r, allowQueryToken)
 	if err != nil {
 		if errors.Is(err, auth.ErrUnauthorized) {
 			httpx.MarkReadplane(w, "miss")

--- a/app/readplane/internal/routes/local_media_test.go
+++ b/app/readplane/internal/routes/local_media_test.go
@@ -49,6 +49,39 @@ func TestServeLocalMediaNativeRange(t *testing.T) {
 	assert.Equal(t, "hit", rec.Header().Get("X-Crate-Readplane"))
 }
 
+func TestTrackStreamAcceptsNativeQueryToken(t *testing.T) {
+	root := t.TempDir()
+	require.NoError(
+		t,
+		os.WriteFile(filepath.Join(root, "track.mp3"), []byte("stream"), 0o644),
+	)
+	server := &Server{
+		cfg: config.Config{
+			Version:           "test",
+			LocalMediaEnabled: true,
+			MusicRoot:         root,
+		},
+		auth:    queryTokenAuthenticator{},
+		catalog: catalog.NewStore(nil, 0),
+		localMedia: stubLocalMediaCatalog{descriptor: catalog.LocalMediaDescriptor{
+			StoredPath: "track.mp3", Root: "music", RequestedPolicy: "original",
+			EffectivePolicy: "original", DeliveryFormat: "mp3",
+		}},
+		logger: slog.New(slog.NewTextHandler(io.Discard, nil)),
+	}
+	request := httptest.NewRequest(
+		http.MethodGet,
+		"/api/tracks/1/stream?token=native-token",
+		nil,
+	)
+	response := httptest.NewRecorder()
+
+	server.Handler().ServeHTTP(response, request)
+
+	assert.Equal(t, http.StatusOK, response.Code)
+	assert.Equal(t, "stream", response.Body.String())
+}
+
 func TestServeLocalMediaReadsTranscodedVariantsFromCacheRoot(t *testing.T) {
 	cacheRoot := t.TempDir()
 	musicRoot := t.TempDir()

--- a/app/readplane/internal/routes/server.go
+++ b/app/readplane/internal/routes/server.go
@@ -32,7 +32,7 @@ type Server struct {
 	cfg             config.Config
 	pool            *pgxpool.Pool
 	redis           *redis.Client
-	auth            *auth.Authenticator
+	auth            routeAuthenticator
 	catalog         *catalog.Store
 	localMedia      localMediaCatalog
 	artworkCatalog  artworkCatalog
@@ -42,6 +42,13 @@ type Server struct {
 	fallback        *httpx.FallbackProxy
 	federationProxy *readplanefederation.Proxy
 	logger          *slog.Logger
+}
+
+type routeAuthenticator interface {
+	Authenticate(*http.Request, bool) (*auth.User, error)
+	AuthenticateProfile(*http.Request, bool) (*auth.User, error)
+	InvalidateScope(string)
+	Stats() auth.IdentityCacheStats
 }
 
 type localMediaCatalog interface {
@@ -178,7 +185,7 @@ func (s *Server) federatedStream(w http.ResponseWriter, r *http.Request) {
 		httpx.WriteError(w, http.StatusServiceUnavailable, "Federation stream proxy unavailable")
 		return
 	}
-	user, err := s.auth.Authenticate(r, false)
+	user, err := s.auth.Authenticate(r, true)
 	if err != nil {
 		s.fallbackOrAuthError(w, r, err)
 		return

--- a/app/tests/test_global_catalog_reconciliation.py
+++ b/app/tests/test_global_catalog_reconciliation.py
@@ -306,6 +306,266 @@ def test_full_match_recompute_rebinds_recording_mbid_without_unique_violation(
     assert recording_mbid == "recording-mbid"
 
 
+def test_full_match_recompute_keeps_release_mbid_after_anchor_is_pruned(
+    pg_db,
+):
+    from crate.db.tx import read_scope, transaction_scope
+    from crate.federation.global_reconciliation import (
+        reconcile_local_catalog,
+        reconcile_local_catalog_batch,
+    )
+
+    pg_db.upsert_artist(
+        {
+            "name": "Linea Aspera",
+            "entity_uid": str(uuid.uuid4()),
+        }
+    )
+    original_album_id = pg_db.upsert_album(
+        {
+            "artist": "Linea Aspera",
+            "name": "Preservation Bias",
+            "path": "/music/Linea Aspera/Preservation Bias",
+            "entity_uid": str(uuid.uuid4()),
+            "musicbrainz_albumid": "release-mbid",
+            "year": "2019",
+            "track_count": 1,
+        }
+    )
+    reconcile_local_catalog()
+
+    replacement_album_id = pg_db.upsert_album(
+        {
+            "artist": "Linea Aspera",
+            "name": "Preservation Bias",
+            "path": "/music/Linea Aspera/2019/Preservation Bias",
+            "entity_uid": str(uuid.uuid4()),
+            "musicbrainz_albumid": "release-mbid",
+            "year": "2019",
+            "track_count": 1,
+        }
+    )
+    reconcile_local_catalog()
+
+    with read_scope() as session:
+        expected_uid = session.execute(
+            text(
+                """
+                SELECT global_entity_uid::text
+                FROM global_catalog_sources
+                WHERE entity_type = 'album'
+                  AND local_id = :album_id
+                """
+            ),
+            {"album_id": replacement_album_id},
+        ).scalar_one()
+
+    with transaction_scope() as session:
+        session.execute(
+            text(
+                """
+                UPDATE global_catalog_sources
+                SET source_deleted_at = NOW(),
+                    source_stale = true
+                WHERE entity_type = 'album'
+                  AND local_id = :album_id
+                """
+            ),
+            {"album_id": original_album_id},
+        )
+        session.execute(
+            text("DELETE FROM library_albums WHERE id = :album_id"),
+            {"album_id": original_album_id},
+        )
+
+    cursor = None
+    while True:
+        batch = reconcile_local_catalog_batch(
+            batch_size=1,
+            cursor=cursor,
+            recompute_matches=True,
+        )
+        if batch["completed"]:
+            break
+        cursor = batch["next_cursor"]
+
+    with read_scope() as session:
+        source_uids = (
+            session.execute(
+                text(
+                    """
+                    SELECT global_entity_uid::text
+                    FROM global_catalog_sources
+                    WHERE entity_type = 'album'
+                      AND local_id = ANY(:album_ids)
+                    ORDER BY local_id
+                    """
+                ),
+                {"album_ids": [original_album_id, replacement_album_id]},
+            )
+            .scalars()
+            .all()
+        )
+        canonical_count = session.execute(
+            text(
+                """
+                SELECT COUNT(*)
+                FROM global_catalog_albums
+                WHERE musicbrainz_release_mbid = 'release-mbid'
+                """
+            )
+        ).scalar_one()
+
+    assert source_uids == [expected_uid]
+    assert canonical_count == 1
+
+
+def test_full_match_recompute_keeps_recording_mbid_after_anchor_is_pruned(
+    pg_db,
+):
+    from crate.db.tx import read_scope, transaction_scope
+    from crate.federation.global_reconciliation import (
+        reconcile_local_catalog,
+        reconcile_local_catalog_batch,
+    )
+
+    pg_db.upsert_artist(
+        {
+            "name": "Pantera",
+            "entity_uid": str(uuid.uuid4()),
+        }
+    )
+    album_id = pg_db.upsert_album(
+        {
+            "artist": "Pantera",
+            "name": "Cowboys From Hell",
+            "path": "/music/Pantera/Cowboys From Hell",
+            "entity_uid": str(uuid.uuid4()),
+            "year": "1990",
+            "track_count": 2,
+        }
+    )
+    original_track_path = "/music/Pantera/Cowboys From Hell/05 - Cemetery Gates.flac"
+    pg_db.upsert_track(
+        {
+            "album_id": album_id,
+            "artist": "Pantera",
+            "album": "Cowboys From Hell",
+            "filename": "05 - Cemetery Gates.flac",
+            "title": "Cemetery Gates",
+            "path": original_track_path,
+            "entity_uid": str(uuid.uuid4()),
+            "musicbrainz_trackid": "recording-mbid",
+            "duration": 423.0,
+            "disc_number": 1,
+            "track_number": 5,
+        }
+    )
+    with read_scope() as session:
+        original_track_id = session.execute(
+            text("SELECT id FROM library_tracks WHERE path = :path"),
+            {"path": original_track_path},
+        ).scalar_one()
+    reconcile_local_catalog()
+
+    replacement_track_path = (
+        "/music/Pantera/Cowboys From Hell/05 - Cemetery Gates (Album Version).flac"
+    )
+    pg_db.upsert_track(
+        {
+            "album_id": album_id,
+            "artist": "Pantera",
+            "album": "Cowboys From Hell",
+            "filename": "05 - Cemetery Gates (Album Version).flac",
+            "title": "Cemetery Gates",
+            "path": replacement_track_path,
+            "entity_uid": str(uuid.uuid4()),
+            "musicbrainz_trackid": "recording-mbid",
+            "duration": 423.0,
+            "disc_number": 1,
+            "track_number": 5,
+        }
+    )
+    with read_scope() as session:
+        replacement_track_id = session.execute(
+            text("SELECT id FROM library_tracks WHERE path = :path"),
+            {"path": replacement_track_path},
+        ).scalar_one()
+    reconcile_local_catalog()
+
+    with read_scope() as session:
+        expected_uid = session.execute(
+            text(
+                """
+                SELECT global_entity_uid::text
+                FROM global_catalog_sources
+                WHERE entity_type = 'track'
+                  AND local_id = :track_id
+                """
+            ),
+            {"track_id": replacement_track_id},
+        ).scalar_one()
+
+    with transaction_scope() as session:
+        session.execute(
+            text(
+                """
+                UPDATE global_catalog_sources
+                SET source_deleted_at = NOW(),
+                    source_stale = true
+                WHERE entity_type = 'track'
+                  AND local_id = :track_id
+                """
+            ),
+            {"track_id": original_track_id},
+        )
+        session.execute(
+            text("DELETE FROM library_tracks WHERE id = :track_id"),
+            {"track_id": original_track_id},
+        )
+
+    cursor = None
+    while True:
+        batch = reconcile_local_catalog_batch(
+            batch_size=1,
+            cursor=cursor,
+            recompute_matches=True,
+        )
+        if batch["completed"]:
+            break
+        cursor = batch["next_cursor"]
+
+    with read_scope() as session:
+        source_uids = (
+            session.execute(
+                text(
+                    """
+                    SELECT global_entity_uid::text
+                    FROM global_catalog_sources
+                    WHERE entity_type = 'track'
+                      AND local_id = ANY(:track_ids)
+                    ORDER BY local_id
+                    """
+                ),
+                {"track_ids": [original_track_id, replacement_track_id]},
+            )
+            .scalars()
+            .all()
+        )
+        canonical_count = session.execute(
+            text(
+                """
+                SELECT COUNT(*)
+                FROM global_catalog_tracks
+                WHERE musicbrainz_recording_mbid = 'recording-mbid'
+                """
+            )
+        ).scalar_one()
+
+    assert source_uids == [expected_uid]
+    assert canonical_count == 1
+
+
 def test_full_match_recompute_splits_sources_that_no_longer_match(pg_db):
     from crate.db.tx import read_scope, transaction_scope
     from crate.federation.global_reconciliation import (


### PR DESCRIPTION
## Summary

- restores query-token authentication for readplane-served artwork and audio streams used by native media elements
- scopes Listen's persistent API cache by active Crate server and authenticated user, deliberately cold-starting legacy unscoped entries
- prevents short-lived native access tokens from refreshing every five seconds
- makes full global-catalog recomputation retain an existing canonical target when a surviving source still carries the same strong MusicBrainz/ISRC/UPC identity

## Root cause

`v2.2.1-beta` appeared healthy because the Traefik `Method(GET, HEAD)` rule was not actually routing interactive GET/HEAD traffic through the Go readplane. Commit `da179fba` fixed that proxy rule, exposing a contract mismatch: FastAPI accepted `?token=...` for native `<img>`/media requests while readplane rejected query tokens on the same asset and stream routes.

The API and database are populated (production user 1 has 162 global artist follows and a non-empty Home snapshot), but Listen's 180-day persistent cache was keyed only by URL. A previously persisted empty response could therefore leak across native users/servers. The fixed five-minute refresh margin also caused access tokens with a shorter lifetime to refresh every five seconds, repeatedly reconnecting Home SSE and aggravating recovery from stale cached state.

The failed full reconciliation had a separate stale-anchor edge case. During match recomputation, the current target was excluded to permit legitimate splits. If its original deterministic anchor had already been pruned, a surviving source with the same release/recording MBID could try to create a new canonical UID and violate the unique identity index. The resolver now keeps that target only as a fallback when no better valid rebind exists, preserving the existing split/rebind behavior.

## User impact

- Android Home and Collection no longer reuse empty state from another identity/server.
- Album and artist artwork loads through readplane in the native app.
- Local and federated audio streams accept the native query-token transport again.
- JSON catalog endpoints continue to reject query tokens; bearer/cookie auth remains required.
- Full reconciliation no longer fails on pruned album/track anchors with strong external identities.

## Validation

- `16 passed` — `test_global_catalog_reconciliation.py`, including release and recording MBID stale-anchor regressions
- `1534 passed, 4 skipped` — complete Listen Vitest suite
- Listen TypeScript typecheck, ESLint and Prettier
- Capacitor production-mode build plus Android/iOS `cap sync`
- complete Go readplane suite and `go vet ./...`
- full Pyright and focused Ruff checks
- production read-only verification: user 1 has 162 follows and 13 populated Home snapshots
