### PR TITLE
fix: preserve local track copies across releases

### DIFF
--- a/app/crate/db/repositories/library_track_upserts.py
+++ b/app/crate/db/repositories/library_track_upserts.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from datetime import datetime, timezone
 
-from sqlalchemy import false, func, or_, select, update
+from sqlalchemy import and_, false, func, or_, select, update
 from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.orm import Session
 
@@ -28,34 +28,71 @@ def upsert_track(data: dict, *, session: Session | None = None) -> None:
         requested_entity_uid = coerce_uuid_or_none(data.get("entity_uid"))
         path_match = LibraryTrack.path == data["path"]
         entity_match = (
-            LibraryTrack.entity_uid == requested_entity_uid
+            and_(
+                LibraryTrack.entity_uid == requested_entity_uid,
+                LibraryTrack.album_id == data.get("album_id"),
+                LibraryTrack.disc_number == int(data.get("disc_number") or 1),
+                LibraryTrack.track_number.is_not_distinct_from(
+                    data.get("track_number")
+                ),
+            )
             if requested_entity_uid is not None
             else false()
         )
         requested_track_mbid = (data.get("musicbrainz_trackid") or "").strip()
+        existing_columns = (
+            LibraryTrack.id,
+            LibraryTrack.slug,
+            LibraryTrack.storage_id,
+            LibraryTrack.entity_uid,
+            LibraryTrack.musicbrainz_albumid,
+            LibraryTrack.musicbrainz_trackid,
+            LibraryTrack.audio_fingerprint,
+            LibraryTrack.audio_fingerprint_source,
+            LibraryTrack.audio_fingerprint_computed_at,
+        )
         existing = s.execute(
-            select(
-                LibraryTrack.id,
-                LibraryTrack.slug,
-                LibraryTrack.storage_id,
-                LibraryTrack.entity_uid,
-                LibraryTrack.musicbrainz_albumid,
-                LibraryTrack.musicbrainz_trackid,
-                LibraryTrack.audio_fingerprint,
-                LibraryTrack.audio_fingerprint_source,
-                LibraryTrack.audio_fingerprint_computed_at,
-            )
+            select(*existing_columns)
             .where(
                 or_(
                     path_match,
                     entity_match,
-                    LibraryTrack.musicbrainz_trackid == requested_track_mbid
-                    if requested_track_mbid
-                    else false(),
                 )
             )
             .limit(1)
         ).first()
+        album_entity_uid = None
+        album_id = data.get("album_id")
+        if album_id is not None:
+            album_entity_uid = s.execute(
+                select(LibraryAlbum.entity_uid)
+                .where(LibraryAlbum.id == album_id)
+                .limit(1)
+            ).scalar_one_or_none()
+        if requested_entity_uid is not None and existing is None:
+            entity_uid_is_occupied = s.execute(
+                select(LibraryTrack.id)
+                .where(LibraryTrack.entity_uid == requested_entity_uid)
+                .limit(1)
+            ).scalar_one_or_none()
+            if entity_uid_is_occupied is not None:
+                requested_entity_uid = track_entity_uid(
+                    album_uid=album_entity_uid,
+                    artist_name=data["artist"],
+                    album_name=data["album"],
+                    title=data.get("title"),
+                    filename=data.get("filename"),
+                    disc_number=data.get("disc_number"),
+                    track_number=data.get("track_number"),
+                )
+                existing = s.execute(
+                    select(*existing_columns)
+                    .where(
+                        LibraryTrack.entity_uid == requested_entity_uid,
+                        LibraryTrack.album_id == album_id,
+                    )
+                    .limit(1)
+                ).first()
         slug = (
             existing[1]
             if existing and existing[1]
@@ -67,14 +104,6 @@ def upsert_track(data: dict, *, session: Session | None = None) -> None:
                 ),
             )
         )
-        album_entity_uid = None
-        album_id = data.get("album_id")
-        if album_id is not None:
-            album_entity_uid = s.execute(
-                select(LibraryAlbum.entity_uid)
-                .where(LibraryAlbum.id == album_id)
-                .limit(1)
-            ).scalar_one_or_none()
         entity_uid = (
             existing[3]
             if existing and existing[3]

--- a/app/tests/test_db.py
+++ b/app/tests/test_db.py
@@ -2953,6 +2953,182 @@ class TestLibraryCRUD:
             )
         assert count == 1
 
+    def test_upsert_track_keeps_release_copies_with_same_recording_mbid(self, pg_db):
+        from crate.db.tx import transaction_scope
+
+        pg_db.upsert_artist({"name": "Joy Division"})
+        original_album_id = pg_db.upsert_album(
+            {
+                "artist": "Joy Division",
+                "name": "Closer",
+                "path": "/music/joy-division/closer",
+            }
+        )
+        collector_album_id = pg_db.upsert_album(
+            {
+                "artist": "Joy Division",
+                "name": "Closer (Collector's Edition)",
+                "path": "/music/joy-division/closer-collectors-edition",
+            }
+        )
+        recording_mbid = "4e44d50e-0c7b-4cca-816c-f2a78d085a72"
+
+        pg_db.upsert_track(
+            {
+                "album_id": original_album_id,
+                "artist": "Joy Division",
+                "album": "Closer",
+                "entity_uid": "123e4567-e89b-12d3-a456-426614174101",
+                "filename": "01-atmosphere.flac",
+                "title": "Atmosphere",
+                "track_number": 1,
+                "musicbrainz_trackid": recording_mbid,
+                "path": "/music/joy-division/closer/01-atmosphere.flac",
+            }
+        )
+        pg_db.upsert_track(
+            {
+                "album_id": collector_album_id,
+                "artist": "Joy Division",
+                "album": "Closer (Collector's Edition)",
+                "entity_uid": "123e4567-e89b-12d3-a456-426614174101",
+                "filename": "10-atmosphere.flac",
+                "title": "Atmosphere",
+                "track_number": 10,
+                "musicbrainz_trackid": recording_mbid,
+                "path": (
+                    "/music/joy-division/closer-collectors-edition/10-atmosphere.flac"
+                ),
+            }
+        )
+
+        original_tracks = pg_db.get_library_tracks(original_album_id)
+        collector_tracks = pg_db.get_library_tracks(collector_album_id)
+        assert len(original_tracks) == 1
+        assert len(collector_tracks) == 1
+        assert original_tracks[0]["entity_uid"] != collector_tracks[0]["entity_uid"]
+        assert original_tracks[0]["musicbrainz_trackid"] == recording_mbid
+        assert collector_tracks[0]["musicbrainz_trackid"] == recording_mbid
+
+        with transaction_scope() as session:
+            count = session.execute(
+                text(
+                    """
+                    SELECT COUNT(*)
+                    FROM library_tracks
+                    WHERE musicbrainz_trackid = :recording_mbid
+                    """
+                ),
+                {"recording_mbid": recording_mbid},
+            ).scalar_one()
+        assert count == 2
+
+    def test_upsert_track_relocates_release_copy_with_shared_recording_mbid(
+        self, pg_db
+    ):
+        pg_db.upsert_artist({"name": "Joy Division"})
+        original_album_id = pg_db.upsert_album(
+            {
+                "artist": "Joy Division",
+                "name": "Closer",
+                "path": "/music/joy-division/closer",
+            }
+        )
+        collector_album_id = pg_db.upsert_album(
+            {
+                "artist": "Joy Division",
+                "name": "Closer (Collector's Edition)",
+                "path": "/music/joy-division/closer-collectors-edition",
+            }
+        )
+        recording_mbid = "4e44d50e-0c7b-4cca-816c-f2a78d085a72"
+        shared_entity_uid = "123e4567-e89b-12d3-a456-426614174101"
+
+        pg_db.upsert_track(
+            {
+                "album_id": original_album_id,
+                "artist": "Joy Division",
+                "album": "Closer",
+                "entity_uid": shared_entity_uid,
+                "filename": "01-atmosphere.flac",
+                "title": "Atmosphere",
+                "track_number": 1,
+                "musicbrainz_trackid": recording_mbid,
+                "path": "/music/joy-division/closer/01-atmosphere.flac",
+            }
+        )
+        collector_track = {
+            "album_id": collector_album_id,
+            "artist": "Joy Division",
+            "album": "Closer (Collector's Edition)",
+            "entity_uid": shared_entity_uid,
+            "filename": "10-atmosphere.flac",
+            "title": "Atmosphere",
+            "track_number": 10,
+            "musicbrainz_trackid": recording_mbid,
+            "path": "/music/joy-division/closer-collectors-edition/10-atmosphere.flac",
+        }
+        pg_db.upsert_track(collector_track)
+
+        relocated_path = (
+            "/music/joy-division/closer-collectors-edition/disc-2/10-atmosphere.flac"
+        )
+        pg_db.upsert_track({**collector_track, "path": relocated_path})
+
+        collector_tracks = pg_db.get_library_tracks(collector_album_id)
+        assert len(collector_tracks) == 1
+        assert collector_tracks[0]["path"] == relocated_path
+
+    def test_upsert_track_keeps_repeated_recording_within_same_release(self, pg_db):
+        pg_db.upsert_artist({"name": "Joy Division"})
+        album_id = pg_db.upsert_album(
+            {
+                "artist": "Joy Division",
+                "name": "Closer (Collector's Edition)",
+                "path": "/music/joy-division/closer-collectors-edition",
+            }
+        )
+        recording_mbid = "4e44d50e-0c7b-4cca-816c-f2a78d085a72"
+        shared_entity_uid = "123e4567-e89b-12d3-a456-426614174101"
+        base_track = {
+            "album_id": album_id,
+            "artist": "Joy Division",
+            "album": "Closer (Collector's Edition)",
+            "entity_uid": shared_entity_uid,
+            "title": "Atmosphere",
+            "musicbrainz_trackid": recording_mbid,
+        }
+
+        pg_db.upsert_track(
+            {
+                **base_track,
+                "filename": "01-atmosphere.flac",
+                "disc_number": 1,
+                "track_number": 1,
+                "path": (
+                    "/music/joy-division/closer-collectors-edition/"
+                    "disc-1/01-atmosphere.flac"
+                ),
+            }
+        )
+        pg_db.upsert_track(
+            {
+                **base_track,
+                "filename": "10-atmosphere.flac",
+                "disc_number": 2,
+                "track_number": 10,
+                "path": (
+                    "/music/joy-division/closer-collectors-edition/"
+                    "disc-2/10-atmosphere.flac"
+                ),
+            }
+        )
+
+        tracks = pg_db.get_library_tracks(album_id)
+        assert len(tracks) == 2
+        assert {track["disc_number"] for track in tracks} == {1, 2}
+        assert {track["musicbrainz_trackid"] for track in tracks} == {recording_mbid}
+
     def test_get_library_artists_pagination(self, pg_db):
         for i in range(5):
             pg_db.upsert_artist({"name": f"Artist {i:02d}"})

--- a/app/tests/test_global_catalog_reconciliation.py
+++ b/app/tests/test_global_catalog_reconciliation.py
@@ -653,12 +653,13 @@ def test_full_match_recompute_keeps_recording_mbid_after_anchor_is_pruned(
             session.execute(
                 text(
                     """
-                    SELECT global_entity_uid::text
-                    FROM global_catalog_sources
-                    WHERE entity_type = 'track'
-                      AND local_id = ANY(:track_ids)
-                    ORDER BY local_id
-                    """
+                        SELECT global_entity_uid::text
+                        FROM global_catalog_sources
+                        WHERE entity_type = 'track'
+                          AND local_id = ANY(:track_ids)
+                          AND source_deleted_at IS NULL
+                        ORDER BY local_id
+                        """
                 ),
                 {"track_ids": [original_track_id, replacement_track_id]},
             )


### PR DESCRIPTION
## What changed

- stop treating a MusicBrainz recording MBID as a unique local `library_tracks` occurrence
- scope local identity matching to the album, disc and track position
- derive a stable release-scoped entity UID when a recording UID is already occupied
- reuse that derived UID when the same local occurrence moves on disk
- keep the global reconciliation test focused on active catalog sources

## Root cause

`upsert_track()` matched existing rows globally by `musicbrainz_trackid` and by
an MBID-derived `entity_uid`. A recording MBID identifies the canonical
recording, not a playable file occurrence in a particular release. When the
same recording existed in an original album, remaster, collector edition, or
more than once in a multidisc release, a sync moved the existing row between
albums instead of preserving both files. This produced real albums with zero
tracks and could make catalog reconciliation oscillate.

The local library now preserves every release occurrence. The global catalog
remains responsible for canonical deduplication by recording MBID.

## User impact

- release variants no longer steal tracks from each other during scans
- zero-track albums with actual audio can be safely resynced
- file relocations still update the existing row
- repeated recordings inside one multidisc release remain playable as separate occurrences

## Validation

- `app/tests/test_db.py`: 100 passed
- `app/tests/test_library_sync.py` + `app/tests/test_global_catalog_reconciliation.py`: 40 passed
- Ruff format/check: passed
- Pyright on changed files: 0 errors
- pre-commit hooks: passed

After merge, production will be deployed with a fresh recovery snapshot,
affected albums will be resynced, and a full global reconciliation will be
monitored to completion before tagging the release.
