### PR TITLE
fix: prevent orphan albums and identity collisions

### DIFF
--- a/app/crate/db/jobs/global_catalog_reconciliation.py
+++ b/app/crate/db/jobs/global_catalog_reconciliation.py
@@ -1290,7 +1290,16 @@ def _resolve_artist_target(
     if forced_target:
         return forced_target, MatchScore(1.0, "manual_force_merge", auto_merge=True)
 
+    payload = source["source_payload"]
     existing_target = _existing_source_target(session, source)
+    identity_target = _canonical_identity_target(session, "artist", payload)
+    if identity_target and identity_target[0] != existing_target:
+        return identity_target[0], MatchScore(
+            1.0,
+            identity_target[1],
+            auto_merge=True,
+        )
+
     existing_target_allowed = bool(
         existing_target
         and not merge_blocked_for_source(session, source, existing_target)
@@ -1307,7 +1316,6 @@ def _resolve_artist_target(
         if revalidated is not None:
             return revalidated
 
-    payload = source["source_payload"]
     rows = _candidate_artists(session, payload)
     existing_identity_match = (
         recompute_matches
@@ -1355,9 +1363,8 @@ def _resolve_album_target(
     if forced_target:
         return forced_target, MatchScore(1.0, "manual_force_merge", auto_merge=True)
 
-    provenance_target = str(
-        source["source_payload"].get("imported_global_album_uid") or ""
-    )
+    payload = source["source_payload"]
+    provenance_target = str(payload.get("imported_global_album_uid") or "")
     if provenance_target and not merge_blocked_for_source(
         session,
         source,
@@ -1370,6 +1377,14 @@ def _resolve_album_target(
         )
 
     existing_target = _existing_source_target(session, source)
+    identity_target = _canonical_identity_target(session, "album", payload)
+    if identity_target and identity_target[0] != existing_target:
+        return identity_target[0], MatchScore(
+            1.0,
+            identity_target[1],
+            auto_merge=True,
+        )
+
     existing_target_allowed = bool(
         existing_target
         and not merge_blocked_for_source(session, source, existing_target)
@@ -1386,7 +1401,6 @@ def _resolve_album_target(
         if revalidated is not None:
             return revalidated
 
-    payload = source["source_payload"]
     rows = _candidate_albums(session, payload, artist_uid)
     existing_identity_match = (
         recompute_matches
@@ -1434,7 +1448,16 @@ def _resolve_track_target(
     if forced_target:
         return forced_target, MatchScore(1.0, "manual_force_merge", auto_merge=True)
 
+    payload = source["source_payload"]
     existing_target = _existing_source_target(session, source)
+    identity_target = _canonical_identity_target(session, "track", payload)
+    if identity_target and identity_target[0] != existing_target:
+        return identity_target[0], MatchScore(
+            1.0,
+            identity_target[1],
+            auto_merge=True,
+        )
+
     existing_target_allowed = bool(
         existing_target
         and not merge_blocked_for_source(session, source, existing_target)
@@ -1451,7 +1474,6 @@ def _resolve_track_target(
         if revalidated is not None:
             return revalidated
 
-    payload = source["source_payload"]
     rows = _candidate_tracks(session, payload, artist_uid)
     existing_identity_match = (
         recompute_matches
@@ -1591,6 +1613,62 @@ def _has_strong_identity_match(
         payload.get(identifier) and payload.get(identifier) == candidate.get(identifier)
         for identifier in identifiers
     )
+
+
+def _canonical_identity_target(
+    session,
+    entity_type: str,
+    payload: dict[str, Any],
+) -> tuple[str, str] | None:
+    if entity_type == "artist":
+        identifier = payload.get("musicbrainz_artist_mbid")
+        if not identifier:
+            return None
+        target = session.execute(
+            text(
+                """
+                SELECT global_artist_uid::text
+                FROM global_catalog_artists
+                WHERE musicbrainz_artist_mbid = :identifier
+                """
+            ),
+            {"identifier": identifier},
+        ).scalar_one_or_none()
+        method = "musicbrainz_artist_mbid"
+    elif entity_type == "album":
+        identifier = payload.get("musicbrainz_release_mbid")
+        if not identifier:
+            return None
+        target = session.execute(
+            text(
+                """
+                SELECT global_album_uid::text
+                FROM global_catalog_albums
+                WHERE musicbrainz_release_mbid = :identifier
+                """
+            ),
+            {"identifier": identifier},
+        ).scalar_one_or_none()
+        method = "musicbrainz_release_mbid"
+    else:
+        identifier = payload.get("musicbrainz_recording_mbid")
+        if not identifier:
+            return None
+        target = session.execute(
+            text(
+                """
+                SELECT global_track_uid::text
+                FROM global_catalog_tracks
+                WHERE musicbrainz_recording_mbid = :identifier
+                """
+            ),
+            {"identifier": identifier},
+        ).scalar_one_or_none()
+        method = "musicbrainz_recording_mbid"
+
+    if target is None:
+        return None
+    return str(target), method
 
 
 def _existing_source_target(session, source: dict[str, Any]) -> str | None:

--- a/app/crate/library_sync.py
+++ b/app/crate/library_sync.py
@@ -468,6 +468,17 @@ class LibrarySync:
                 audio_files, tree_mtime = self._scan_album_tree(album_dir)
                 actual_track_count = len(audio_files)
 
+                if actual_track_count == 0:
+                    result = self._sync_album_unlocked(
+                        album_dir,
+                        artist_name,
+                        audio_files=audio_files,
+                        tree_mtime=tree_mtime,
+                    )
+                    total_tracks += result["track_count"]
+                    synced_paths.add(album_path)
+                    continue
+
                 dir_mtime = existing_album.get("dir_mtime") if existing_album else None
                 if (
                     existing_album
@@ -563,6 +574,34 @@ class LibrarySync:
 
         # Get existing tracks for this album to reuse data for unchanged files
         existing_album_id = get_album_id_by_path(str(album_dir))
+
+        if not audio_files:
+            indexed_track_count = (
+                get_album_track_count(existing_album_id) if existing_album_id else 0
+            )
+            if existing_album_id and indexed_track_count == 0:
+                log.info(
+                    "Removing empty album index for sidecar-only directory %s",
+                    album_dir,
+                )
+                delete_album(str(album_dir))
+                existing_album_id = None
+            elif existing_album_id:
+                log.warning(
+                    "Preserving album %s after an empty filesystem scan because "
+                    "%d indexed tracks remain",
+                    album_dir,
+                    indexed_track_count,
+                )
+
+            return {
+                "album_id": existing_album_id,
+                "track_count": indexed_track_count,
+                "total_size": 0,
+                "formats": [],
+                "native_scan_payload_shadow": None,
+                "native_scan_payload_used": False,
+            }
 
         existing_tracks_by_path: dict[str, dict] = {}
         if existing_album_id:

--- a/app/tests/test_global_catalog_reconciliation.py
+++ b/app/tests/test_global_catalog_reconciliation.py
@@ -306,6 +306,119 @@ def test_full_match_recompute_rebinds_recording_mbid_without_unique_violation(
     assert recording_mbid == "recording-mbid"
 
 
+def test_full_match_recompute_rebinds_new_release_mbid_before_self_match(
+    pg_db,
+):
+    from crate.db.tx import read_scope, transaction_scope
+    from crate.federation.global_reconciliation import (
+        reconcile_local_catalog,
+        reconcile_local_catalog_batch,
+    )
+
+    pg_db.upsert_artist(
+        {
+            "name": "Between The Buried And Me",
+            "entity_uid": str(uuid.uuid4()),
+        }
+    )
+    original_album_id = pg_db.upsert_album(
+        {
+            "artist": "Between The Buried And Me",
+            "name": "The Blue Nowhere",
+            "path": "/music/Between The Buried And Me/The Blue Nowhere",
+            "entity_uid": str(uuid.uuid4()),
+            "musicbrainz_albumid": "shared-release-mbid",
+            "year": "2025",
+            "track_count": 10,
+        }
+    )
+    deluxe_album_id = pg_db.upsert_album(
+        {
+            "artist": "Between The Buried And Me",
+            "name": "The Blue Nowhere (Deluxe Edition)",
+            "path": (
+                "/music/Between The Buried And Me/The Blue Nowhere (Deluxe Edition)"
+            ),
+            "entity_uid": str(uuid.uuid4()),
+            "year": "2025",
+            "track_count": 14,
+        }
+    )
+    reconcile_local_catalog()
+
+    with read_scope() as session:
+        initial_targets = (
+            session.execute(
+                text(
+                    """
+                    SELECT global_entity_uid::text
+                    FROM global_catalog_sources
+                    WHERE entity_type = 'album'
+                      AND local_id = ANY(:album_ids)
+                    ORDER BY local_id
+                    """
+                ),
+                {"album_ids": [original_album_id, deluxe_album_id]},
+            )
+            .scalars()
+            .all()
+        )
+    assert len(set(initial_targets)) == 2
+
+    with transaction_scope() as session:
+        session.execute(
+            text(
+                """
+                UPDATE library_albums
+                SET musicbrainz_albumid = 'shared-release-mbid'
+                WHERE id = :album_id
+                """
+            ),
+            {"album_id": deluxe_album_id},
+        )
+
+    cursor = None
+    while True:
+        batch = reconcile_local_catalog_batch(
+            batch_size=1,
+            cursor=cursor,
+            recompute_matches=True,
+        )
+        if batch["completed"]:
+            break
+        cursor = batch["next_cursor"]
+
+    with read_scope() as session:
+        reconciled_targets = (
+            session.execute(
+                text(
+                    """
+                    SELECT global_entity_uid::text
+                    FROM global_catalog_sources
+                    WHERE entity_type = 'album'
+                      AND local_id = ANY(:album_ids)
+                    ORDER BY local_id
+                    """
+                ),
+                {"album_ids": [original_album_id, deluxe_album_id]},
+            )
+            .scalars()
+            .all()
+        )
+        canonical_count = session.execute(
+            text(
+                """
+                SELECT COUNT(*)
+                FROM global_catalog_albums
+                WHERE musicbrainz_release_mbid = 'shared-release-mbid'
+                """
+            )
+        ).scalar_one()
+
+    assert len(set(reconciled_targets)) == 1
+    assert canonical_count == 1
+
+
 def test_full_match_recompute_keeps_release_mbid_after_anchor_is_pruned(
     pg_db,
 ):

--- a/app/tests/test_library_sync.py
+++ b/app/tests/test_library_sync.py
@@ -298,6 +298,37 @@ class TestSyncAlbum:
                 assert queued_asset.entity_key == ALBUM_ENTITY_UID
                 assert mock_queue.call_args.kwargs == {"reason": "library-sync"}
 
+    def test_sync_album_ignores_sidecar_only_directory(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            lib = Path(tmpdir)
+            album_dir = lib / "Artist" / "album-uid"
+            album_dir.mkdir(parents=True)
+            (album_dir / "cover.jpg").write_bytes(b"cover")
+            (album_dir / "album.json").write_text("{}")
+
+            config = {
+                "library_path": str(lib),
+                "audio_extensions": [".flac"],
+            }
+
+            from crate.library_sync import LibrarySync
+
+            with (
+                patch("crate.library_sync.get_album_id_by_path", return_value=None),
+                patch("crate.library_sync.upsert_scanned_album") as mock_upsert,
+                patch.object(
+                    LibrarySync, "_refresh_artist_summary_unlocked"
+                ) as mock_refresh,
+                patch("crate.library_sync.delete_album") as mock_delete,
+            ):
+                result = LibrarySync(config).sync_album(album_dir, "Artist")
+
+            assert result["album_id"] is None
+            assert result["track_count"] == 0
+            mock_upsert.assert_not_called()
+            mock_delete.assert_not_called()
+            mock_refresh.assert_called_once()
+
     def test_sync_album_refreshes_artist_summary_after_album_upsert(self):
         with tempfile.TemporaryDirectory() as tmpdir:
             lib = Path(tmpdir)
@@ -829,6 +860,133 @@ class TestSyncAlbum:
 
                 assert count == 0
                 mock_delete_album.assert_not_called()
+
+    def test_sync_artist_dirs_ignores_new_sidecar_only_album(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            lib = Path(tmpdir)
+            artist_dir = lib / "artist-uid"
+            album_dir = artist_dir / "album-uid"
+            album_dir.mkdir(parents=True)
+            (album_dir / "cover.jpg").write_bytes(b"art")
+            (album_dir / "album.json").write_text("{}")
+
+            config = {
+                "library_path": str(lib),
+                "audio_extensions": [".flac"],
+            }
+
+            from crate.library_sync import LibrarySync
+
+            with (
+                patch(
+                    "crate.library_sync.get_library_artist",
+                    return_value={"name": "Between The Buried And Me"},
+                ),
+                patch("crate.library_sync.get_library_albums", return_value=[]),
+                patch("crate.library_sync.get_album_id_by_path", return_value=None),
+                patch("crate.library_sync.upsert_scanned_album") as mock_upsert,
+                patch.object(LibrarySync, "_refresh_artist_summary_unlocked"),
+                patch("crate.library_sync.delete_album") as mock_delete_album,
+            ):
+                count = LibrarySync(config).sync_artist_dirs(
+                    "Between The Buried And Me",
+                    [artist_dir],
+                )
+
+            assert count == 0
+            mock_upsert.assert_not_called()
+            mock_delete_album.assert_not_called()
+
+    def test_sync_artist_dirs_deletes_indexed_sidecar_only_album_without_tracks(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            lib = Path(tmpdir)
+            artist_dir = lib / "artist-uid"
+            album_dir = artist_dir / "album-uid"
+            album_dir.mkdir(parents=True)
+            (album_dir / "cover.jpg").write_bytes(b"art")
+            (album_dir / "album.json").write_text("{}")
+
+            config = {
+                "library_path": str(lib),
+                "audio_extensions": [".flac"],
+            }
+            existing_album = {
+                "id": 143,
+                "path": str(album_dir),
+                "track_count": 0,
+                "dir_mtime": 0,
+            }
+
+            from crate.library_sync import LibrarySync
+
+            with (
+                patch(
+                    "crate.library_sync.get_library_artist",
+                    return_value={"name": "Between The Buried And Me"},
+                ),
+                patch(
+                    "crate.library_sync.get_library_albums",
+                    return_value=[existing_album],
+                ),
+                patch("crate.library_sync.get_album_id_by_path", return_value=143),
+                patch("crate.library_sync.get_album_track_count", return_value=0),
+                patch("crate.library_sync.upsert_scanned_album") as mock_upsert,
+                patch.object(LibrarySync, "_refresh_artist_summary_unlocked"),
+                patch("crate.library_sync.delete_album") as mock_delete_album,
+            ):
+                count = LibrarySync(config).sync_artist_dirs(
+                    "Between The Buried And Me",
+                    [artist_dir],
+                )
+
+            assert count == 0
+            mock_upsert.assert_not_called()
+            mock_delete_album.assert_called_once_with(str(album_dir))
+
+    def test_sync_artist_dirs_preserves_indexed_album_on_transient_empty_scan(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            lib = Path(tmpdir)
+            artist_dir = lib / "artist-uid"
+            album_dir = artist_dir / "album-uid"
+            album_dir.mkdir(parents=True)
+            (album_dir / "cover.jpg").write_bytes(b"art")
+
+            config = {
+                "library_path": str(lib),
+                "audio_extensions": [".flac"],
+            }
+            existing_album = {
+                "id": 143,
+                "path": str(album_dir),
+                "track_count": 11,
+                "dir_mtime": 0,
+            }
+
+            from crate.library_sync import LibrarySync
+
+            with (
+                patch(
+                    "crate.library_sync.get_library_artist",
+                    return_value={"name": "Between The Buried And Me"},
+                ),
+                patch(
+                    "crate.library_sync.get_library_albums",
+                    return_value=[existing_album],
+                ),
+                patch("crate.library_sync.get_album_id_by_path", return_value=143),
+                patch("crate.library_sync.get_album_track_count", return_value=11),
+                patch("crate.library_sync.upsert_scanned_album") as mock_upsert,
+                patch.object(LibrarySync, "_refresh_artist_summary_unlocked"),
+                patch("crate.library_sync.delete_album") as mock_delete_album,
+            ):
+                count = LibrarySync(config).sync_artist_dirs(
+                    "Between The Buried And Me",
+                    [artist_dir],
+                )
+
+            assert count == 11
+            mock_upsert.assert_not_called()
+            mock_delete_album.assert_not_called()
 
     def test_sync_artist_dirs_rolls_up_album_formats(self):
         with tempfile.TemporaryDirectory() as tmpdir:


### PR DESCRIPTION
## Summary

- resolve canonical MusicBrainz identities before revalidating an existing reconciliation target
- prevent full reconciliation from violating unique MBID constraints when metadata converges after an earlier match
- refuse to index sidecar-only album directories with no audio files
- remove an existing zero-track album index when the same orphan directory is scanned
- preserve indexed albums when a transient filesystem scan returns no audio but database tracks still exist

## Production failures reproduced

- release MBID convergence for The Blue Nowhere / The Blue Nowhere (Deluxe Edition)
- UUID-named album directories containing only cover.jpg and album.json
- transient empty scans that must not erase valid album data

## Tests

- `app/tests/test_global_catalog_reconciliation.py`: 17 passed
- `app/tests/test_library_sync.py`: 23 passed
- Ruff check and format: passed
- Pyright on changed files: 0 errors

## Deployment validation

After merge and image publication:

1. create a fresh recovery snapshot
2. deploy the exact main SHA
3. remove only albums that still have zero tracks, zero saved-album references, and zero contributions
4. run a full global reconciliation
5. verify both previously failing release MBIDs resolve to one canonical album
6. validate Android native artwork, stream authentication, home discovery, and followed artists
7. publish the patch beta tag only after production is healthy and reconciliation completes