### PR TITLE
fix(playback): preserve mobile queue transitions

### DIFF
--- a/app/crate/api/catalog.py
+++ b/app/crate/api/catalog.py
@@ -6,6 +6,7 @@ import logging
 
 from fastapi import APIRouter, HTTPException, Query, Request, Response
 from fastapi.responses import RedirectResponse
+from starlette.datastructures import URL
 
 from crate.api.auth import _require_auth as _require_authenticated_user
 from crate.api.browse_artist import (
@@ -974,7 +975,23 @@ def catalog_track_stream(
 ):
     _require_auth(request)
     playback = _catalog_track_playback_payload(request, global_track_uid, delivery)
-    return RedirectResponse(url=playback["stream_url"], status_code=307)
+    return RedirectResponse(
+        url=_authenticated_stream_redirect_url(request, playback["stream_url"]),
+        status_code=307,
+    )
+
+
+def _authenticated_stream_redirect_url(request: Request, stream_url: str) -> str:
+    token = request.query_params.get("token")
+    target = URL(stream_url)
+    if (
+        not token
+        or target.scheme
+        or target.netloc
+        or not target.path.startswith("/api/")
+    ):
+        return stream_url
+    return str(target.include_query_params(token=token))
 
 
 @router.get(

--- a/app/listen/src/lib/gapless5/gapless5-buffering.test.ts
+++ b/app/listen/src/lib/gapless5/gapless5-buffering.test.ts
@@ -8,6 +8,7 @@ import {
 
 afterEach(() => {
   vi.useRealTimers();
+  vi.unstubAllGlobals();
 });
 
 function ranges(values: Array<[number, number]>): TimeRanges {
@@ -86,6 +87,74 @@ describe("Gapless5.replaceTrack", () => {
       "four",
       "five-refreshed",
     ]);
+    player.removeAllTracks();
+  });
+});
+
+describe("Gapless5 mobile background auto-advance", () => {
+  it("advances from the native HTMLAudioElement ended event", async () => {
+    vi.useFakeTimers();
+    const instances: FakeAudio[] = [];
+
+    class FakeAudio extends EventTarget {
+      buffered = ranges([]);
+      controls = false;
+      crossOrigin: string | null = null;
+      currentTime = 0;
+      duration = 180;
+      error: MediaError | null = null;
+      loop = false;
+      networkState = 1;
+      paused = true;
+      playbackRate = 1;
+      preload = "auto";
+      preservesPitch = true;
+      readyState = 4;
+      seekable = ranges([[0, 180]]);
+      src = "";
+      srcObject: MediaProvider | null = null;
+      volume = 1;
+
+      constructor() {
+        super();
+        instances.push(this);
+      }
+
+      load() {}
+
+      pause() {
+        this.paused = true;
+      }
+
+      play() {
+        this.paused = false;
+        return Promise.resolve();
+      }
+    }
+
+    vi.stubGlobal("Audio", FakeAudio);
+    const player = new Gapless5({
+      tracks: ["one", "two"],
+      useHTML5Audio: true,
+      useWebAudio: false,
+      loadLimit: 2,
+    });
+    const first = instances.find((audio) => audio.src === "one");
+    expect(first).toBeDefined();
+    first!.dispatchEvent(new Event("loadedmetadata"));
+    first!.dispatchEvent(new Event("loadeddata"));
+    const second = instances.find((audio) => audio.src === "two");
+    expect(second).toBeDefined();
+    second!.dispatchEvent(new Event("loadedmetadata"));
+    second!.dispatchEvent(new Event("loadeddata"));
+
+    player.play();
+    await Promise.resolve();
+    first!.dispatchEvent(new Event("ended"));
+
+    expect(player.getIndex()).toBe(1);
+    first!.dispatchEvent(new Event("ended"));
+    expect(player.getIndex()).toBe(1);
     player.removeAllTracks();
   });
 });

--- a/app/listen/src/lib/gapless5/gapless5.js
+++ b/app/listen/src/lib/gapless5/gapless5.js
@@ -220,7 +220,7 @@ function Gapless5Source(parentPlayer, parentLog, inAudioPath) {
   };
 
   const onEnded = () => {
-    if (state === Gapless5State.Play) {
+    if (state === Gapless5State.Play && player.currentSource() === this) {
       player.onEndedCallback();
     }
   };
@@ -735,6 +735,10 @@ function Gapless5Source(parentPlayer, parentLog, inAudioPath) {
         audioObj.addEventListener("loadeddata", onLoadedHTML5Audio, false);
         audioObj.addEventListener("canplay", onLoadedHTML5Audio, false);
         audioObj.addEventListener("canplaythrough", onLoadedHTML5Audio, false);
+        // Background tabs can throttle the transition timer for long enough
+        // to drop the browser MediaSession. The media element's native ended
+        // event remains the authoritative fallback while audio is active.
+        audioObj.addEventListener("ended", onEnded, false);
         audioObj.addEventListener(
           "loadeddata",
           () =>

--- a/app/tests/test_global_catalog_playback.py
+++ b/app/tests/test_global_catalog_playback.py
@@ -339,6 +339,54 @@ def test_catalog_track_stream_endpoint_redirects_to_resolved_stream(test_app):
     assert response.headers["location"] == "/api/federation/remote/streams/ticket-1"
 
 
+def test_catalog_track_stream_preserves_native_query_token_on_internal_redirect(
+    test_app,
+):
+    global_uid = str(uuid.uuid4())
+
+    with pytest.MonkeyPatch.context() as monkeypatch:
+        monkeypatch.setattr(
+            "crate.api.catalog._catalog_track_playback_payload",
+            lambda request, uid, delivery: {
+                "stream_url": (
+                    "/api/tracks/by-entity/track-local-1/stream?delivery=balanced"
+                )
+            },
+        )
+
+        response = test_app.get(
+            f"/api/catalog/tracks/{global_uid}/stream"
+            "?delivery=balanced&token=native-token",
+            follow_redirects=False,
+        )
+
+    assert response.status_code == 307
+    assert response.headers["location"] == (
+        "/api/tracks/by-entity/track-local-1/stream"
+        "?delivery=balanced&token=native-token"
+    )
+
+
+def test_catalog_track_stream_does_not_forward_token_to_external_redirect(test_app):
+    global_uid = str(uuid.uuid4())
+
+    with pytest.MonkeyPatch.context() as monkeypatch:
+        monkeypatch.setattr(
+            "crate.api.catalog._catalog_track_playback_payload",
+            lambda request, uid, delivery: {
+                "stream_url": "https://media.example/track.flac"
+            },
+        )
+
+        response = test_app.get(
+            f"/api/catalog/tracks/{global_uid}/stream?token=native-token",
+            follow_redirects=False,
+        )
+
+    assert response.status_code == 307
+    assert response.headers["location"] == "https://media.example/track.flac"
+
+
 def test_catalog_track_eq_features_endpoint_delegates_to_local_track(test_app):
     global_uid = str(uuid.uuid4())
 


### PR DESCRIPTION
## Summary

- Preserve native query authentication when a canonical catalog stream redirects to an internal resolved stream.
- Never forward that credential to absolute or external redirect targets.
- Use the active HTML media element ended event as a background-safe web-mobile auto-advance fallback.
- Ignore stale ended events from previous or fading sources.

## Root cause

Two independent failures produced the same symptom:

1. Android native queues used the canonical catalog stream with a query credential. Its 307 redirect removed that credential, the resolved stream returned 401, ExoPlayer stopped, and MediaSession plus Bluetooth metadata disappeared.
2. Chrome Android relied only on a JavaScript completion timer in Gapless-5. Android throttles that timer in background or with the screen locked, so the queue did not advance.

## Security

The compatibility credential is copied only to relative internal API targets. Absolute and external URLs never receive it. Scoped media tickets and Media3 authorization headers remain the durable migration.

## Validation

- Backend catalog playback suite: 15 passed.
- Focused playback suites: 104 passed.
- Listen typecheck and ESLint passed.
- Pyright passed for changed backend modules.
- Listen production and Capacitor builds passed.
- Pre-commit hooks passed.

## Production checks

- Validate two-track auto-advance in Android native and Chrome Android.
- Repeat with screen lock and Bluetooth.
- Confirm second-track metadata remains visible.
- Confirm no canonical-to-resolved stream transition returns 401.