### PR TITLE
fix: stabilize mobile playback and incremental releases

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -13,15 +13,83 @@ env:
   REGISTRY: ghcr.io
   OWNER: ${{ github.repository_owner }}
 
+concurrency:
+  group: build-images-main
+  cancel-in-progress: false
+
 jobs:
+  changes:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: read
+    outputs:
+      api: ${{ steps.filter.outputs.api }}
+      readplane: ${{ steps.filter.outputs.readplane }}
+      worker: ${{ steps.filter.outputs.worker }}
+      analysis_worker: ${{ steps.filter.outputs.analysis_worker }}
+      playback_worker: ${{ steps.filter.outputs.playback_worker }}
+      media_worker: ${{ steps.filter.outputs.media_worker }}
+      ui: ${{ steps.filter.outputs.ui }}
+      listen: ${{ steps.filter.outputs.listen }}
+      site: ${{ steps.filter.outputs.site }}
+      docs: ${{ steps.filter.outputs.docs }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - uses: docker/login-action@v4
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Resolve last promoted release
+        id: baseline
+        env:
+          MANIFEST_IMAGE: ${{ env.REGISTRY }}/${{ env.OWNER }}/crate-release-manifest:stable
+        run: |
+          set -Eeuo pipefail
+          baseline=""
+          if docker pull -q "$MANIFEST_IMAGE" >/dev/null 2>&1; then
+            container="$(docker create "$MANIFEST_IMAGE" true)"
+            trap 'docker rm -f "$container" >/dev/null 2>&1 || true' EXIT
+            docker cp "$container:/release-manifest.json" /tmp/previous-release.json
+            python scripts/release_manifest.py validate \
+              --manifest /tmp/previous-release.json \
+              --registry "$REGISTRY" \
+              --owner "$OWNER"
+            baseline="$(python scripts/release_manifest.py base-sha \
+              --manifest /tmp/previous-release.json)"
+          fi
+          echo "sha=$baseline" >> "$GITHUB_OUTPUT"
+
+      - name: Detect affected images
+        id: filter
+        env:
+          BASE_SHA: ${{ steps.baseline.outputs.sha }}
+          REQUESTED_IMAGES: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.images || '' }}
+        run: |
+          set -Eeuo pipefail
+          args=(detect --head "$GITHUB_SHA")
+          if [[ -n "$BASE_SHA" ]]; then
+            args+=(--base "$BASE_SHA")
+          fi
+          if [[ -n "$REQUESTED_IMAGES" ]]; then
+            args+=(--requested "$REQUESTED_IMAGES")
+          fi
+          python scripts/release_manifest.py "${args[@]}" >> "$GITHUB_OUTPUT"
+
   build-api:
-    if: |
-      github.event_name == 'push' ||
-      (github.event_name == 'workflow_dispatch' && (contains(github.event.inputs.images, 'backend') || contains(github.event.inputs.images, 'api') || github.event.inputs.images == 'all'))
+    needs: changes
+    if: needs.changes.outputs.api == 'true'
     runs-on: ubuntu-latest
     permissions:
       contents: read
       packages: write
+    outputs:
+      digest: ${{ steps.build.outputs.digest }}
     steps:
       - uses: actions/checkout@v6
 
@@ -38,10 +106,10 @@ jobs:
         with:
           images: ${{ env.REGISTRY }}/${{ env.OWNER }}/crate-api
           tags: |
-            type=sha,prefix=,format=short
-            type=raw,value=latest
+            type=sha,prefix=,format=long
 
       - uses: docker/build-push-action@v7
+        id: build
         with:
           context: ./app
           file: ./app/Dockerfile
@@ -50,17 +118,18 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           platforms: linux/amd64
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-from: type=gha,scope=api
+          cache-to: type=gha,scope=api,mode=max
 
   build-worker:
-    if: |
-      github.event_name == 'push' ||
-      (github.event_name == 'workflow_dispatch' && (contains(github.event.inputs.images, 'backend') || contains(github.event.inputs.images, 'worker') || github.event.inputs.images == 'all'))
+    needs: changes
+    if: needs.changes.outputs.worker == 'true'
     runs-on: ubuntu-latest
     permissions:
       contents: read
       packages: write
+    outputs:
+      digest: ${{ steps.build.outputs.digest }}
     steps:
       - uses: actions/checkout@v6
 
@@ -84,12 +153,12 @@ jobs:
         with:
           images: ${{ env.REGISTRY }}/${{ env.OWNER }}/crate-worker
           tags: |
-            type=sha,prefix=,format=short
-            type=raw,value=latest
+            type=sha,prefix=,format=long
 
       # Core worker image: no Torch, Essentia, librosa, or model checkpoints.
       # The heavy audio analysis stack is isolated in crate-analysis-worker.
       - uses: docker/build-push-action@v7
+        id: build
         with:
           context: ./app
           file: ./app/Dockerfile
@@ -98,17 +167,18 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           platforms: linux/amd64
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-from: type=gha,scope=worker
+          cache-to: type=gha,scope=worker,mode=max
 
   build-analysis-worker:
-    if: |
-      github.event_name == 'push' ||
-      (github.event_name == 'workflow_dispatch' && (contains(github.event.inputs.images, 'backend') || contains(github.event.inputs.images, 'worker') || contains(github.event.inputs.images, 'analysis-worker') || github.event.inputs.images == 'all'))
+    needs: changes
+    if: needs.changes.outputs.analysis_worker == 'true'
     runs-on: ubuntu-latest
     permissions:
       contents: read
       packages: write
+    outputs:
+      digest: ${{ steps.build.outputs.digest }}
     steps:
       - uses: actions/checkout@v6
 
@@ -132,10 +202,10 @@ jobs:
         with:
           images: ${{ env.REGISTRY }}/${{ env.OWNER }}/crate-analysis-worker
           tags: |
-            type=sha,prefix=,format=short
-            type=raw,value=latest
+            type=sha,prefix=,format=long
 
       - uses: docker/build-push-action@v7
+        id: build
         with:
           context: ./app
           file: ./app/Dockerfile
@@ -144,17 +214,18 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           platforms: linux/amd64
-          cache-from: type=gha
-          cache-to: type=gha,mode=max,ignore-error=true
+          cache-from: type=gha,scope=analysis-worker
+          cache-to: type=gha,scope=analysis-worker,mode=max,ignore-error=true
 
   build-playback-worker:
-    if: |
-      github.event_name == 'push' ||
-      (github.event_name == 'workflow_dispatch' && (contains(github.event.inputs.images, 'backend') || contains(github.event.inputs.images, 'worker') || contains(github.event.inputs.images, 'playback-worker') || github.event.inputs.images == 'all'))
+    needs: changes
+    if: needs.changes.outputs.playback_worker == 'true'
     runs-on: ubuntu-latest
     permissions:
       contents: read
       packages: write
+    outputs:
+      digest: ${{ steps.build.outputs.digest }}
     steps:
       - uses: actions/checkout@v6
 
@@ -171,10 +242,10 @@ jobs:
         with:
           images: ${{ env.REGISTRY }}/${{ env.OWNER }}/crate-playback-worker
           tags: |
-            type=sha,prefix=,format=short
-            type=raw,value=latest
+            type=sha,prefix=,format=long
 
       - uses: docker/build-push-action@v7
+        id: build
         with:
           context: ./app
           file: ./app/Dockerfile
@@ -183,17 +254,18 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           platforms: linux/amd64
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-from: type=gha,scope=playback-worker
+          cache-to: type=gha,scope=playback-worker,mode=max
 
   build-media-worker:
-    if: |
-      github.event_name == 'push' ||
-      (github.event_name == 'workflow_dispatch' && (contains(github.event.inputs.images, 'backend') || contains(github.event.inputs.images, 'media-worker') || github.event.inputs.images == 'all'))
+    needs: changes
+    if: needs.changes.outputs.media_worker == 'true'
     runs-on: ubuntu-latest
     permissions:
       contents: read
       packages: write
+    outputs:
+      digest: ${{ steps.build.outputs.digest }}
     steps:
       - uses: actions/checkout@v6
 
@@ -210,10 +282,10 @@ jobs:
         with:
           images: ${{ env.REGISTRY }}/${{ env.OWNER }}/crate-media-worker
           tags: |
-            type=sha,prefix=,format=short
-            type=raw,value=latest
+            type=sha,prefix=,format=long
 
       - uses: docker/build-push-action@v7
+        id: build
         with:
           context: ./app
           file: ./app/Dockerfile
@@ -222,17 +294,18 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           platforms: linux/amd64
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-from: type=gha,scope=media-worker
+          cache-to: type=gha,scope=media-worker,mode=max
 
   build-readplane:
-    if: |
-      github.event_name == 'push' ||
-      (github.event_name == 'workflow_dispatch' && (contains(github.event.inputs.images, 'backend') || contains(github.event.inputs.images, 'readplane') || github.event.inputs.images == 'all'))
+    needs: changes
+    if: needs.changes.outputs.readplane == 'true'
     runs-on: ubuntu-latest
     permissions:
       contents: read
       packages: write
+    outputs:
+      digest: ${{ steps.build.outputs.digest }}
     steps:
       - uses: actions/checkout@v6
 
@@ -249,10 +322,10 @@ jobs:
         with:
           images: ${{ env.REGISTRY }}/${{ env.OWNER }}/crate-readplane
           tags: |
-            type=sha,prefix=,format=short
-            type=raw,value=latest
+            type=sha,prefix=,format=long
 
       - uses: docker/build-push-action@v7
+        id: build
         with:
           context: ./app/readplane
           file: ./app/readplane/Dockerfile
@@ -262,17 +335,18 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           platforms: linux/amd64
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-from: type=gha,scope=readplane
+          cache-to: type=gha,scope=readplane,mode=max
 
   build-ui:
-    if: |
-      github.event_name == 'push' ||
-      (github.event_name == 'workflow_dispatch' && (contains(github.event.inputs.images, 'ui') || github.event.inputs.images == 'all'))
+    needs: changes
+    if: needs.changes.outputs.ui == 'true'
     runs-on: ubuntu-latest
     permissions:
       contents: read
       packages: write
+    outputs:
+      digest: ${{ steps.build.outputs.digest }}
     steps:
       - uses: actions/checkout@v6
 
@@ -289,27 +363,28 @@ jobs:
         with:
           images: ${{ env.REGISTRY }}/${{ env.OWNER }}/crate-ui
           tags: |
-            type=sha,prefix=,format=short
-            type=raw,value=latest
+            type=sha,prefix=,format=long
 
       - uses: docker/build-push-action@v7
+        id: build
         with:
           context: ./app
           file: ./app/ui/Dockerfile
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-from: type=gha,scope=ui
+          cache-to: type=gha,scope=ui,mode=max
 
   build-listen:
-    if: |
-      github.event_name == 'push' ||
-      (github.event_name == 'workflow_dispatch' && (contains(github.event.inputs.images, 'listen') || github.event.inputs.images == 'all'))
+    needs: changes
+    if: needs.changes.outputs.listen == 'true'
     runs-on: ubuntu-latest
     permissions:
       contents: read
       packages: write
+    outputs:
+      digest: ${{ steps.build.outputs.digest }}
     steps:
       - uses: actions/checkout@v6
 
@@ -326,27 +401,28 @@ jobs:
         with:
           images: ${{ env.REGISTRY }}/${{ env.OWNER }}/crate-listen
           tags: |
-            type=sha,prefix=,format=short
-            type=raw,value=latest
+            type=sha,prefix=,format=long
 
       - uses: docker/build-push-action@v7
+        id: build
         with:
           context: ./app
           file: ./app/listen/Dockerfile
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-from: type=gha,scope=listen
+          cache-to: type=gha,scope=listen,mode=max
 
   build-docs:
-    if: |
-      github.event_name == 'push' ||
-      (github.event_name == 'workflow_dispatch' && (contains(github.event.inputs.images, 'docs') || github.event.inputs.images == 'all'))
+    needs: changes
+    if: needs.changes.outputs.docs == 'true'
     runs-on: ubuntu-latest
     permissions:
       contents: read
       packages: write
+    outputs:
+      digest: ${{ steps.build.outputs.digest }}
     steps:
       - uses: actions/checkout@v6
 
@@ -363,30 +439,31 @@ jobs:
         with:
           images: ${{ env.REGISTRY }}/${{ env.OWNER }}/crate-docs
           tags: |
-            type=sha,prefix=,format=short
-            type=raw,value=latest
+            type=sha,prefix=,format=long
 
       # NOTE: docs build context is the repo root (not ./app) because
       # the Dockerfile needs to COPY both app/docs/ (source) and docs/
       # (markdown files consumed by import.meta.glob at build time).
       - uses: docker/build-push-action@v7
+        id: build
         with:
           context: .
           file: ./app/docs/Dockerfile
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-from: type=gha,scope=docs
+          cache-to: type=gha,scope=docs,mode=max
 
   build-site:
-    if: |
-      github.event_name == 'push' ||
-      (github.event_name == 'workflow_dispatch' && (contains(github.event.inputs.images, 'site') || github.event.inputs.images == 'all'))
+    needs: changes
+    if: needs.changes.outputs.site == 'true'
     runs-on: ubuntu-latest
     permissions:
       contents: read
       packages: write
+    outputs:
+      digest: ${{ steps.build.outputs.digest }}
     steps:
       - uses: actions/checkout@v6
 
@@ -403,17 +480,214 @@ jobs:
         with:
           images: ${{ env.REGISTRY }}/${{ env.OWNER }}/crate-site
           tags: |
-            type=sha,prefix=,format=short
-            type=raw,value=latest
+            type=sha,prefix=,format=long
 
       # NOTE: site build context is the repo root (matches the docs job)
       # so the Dockerfile's COPY app/site/... resolves cleanly.
       - uses: docker/build-push-action@v7
+        id: build
         with:
           context: .
           file: ./app/site/Dockerfile
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-from: type=gha,scope=site
+          cache-to: type=gha,scope=site,mode=max
+
+  promote-release:
+    needs:
+      - changes
+      - build-api
+      - build-readplane
+      - build-worker
+      - build-analysis-worker
+      - build-playback-worker
+      - build-media-worker
+      - build-ui
+      - build-listen
+      - build-site
+      - build-docs
+    if: always() && needs.changes.result == 'success'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+      attestations: write
+      artifact-metadata: write
+    env:
+      CHANGED_API: ${{ needs.changes.outputs.api }}
+      CHANGED_READPLANE: ${{ needs.changes.outputs.readplane }}
+      CHANGED_WORKER: ${{ needs.changes.outputs.worker }}
+      CHANGED_ANALYSIS_WORKER: ${{ needs.changes.outputs.analysis_worker }}
+      CHANGED_PLAYBACK_WORKER: ${{ needs.changes.outputs.playback_worker }}
+      CHANGED_MEDIA_WORKER: ${{ needs.changes.outputs.media_worker }}
+      CHANGED_UI: ${{ needs.changes.outputs.ui }}
+      CHANGED_LISTEN: ${{ needs.changes.outputs.listen }}
+      CHANGED_SITE: ${{ needs.changes.outputs.site }}
+      CHANGED_DOCS: ${{ needs.changes.outputs.docs }}
+      RESULT_API: ${{ needs['build-api'].result }}
+      RESULT_READPLANE: ${{ needs['build-readplane'].result }}
+      RESULT_WORKER: ${{ needs['build-worker'].result }}
+      RESULT_ANALYSIS_WORKER: ${{ needs['build-analysis-worker'].result }}
+      RESULT_PLAYBACK_WORKER: ${{ needs['build-playback-worker'].result }}
+      RESULT_MEDIA_WORKER: ${{ needs['build-media-worker'].result }}
+      RESULT_UI: ${{ needs['build-ui'].result }}
+      RESULT_LISTEN: ${{ needs['build-listen'].result }}
+      RESULT_SITE: ${{ needs['build-site'].result }}
+      RESULT_DOCS: ${{ needs['build-docs'].result }}
+      DIGEST_API: ${{ needs['build-api'].outputs.digest }}
+      DIGEST_READPLANE: ${{ needs['build-readplane'].outputs.digest }}
+      DIGEST_WORKER: ${{ needs['build-worker'].outputs.digest }}
+      DIGEST_ANALYSIS_WORKER: ${{ needs['build-analysis-worker'].outputs.digest }}
+      DIGEST_PLAYBACK_WORKER: ${{ needs['build-playback-worker'].outputs.digest }}
+      DIGEST_MEDIA_WORKER: ${{ needs['build-media-worker'].outputs.digest }}
+      DIGEST_UI: ${{ needs['build-ui'].outputs.digest }}
+      DIGEST_LISTEN: ${{ needs['build-listen'].outputs.digest }}
+      DIGEST_SITE: ${{ needs['build-site'].outputs.digest }}
+      DIGEST_DOCS: ${{ needs['build-docs'].outputs.digest }}
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: docker/setup-buildx-action@v4
+
+      - uses: docker/login-action@v4
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Reject incomplete selected builds
+        run: |
+          set -Eeuo pipefail
+          check_result() {
+            local name="$1"
+            local changed="$2"
+            local result="$3"
+            if [[ "$changed" == "true" && "$result" != "success" ]]; then
+              echo "Required image build failed: ${name} (${result})" >&2
+              return 1
+            fi
+          }
+          check_result api "$CHANGED_API" "$RESULT_API"
+          check_result readplane "$CHANGED_READPLANE" "$RESULT_READPLANE"
+          check_result worker "$CHANGED_WORKER" "$RESULT_WORKER"
+          check_result analysis-worker "$CHANGED_ANALYSIS_WORKER" "$RESULT_ANALYSIS_WORKER"
+          check_result playback-worker "$CHANGED_PLAYBACK_WORKER" "$RESULT_PLAYBACK_WORKER"
+          check_result media-worker "$CHANGED_MEDIA_WORKER" "$RESULT_MEDIA_WORKER"
+          check_result ui "$CHANGED_UI" "$RESULT_UI"
+          check_result listen "$CHANGED_LISTEN" "$RESULT_LISTEN"
+          check_result site "$CHANGED_SITE" "$RESULT_SITE"
+          check_result docs "$CHANGED_DOCS" "$RESULT_DOCS"
+
+      - name: Assemble complete release manifest
+        env:
+          STABLE_MANIFEST: ${{ env.REGISTRY }}/${{ env.OWNER }}/crate-release-manifest:stable
+        run: |
+          set -Eeuo pipefail
+          previous_args=()
+          if docker pull -q "$STABLE_MANIFEST" >/dev/null 2>&1; then
+            container="$(docker create "$STABLE_MANIFEST" true)"
+            trap 'docker rm -f "$container" >/dev/null 2>&1 || true' EXIT
+            docker cp "$container:/release-manifest.json" /tmp/previous-release.json
+            python scripts/release_manifest.py validate \
+              --manifest /tmp/previous-release.json \
+              --registry "$REGISTRY" \
+              --owner "$OWNER"
+            previous_args=(--previous /tmp/previous-release.json)
+          fi
+
+          digest_args=()
+          [[ "$CHANGED_API" == "true" ]] && digest_args+=(--digest "api=$DIGEST_API")
+          [[ "$CHANGED_READPLANE" == "true" ]] && digest_args+=(--digest "readplane=$DIGEST_READPLANE")
+          [[ "$CHANGED_WORKER" == "true" ]] && digest_args+=(--digest "worker=$DIGEST_WORKER")
+          [[ "$CHANGED_ANALYSIS_WORKER" == "true" ]] && digest_args+=(--digest "analysis-worker=$DIGEST_ANALYSIS_WORKER")
+          [[ "$CHANGED_PLAYBACK_WORKER" == "true" ]] && digest_args+=(--digest "playback-worker=$DIGEST_PLAYBACK_WORKER")
+          [[ "$CHANGED_MEDIA_WORKER" == "true" ]] && digest_args+=(--digest "media-worker=$DIGEST_MEDIA_WORKER")
+          [[ "$CHANGED_UI" == "true" ]] && digest_args+=(--digest "ui=$DIGEST_UI")
+          [[ "$CHANGED_LISTEN" == "true" ]] && digest_args+=(--digest "listen=$DIGEST_LISTEN")
+          [[ "$CHANGED_SITE" == "true" ]] && digest_args+=(--digest "site=$DIGEST_SITE")
+          [[ "$CHANGED_DOCS" == "true" ]] && digest_args+=(--digest "docs=$DIGEST_DOCS")
+
+          python scripts/release_manifest.py assemble \
+            --release-sha "$GITHUB_SHA" \
+            --registry "$REGISTRY" \
+            --owner "$OWNER" \
+            "${previous_args[@]}" \
+            "${digest_args[@]}" \
+            --output /tmp/release-manifest.json
+
+          while IFS= read -r reference; do
+            docker buildx imagetools inspect "$reference" >/dev/null
+          done < <(python scripts/release_manifest.py refs \
+            --manifest /tmp/release-manifest.json)
+
+      - name: Publish immutable release manifest
+        id: manifest
+        env:
+          MANIFEST_REPOSITORY: ${{ env.REGISTRY }}/${{ env.OWNER }}/crate-release-manifest
+        run: |
+          set -Eeuo pipefail
+          immutable_ref="${MANIFEST_REPOSITORY}:${GITHUB_SHA}"
+          mkdir -p /tmp/release-manifest-image
+          cp /tmp/release-manifest.json /tmp/release-manifest-image/release-manifest.json
+          printf 'FROM scratch\nCOPY release-manifest.json /release-manifest.json\n' \
+            > /tmp/release-manifest-image/Dockerfile
+
+          if docker pull -q "$immutable_ref" >/dev/null 2>&1; then
+            container="$(docker create "$immutable_ref" true)"
+            trap 'docker rm -f "$container" >/dev/null 2>&1 || true' EXIT
+            docker cp "$container:/release-manifest.json" /tmp/existing-release.json
+            cmp /tmp/existing-release.json /tmp/release-manifest.json
+          else
+            docker buildx build \
+              --provenance=true \
+              --push \
+              --tag "$immutable_ref" \
+              /tmp/release-manifest-image
+          fi
+
+          digest="$(docker buildx imagetools inspect "$immutable_ref" \
+            --format '{{json .Manifest.Digest}}' | tr -d '"')"
+          echo "digest=$digest" >> "$GITHUB_OUTPUT"
+
+      - name: Promote changed images to latest
+        run: |
+          set -Eeuo pipefail
+          promote_latest() {
+            local changed="$1"
+            local repository="$2"
+            local digest="$3"
+            if [[ "$changed" == "true" ]]; then
+              docker buildx imagetools create \
+                --tag "${REGISTRY}/${OWNER}/${repository}:latest" \
+                "${REGISTRY}/${OWNER}/${repository}@${digest}"
+            fi
+          }
+          promote_latest "$CHANGED_API" crate-api "$DIGEST_API"
+          promote_latest "$CHANGED_READPLANE" crate-readplane "$DIGEST_READPLANE"
+          promote_latest "$CHANGED_WORKER" crate-worker "$DIGEST_WORKER"
+          promote_latest "$CHANGED_ANALYSIS_WORKER" crate-analysis-worker "$DIGEST_ANALYSIS_WORKER"
+          promote_latest "$CHANGED_PLAYBACK_WORKER" crate-playback-worker "$DIGEST_PLAYBACK_WORKER"
+          promote_latest "$CHANGED_MEDIA_WORKER" crate-media-worker "$DIGEST_MEDIA_WORKER"
+          promote_latest "$CHANGED_UI" crate-ui "$DIGEST_UI"
+          promote_latest "$CHANGED_LISTEN" crate-listen "$DIGEST_LISTEN"
+          promote_latest "$CHANGED_SITE" crate-site "$DIGEST_SITE"
+          promote_latest "$CHANGED_DOCS" crate-docs "$DIGEST_DOCS"
+
+      - name: Attest release manifest
+        uses: actions/attest@v4
+        with:
+          subject-name: ${{ env.REGISTRY }}/${{ env.OWNER }}/crate-release-manifest
+          subject-digest: ${{ steps.manifest.outputs.digest }}
+          push-to-registry: true
+
+      - name: Promote release manifest to stable
+        env:
+          MANIFEST_REPOSITORY: ${{ env.REGISTRY }}/${{ env.OWNER }}/crate-release-manifest
+        run: |
+          set -Eeuo pipefail
+          docker buildx imagetools create \
+            --tag "${MANIFEST_REPOSITORY}:stable" \
+            "${MANIFEST_REPOSITORY}@${{ steps.manifest.outputs.digest }}"

--- a/Makefile
+++ b/Makefile
@@ -743,8 +743,8 @@ _create-dirs:
 # DEPLOY (production)
 # ===========================================================================
 
-# Defaults to the short SHA tag published by GitHub Actions for origin/main.
-# VERSION=<full-main-sha> pins compose and every application image to one release.
+# Resolves the immutable release manifest published for origin/main.
+# VERSION=<full-main-sha> pins compose and every application image by OCI digest.
 # Lower-level overrides remain available for development and incident recovery:
 # DEPLOY_IMAGE_TAG=<tag>, DEPLOY_REF=<git-ref>, DEPLOY_IMAGE_OWNER=<owner>, DEPLOY_PUBLIC_CHECKS=0.
 .PHONY: deploy
@@ -766,6 +766,12 @@ deploy-rollback: ## Restore a recovery set (requires CONFIRM=restore-production)
 	@test -n "$(strip $(DEPLOY_ID))" || { echo "$(RED)DEPLOY_ID=<release-id> is required$(NC)"; exit 1; }
 	@test "$(CONFIRM)" = "restore-production" || { echo "$(RED)CONFIRM=restore-production is required$(NC)"; exit 1; }
 	@SERVER_USER="$(SERVER_USER)" SERVER_HOST="$(SERVER_HOST)" SERVER_PATH="$(SERVER_PATH)" DEPLOY_ID="$(strip $(DEPLOY_ID))" DEPLOY_CONFIRM="$(CONFIRM)" DEPLOY_IMAGE_OWNER="$(DEPLOY_IMAGE_OWNER)" DEPLOY_IMAGE_REGISTRY="$(DEPLOY_IMAGE_REGISTRY)" scripts/deploy.sh rollback
+
+.PHONY: deploy-image-rollback
+deploy-image-rollback: ## Roll back only application images/config (requires CONFIRM=rollback-images)
+	@test -n "$(strip $(DEPLOY_ID))" || { echo "$(RED)DEPLOY_ID=<release-id> is required$(NC)"; exit 1; }
+	@test "$(CONFIRM)" = "rollback-images" || { echo "$(RED)CONFIRM=rollback-images is required$(NC)"; exit 1; }
+	@SERVER_USER="$(SERVER_USER)" SERVER_HOST="$(SERVER_HOST)" SERVER_PATH="$(SERVER_PATH)" DEPLOY_ID="$(strip $(DEPLOY_ID))" DEPLOY_CONFIRM="$(CONFIRM)" DEPLOY_IMAGE_OWNER="$(DEPLOY_IMAGE_OWNER)" DEPLOY_IMAGE_REGISTRY="$(DEPLOY_IMAGE_REGISTRY)" scripts/deploy.sh image-rollback
 
 .PHONY: deploy-build
 deploy-build: ## Deploy by building on the server (GHCR fallback)

--- a/README.md
+++ b/README.md
@@ -379,7 +379,8 @@ make dev-logs [s=svc] # Follow dev logs (optionally filter by service)
 make dev-test         # Run pytest in the worker container
 
 # Deploy (production)
-make deploy           # Sync + pull GHCR images + restart
+make deploy           # Deploy an immutable manifest; restart changed services
+make deploy-image-rollback DEPLOY_ID=X CONFIRM=rollback-images
 make deploy-build     # Deploy with on-server build (fallback)
 make deploy-sync      # Sync files only (no restart)
 make deploy-restart   # Restart remote services

--- a/app/crate/db/repositories/library_album_upserts.py
+++ b/app/crate/db/repositories/library_album_upserts.py
@@ -41,30 +41,37 @@ def upsert_album(data: dict, *, session: Session | None = None) -> int:
             for value in (data.get("release_group_secondary_types") or [])
             if str(value).strip()
         ]
+        existing_columns = (
+            LibraryAlbum.id,
+            LibraryAlbum.slug,
+            LibraryAlbum.storage_id,
+            LibraryAlbum.entity_uid,
+            LibraryAlbum.musicbrainz_albumid,
+            LibraryAlbum.musicbrainz_releasegroupid,
+            LibraryAlbum.tag_album,
+        )
         existing = s.execute(
-            select(
-                LibraryAlbum.id,
-                LibraryAlbum.slug,
-                LibraryAlbum.storage_id,
-                LibraryAlbum.entity_uid,
-                LibraryAlbum.musicbrainz_albumid,
-                LibraryAlbum.musicbrainz_releasegroupid,
-                LibraryAlbum.tag_album,
-            )
-            .where(
-                or_(
-                    path_match,
-                    entity_match,
-                    LibraryAlbum.musicbrainz_albumid == requested_mbid
-                    if requested_mbid
-                    else false(),
-                    LibraryAlbum.musicbrainz_releasegroupid == requested_rgid
-                    if requested_rgid
-                    else false(),
-                )
-            )
-            .limit(1)
+            select(*existing_columns).where(path_match).limit(1)
         ).first()
+        if existing is None and requested_entity_uid is not None:
+            existing = s.execute(
+                select(*existing_columns).where(entity_match).limit(1)
+            ).first()
+        if existing is None and (requested_mbid or requested_rgid):
+            existing = s.execute(
+                select(*existing_columns)
+                .where(
+                    or_(
+                        LibraryAlbum.musicbrainz_albumid == requested_mbid
+                        if requested_mbid
+                        else false(),
+                        LibraryAlbum.musicbrainz_releasegroupid == requested_rgid
+                        if requested_rgid
+                        else false(),
+                    )
+                )
+                .limit(1)
+            ).first()
         slug = (
             existing[1]
             if existing and existing[1]

--- a/app/listen/src/contexts/player-utils.test.ts
+++ b/app/listen/src/contexts/player-utils.test.ts
@@ -9,6 +9,7 @@ import { getOfflineNativePlaybackUrl } from "@/lib/offline";
 import { setPlaybackDeliveryPolicyPreference } from "@/lib/player-playback-prefs";
 import {
   ANDROID_CONTINUOUS_ALBUM_CROSSFADE_SECONDS,
+  ANDROID_MEDIA_SESSION_HANDOFF_SECONDS,
   getEffectiveCrossfadeSeconds,
   getStoredQueue,
   getStreamUrl,
@@ -355,6 +356,20 @@ describe("getEffectiveCrossfadeSeconds", () => {
         { html5OnlyPlayback: true },
       ),
     ).toBe(ANDROID_CONTINUOUS_ALBUM_CROSSFADE_SECONDS);
+  });
+
+  it("keeps a minimal HTML5 handoff for non-album queues when crossfade is off", () => {
+    expect(
+      getEffectiveCrossfadeSeconds(
+        TRACK_A,
+        TRACK_B,
+        PLAYLIST_SOURCE,
+        false,
+        0,
+        true,
+        { html5OnlyPlayback: true },
+      ),
+    ).toBe(ANDROID_MEDIA_SESSION_HANDOFF_SECONDS);
   });
 
   it("keeps true gapless album playback when enhanced mobile audio is enabled", () => {

--- a/app/listen/src/contexts/player-utils.ts
+++ b/app/listen/src/contexts/player-utils.ts
@@ -11,6 +11,7 @@ export const STORAGE_KEY = "listen-player-state";
 export const RECENTLY_PLAYED_KEY = "listen-recently-played";
 export const MAX_RECENT = 10;
 export const ANDROID_CONTINUOUS_ALBUM_CROSSFADE_SECONDS = 1;
+export const ANDROID_MEDIA_SESSION_HANDOFF_SECONDS = 0.15;
 export const SMART_TRANSITION_SHORT_SECONDS = 2;
 export const SMART_TRANSITION_BALANCED_SECONDS = 4;
 export const SMART_TRANSITION_LONG_SECONDS = 6;
@@ -534,7 +535,14 @@ export function getEffectiveCrossfadeSeconds(
       );
     }
   }
-  if (clampedSeconds <= 0) return 0;
+  if (clampedSeconds <= 0) {
+    if (shouldMaskHtml5Gap && nextTrack) {
+      return continuousAlbumTransition
+        ? ANDROID_CONTINUOUS_ALBUM_CROSSFADE_SECONDS
+        : ANDROID_MEDIA_SESSION_HANDOFF_SECONDS;
+    }
+    return 0;
+  }
   if (!smartCrossfadeEnabled) return clampedSeconds;
   if (continuousAlbumTransition) {
     return shouldMaskHtml5Gap

--- a/app/listen/src/contexts/use-media-session.test.tsx
+++ b/app/listen/src/contexts/use-media-session.test.tsx
@@ -1,0 +1,170 @@
+import { renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { Track } from "./player-types";
+import { useMediaSession } from "./use-media-session";
+
+const runtime = vi.hoisted(() => ({ isNative: false }));
+
+vi.mock("@/lib/capacitor-runtime", () => ({
+  get isNative() {
+    return runtime.isNative;
+  },
+}));
+
+vi.mock("@/lib/android-native-engine", () => ({
+  shouldUseAndroidNativePlayer: () => false,
+}));
+
+vi.mock("@/lib/api", () => ({
+  resolveMaybeApiAssetUrl: (value: string | undefined) => value ?? "",
+}));
+
+vi.mock("@/lib/desktop-tray", () => ({
+  syncDesktopMediaSession: vi.fn(),
+}));
+
+vi.mock("@/lib/native-media-session", () => ({
+  onNativeMediaControl: vi.fn(async () => () => {}),
+  stopNativeMediaSession: vi.fn(async () => {}),
+  syncNativeMediaSession: vi.fn(async () => {}),
+}));
+
+vi.mock("@/lib/platform", () => ({
+  isTauriRuntime: false,
+}));
+
+const TRACK_A: Track = {
+  id: "track-a",
+  title: "Track A",
+  artist: "Artist",
+  album: "Album",
+};
+
+const TRACK_B: Track = {
+  ...TRACK_A,
+  id: "track-b",
+  title: "Track B",
+};
+
+const controls = {
+  pause: vi.fn(),
+  resume: vi.fn(),
+  next: vi.fn(),
+  prev: vi.fn(),
+  seek: vi.fn(),
+};
+
+type MutableMediaSession = {
+  metadata: MediaMetadata | null;
+  playbackState: MediaSessionPlaybackState;
+  setActionHandler: ReturnType<typeof vi.fn>;
+  setPositionState: ReturnType<typeof vi.fn>;
+};
+
+let mediaSession: MutableMediaSession;
+let originalMediaSession: PropertyDescriptor | undefined;
+let originalMediaMetadata: PropertyDescriptor | undefined;
+
+function renderSession(
+  currentTrack: Track | undefined = TRACK_A,
+  currentTime = 0,
+) {
+  return renderHook(
+    ({ track, time }: { track: Track | undefined; time: number }) =>
+      useMediaSession({
+        currentTrack: track,
+        isPlaying: true,
+        currentTime: time,
+        duration: 180,
+        ...controls,
+      }),
+    { initialProps: { track: currentTrack, time: currentTime } },
+  );
+}
+
+beforeEach(() => {
+  runtime.isNative = false;
+  vi.clearAllMocks();
+  mediaSession = {
+    metadata: null,
+    playbackState: "none",
+    setActionHandler: vi.fn(),
+    setPositionState: vi.fn(),
+  };
+  originalMediaSession = Object.getOwnPropertyDescriptor(
+    navigator,
+    "mediaSession",
+  );
+  originalMediaMetadata = Object.getOwnPropertyDescriptor(
+    globalThis,
+    "MediaMetadata",
+  );
+  Object.defineProperty(navigator, "mediaSession", {
+    configurable: true,
+    value: mediaSession,
+  });
+  Object.defineProperty(globalThis, "MediaMetadata", {
+    configurable: true,
+    value: class {
+      constructor(public init: MediaMetadataInit) {}
+    },
+  });
+});
+
+afterEach(() => {
+  if (originalMediaSession) {
+    Object.defineProperty(navigator, "mediaSession", originalMediaSession);
+  } else {
+    Reflect.deleteProperty(navigator, "mediaSession");
+  }
+  if (originalMediaMetadata) {
+    Object.defineProperty(globalThis, "MediaMetadata", originalMediaMetadata);
+  } else {
+    Reflect.deleteProperty(globalThis, "MediaMetadata");
+  }
+});
+
+describe("useMediaSession", () => {
+  it("reasserts playing when the active track changes", () => {
+    const { rerender } = renderSession();
+    expect(mediaSession.playbackState).toBe("playing");
+
+    mediaSession.playbackState = "none";
+    rerender({ track: TRACK_B, time: 0 });
+
+    expect(mediaSession.playbackState).toBe("playing");
+  });
+
+  it("repairs browser playback state during position updates", () => {
+    const { rerender } = renderSession();
+    mediaSession.playbackState = "none";
+
+    rerender({ track: TRACK_A, time: 1 });
+
+    expect(mediaSession.playbackState).toBe("playing");
+  });
+
+  it("repairs playback state when position reporting is unsupported", () => {
+    const { rerender } = renderSession();
+    mediaSession.playbackState = "none";
+    mediaSession.setPositionState.mockImplementation(() => {
+      throw new Error("unsupported");
+    });
+
+    rerender({ track: TRACK_A, time: 2 });
+
+    expect(mediaSession.playbackState).toBe("playing");
+  });
+
+  it("does not create a competing WebView media session in native shells", () => {
+    runtime.isNative = true;
+
+    renderSession();
+
+    expect(mediaSession.metadata).toBeNull();
+    expect(mediaSession.playbackState).toBe("none");
+    expect(mediaSession.setActionHandler).not.toHaveBeenCalled();
+    expect(mediaSession.setPositionState).not.toHaveBeenCalled();
+  });
+});

--- a/app/listen/src/contexts/use-media-session.ts
+++ b/app/listen/src/contexts/use-media-session.ts
@@ -2,6 +2,7 @@ import { useEffect, useRef } from "react";
 import type { Track } from "./player-types";
 import { shouldUseAndroidNativePlayer } from "@/lib/android-native-engine";
 import { resolveMaybeApiAssetUrl } from "@/lib/api";
+import { isNative } from "@/lib/capacitor-runtime";
 import { syncDesktopMediaSession } from "@/lib/desktop-tray";
 import {
   onNativeMediaControl,
@@ -105,7 +106,7 @@ export function useMediaSession({
 
   // Update metadata when track changes
   useEffect(() => {
-    if (!("mediaSession" in navigator) || !currentTrack) return;
+    if (isNative || !("mediaSession" in navigator) || !currentTrack) return;
 
     const artwork: MediaImage[] = [];
     const coverUrl = resolveMaybeApiAssetUrl(currentTrack.albumCover);
@@ -129,14 +130,15 @@ export function useMediaSession({
 
   // Update playback state
   useEffect(() => {
-    if (!("mediaSession" in navigator)) return;
+    if (isNative || !("mediaSession" in navigator)) return;
     navigator.mediaSession.playbackState = isPlaying ? "playing" : "paused";
-  }, [isPlaying]);
+  }, [currentTrack?.id, isPlaying]);
 
   // Update position state for seek bar on lockscreen
   const positionSeconds = Math.floor(Math.min(currentTime, duration));
   useEffect(() => {
-    if (!("mediaSession" in navigator) || !duration) return;
+    if (isNative || !("mediaSession" in navigator) || !duration) return;
+    navigator.mediaSession.playbackState = isPlaying ? "playing" : "paused";
     try {
       navigator.mediaSession.setPositionState({
         duration: duration || 0,
@@ -146,7 +148,7 @@ export function useMediaSession({
     } catch {
       // Some browsers don't support setPositionState
     }
-  }, [duration, positionSeconds]);
+  }, [duration, isPlaying, positionSeconds]);
 
   const nativePositionSeconds = Math.floor(
     Math.max(0, duration > 0 ? Math.min(currentTime, duration) : currentTime),
@@ -219,7 +221,7 @@ export function useMediaSession({
 
   // Register action handlers
   useEffect(() => {
-    if (!("mediaSession" in navigator)) return;
+    if (isNative || !("mediaSession" in navigator)) return;
 
     const actions: Array<[MediaSessionAction, MediaSessionActionHandler]> = [
       ["play", () => actionsRef.current.resume()],

--- a/app/listen/src/lib/gapless-player-audio-recovery.test.ts
+++ b/app/listen/src/lib/gapless-player-audio-recovery.test.ts
@@ -213,6 +213,25 @@ describe("gapless player audio recovery", () => {
     expect(gaplessMock.instances[0]!.playCalls).toBe(1);
   });
 
+  it("ramps Chrome output after resuming a suspended AudioContext", async () => {
+    vi.useFakeTimers();
+    delete document.documentElement.dataset.listenRuntime;
+    const context = gaplessMock.createContext("suspended");
+    gaplessMock.contextQueue.push(context);
+
+    initPlayer();
+    loadQueue(["/tracks/a.flac"], 0);
+    setVolume(0.73);
+
+    await play();
+
+    const player = gaplessMock.instances[0]!;
+    expect(player.volume).toBe(0);
+    await vi.advanceTimersByTimeAsync(40);
+    expect(player.volume).toBeCloseTo(0.73);
+    vi.useRealTimers();
+  });
+
   it("rebuilds the player when the AudioContext was closed while idle", async () => {
     const closedContext = gaplessMock.createContext("closed");
     const freshContext = gaplessMock.createContext("running");

--- a/app/listen/src/lib/gapless-player.test.ts
+++ b/app/listen/src/lib/gapless-player.test.ts
@@ -194,6 +194,8 @@ describe("initPlayer", () => {
     expect(options.crossfadeShape).toBe(3);
     expect(options.volume).toBe(1);
     expect(options.logLevel).toBe(3);
+    expect(options.deferAdjacentLoadsUntilBufferedSeconds).toBe(15);
+    expect(options.switchToWebAudioDuringPlayback).toBe(false);
     expect(player).toBeDefined();
   });
 

--- a/app/listen/src/lib/gapless-player.ts
+++ b/app/listen/src/lib/gapless-player.ts
@@ -47,6 +47,8 @@ const GAPLESS_LOG_LEVEL_WARNING = 3;
 const GAPLESS_CROSSFADE_EQUAL_POWER = 3;
 const DESKTOP_DECODE_TRACK_LIMIT = 2;
 const MOBILE_HTML5_TRACK_LIMIT = 2;
+const ADJACENT_LOAD_BUFFER_SECONDS = 15;
+const RESUMED_AUDIO_CONTEXT_RAMP_MS = 24;
 
 export interface GaplessPlayerCallbacks {
   onTimeUpdate?: (positionMs: number, trackIndex: number) => void;
@@ -241,8 +243,14 @@ export function initPlayer(callbacks: GaplessPlayerCallbacks = {}): Gapless5 {
     volume: lastVolume,
     logLevel: GAPLESS_LOG_LEVEL_WARNING,
     // Keep the next mobile <audio> source ready before the active element
-    // reaches ended, preserving uninterrupted media-session/Bluetooth state.
+    // reaches ended, but only after the current stream has a safe buffer.
+    // Starting both FLAC requests together can starve Android's active decoder.
     loadLimit: getPlaybackLoadLimit(preferHtml5Audio),
+    deferAdjacentLoadsUntilBufferedSeconds: ADJACENT_LOAD_BUFFER_SECONDS,
+    // Switching an audible source from HTML5 to WebAudio mid-track can click
+    // even when both clocks are aligned. Decoded buffers remain available for
+    // tracks that have not started yet.
+    switchToWebAudioDuringPlayback: false,
   });
   appliedVolume = lastVolume;
 
@@ -664,10 +672,18 @@ async function prepareAudioForPlaybackInner(
 
 export async function play(): Promise<void> {
   stopFade();
+  const shouldRampAfterResume =
+    !isTauriDesktopRuntime() && getAudioContext()?.state === "suspended";
   await prepareAudioForPlayback("play", {
     rebuildIfTauriOutputMayBeStale: true,
   });
   tauriPlaybackWasActive = true;
+  if (shouldRampAfterResume && instance) {
+    applyVolume(0);
+    instance.play();
+    animateVolume(0, lastVolume, RESUMED_AUDIO_CONTEXT_RAMP_MS);
+    return;
+  }
   instance?.play();
 }
 

--- a/app/listen/src/lib/gapless5/gapless5-buffering.test.ts
+++ b/app/listen/src/lib/gapless5/gapless5-buffering.test.ts
@@ -92,7 +92,7 @@ describe("Gapless5.replaceTrack", () => {
 });
 
 describe("Gapless5 mobile background auto-advance", () => {
-  it("advances from the native HTMLAudioElement ended event", async () => {
+  it("defers the next request until the active stream has a safe buffer", () => {
     vi.useFakeTimers();
     const instances: FakeAudio[] = [];
 
@@ -138,11 +138,91 @@ describe("Gapless5 mobile background auto-advance", () => {
       useHTML5Audio: true,
       useWebAudio: false,
       loadLimit: 2,
+      deferAdjacentLoadsUntilBufferedSeconds: 15,
+    });
+    const first = instances.find((audio) => audio.src === "one");
+    expect(first).toBeDefined();
+    expect(instances.find((audio) => audio.src === "two")).toBeUndefined();
+
+    first!.dispatchEvent(new Event("loadedmetadata"));
+    first!.dispatchEvent(new Event("loadeddata"));
+    first!.buffered = ranges([[0, 5]]);
+    vi.advanceTimersByTime(30);
+    expect(instances.find((audio) => audio.src === "two")).toBeUndefined();
+
+    first!.currentTime = 172;
+    first!.buffered = ranges([[0, 176]]);
+    player.setPosition(172_000);
+    vi.advanceTimersByTime(30);
+    expect(instances.find((audio) => audio.src === "two")).toBeDefined();
+
+    player.removeAllTracks();
+  });
+
+  it("advances from the native HTMLAudioElement ended event", async () => {
+    vi.useFakeTimers();
+    const instances: FakeAudio[] = [];
+
+    class FakeAudio extends EventTarget {
+      buffered = ranges([]);
+      controls = false;
+      crossOrigin: string | null = null;
+      currentTime = 0;
+      duration = 180;
+      error: MediaError | null = null;
+      loop = false;
+      networkState = 1;
+      paused = true;
+      playbackRate = 1;
+      preload = "auto";
+      preservesPitch = true;
+      readyState = 4;
+      seekable = ranges([[0, 180]]);
+      src = "";
+      srcObject: MediaProvider | null = null;
+      volume = 1;
+      removedEvents: string[] = [];
+
+      constructor() {
+        super();
+        instances.push(this);
+      }
+
+      load() {}
+
+      pause() {
+        this.paused = true;
+      }
+
+      play() {
+        this.paused = false;
+        return Promise.resolve();
+      }
+
+      override removeEventListener(
+        type: string,
+        callback: EventListenerOrEventListenerObject | null,
+        options?: boolean | EventListenerOptions,
+      ) {
+        this.removedEvents.push(type);
+        super.removeEventListener(type, callback, options);
+      }
+    }
+
+    vi.stubGlobal("Audio", FakeAudio);
+    const player = new Gapless5({
+      tracks: ["one", "two"],
+      useHTML5Audio: true,
+      useWebAudio: false,
+      loadLimit: 2,
+      deferAdjacentLoadsUntilBufferedSeconds: 15,
     });
     const first = instances.find((audio) => audio.src === "one");
     expect(first).toBeDefined();
     first!.dispatchEvent(new Event("loadedmetadata"));
     first!.dispatchEvent(new Event("loadeddata"));
+    first!.buffered = ranges([[0, 20]]);
+    vi.advanceTimersByTime(30);
     const second = instances.find((audio) => audio.src === "two");
     expect(second).toBeDefined();
     second!.dispatchEvent(new Event("loadedmetadata"));
@@ -156,5 +236,127 @@ describe("Gapless5 mobile background auto-advance", () => {
     first!.dispatchEvent(new Event("ended"));
     expect(player.getIndex()).toBe(1);
     player.removeAllTracks();
+    expect(first!.removedEvents).toContain("ended");
+  });
+});
+
+describe("Gapless5 WebAudio promotion", () => {
+  it("keeps an active HTML5 source playing when its WebAudio buffer finishes decoding", async () => {
+    vi.useFakeTimers();
+    let resolveDecode: ((buffer: { duration: number }) => void) | undefined;
+    const decodePromise = new Promise<{ duration: number }>((resolve) => {
+      resolveDecode = resolve;
+    });
+    const instances: FakeAudio[] = [];
+
+    class FakeAudio extends EventTarget {
+      buffered = ranges([[0, 180]]);
+      controls = false;
+      crossOrigin: string | null = null;
+      currentTime = 0;
+      duration = 180;
+      error: MediaError | null = null;
+      loop = false;
+      networkState = 1;
+      paused = true;
+      pauseCalls = 0;
+      playbackRate = 1;
+      preload = "auto";
+      preservesPitch = true;
+      readyState = 4;
+      seekable = ranges([[0, 180]]);
+      src = "";
+      srcObject: MediaProvider | null = null;
+      volume = 1;
+
+      constructor() {
+        super();
+        instances.push(this);
+      }
+
+      load() {}
+
+      pause() {
+        this.pauseCalls += 1;
+        this.paused = true;
+      }
+
+      play() {
+        this.paused = false;
+        return Promise.resolve();
+      }
+    }
+
+    const node = () => ({
+      connect: vi.fn(),
+      disconnect: vi.fn(),
+    });
+    const context = {
+      baseLatency: 0,
+      currentTime: 0,
+      destination: node(),
+      state: "running",
+      createBufferSource: vi.fn(() => ({
+        ...node(),
+        buffer: null,
+        loop: false,
+        playbackRate: { value: 1 },
+        start: vi.fn(),
+        stop: vi.fn(),
+      })),
+      createGain: vi.fn(() => ({
+        ...node(),
+        gain: {
+          value: 1,
+          linearRampToValueAtTime: vi.fn(),
+        },
+      })),
+      decodeAudioData: vi.fn(() => decodePromise),
+      resume: vi.fn(() => Promise.resolve()),
+    };
+
+    vi.stubGlobal("Audio", FakeAudio);
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => ({
+        ok: true,
+        status: 200,
+        arrayBuffer: async () => new ArrayBuffer(8),
+      })),
+    );
+    Object.defineProperty(window, "gapless5AudioContext", {
+      configurable: true,
+      writable: true,
+      value: context,
+    });
+
+    const player = new Gapless5({
+      tracks: ["one"],
+      useHTML5Audio: true,
+      useWebAudio: true,
+      switchToWebAudioDuringPlayback: false,
+    });
+    const first = instances.find((audio) => audio.src === "one");
+    expect(first).toBeDefined();
+    first!.dispatchEvent(new Event("loadedmetadata"));
+    first!.dispatchEvent(new Event("loadeddata"));
+    player.play();
+    await Promise.resolve();
+    expect(first!.paused).toBe(false);
+
+    for (let index = 0; index < 6; index += 1) {
+      await Promise.resolve();
+    }
+    expect(context.decodeAudioData).toHaveBeenCalledTimes(1);
+    resolveDecode?.({ duration: 180 });
+    for (let index = 0; index < 4; index += 1) {
+      await Promise.resolve();
+    }
+
+    expect(first!.pauseCalls).toBe(0);
+    expect(context.createBufferSource).not.toHaveBeenCalled();
+
+    player.removeAllTracks();
+    Reflect.deleteProperty(window, "gapless5AudioContext");
   });
 });

--- a/app/listen/src/lib/gapless5/gapless5.js
+++ b/app/listen/src/lib/gapless5/gapless5.js
@@ -206,6 +206,20 @@ function Gapless5Source(parentPlayer, parentLog, inAudioPath) {
     if (request) {
       request.abort();
     }
+    if (audio) {
+      audio.removeEventListener("loadedmetadata", onLoadedHTML5Metadata, false);
+      audio.removeEventListener("loadeddata", onLoadedHTML5Audio, false);
+      audio.removeEventListener("canplay", onLoadedHTML5Audio, false);
+      audio.removeEventListener("canplaythrough", onLoadedHTML5Audio, false);
+      audio.removeEventListener("ended", onEnded, false);
+      try {
+        audio.removeAttribute?.("src");
+        audio.srcObject = null;
+        audio.load();
+      } catch {
+        // Releasing a detached media element is best-effort.
+      }
+    }
     audio = null;
     source = null;
     buffer = null;
@@ -269,7 +283,8 @@ function Gapless5Source(parentPlayer, parentLog, inAudioPath) {
     } else if (
       audio !== null &&
       queuedState === Gapless5State.None &&
-      this.inPlayState(true)
+      this.inPlayState(true) &&
+      player.switchToWebAudioDuringPlayback
     ) {
       log.debug(`Switching from HTML5 to WebAudio: ${this.audioPath}`);
       setState(Gapless5State.Stop);
@@ -455,7 +470,7 @@ function Gapless5Source(parentPlayer, parentLog, inAudioPath) {
             if (!webAudioSwitched) {
               player.onplay(this.audioPath);
             }
-            if (audio) {
+            if (audio && crossfadeOut > 0) {
               setEndedCallbackTime(audio.duration - offsetSec);
             }
           } else if (audio) {
@@ -849,6 +864,7 @@ function Gapless5FileList(
   inLoadLimit = -1,
   inTracks = [],
   inStartingTrack = 0,
+  inDeferAdjacentLoadsUntilBufferedSeconds = 0,
 ) {
   const player = parentPlayer;
   const log = parentLog;
@@ -866,6 +882,11 @@ function Gapless5FileList(
   this.shuffleRequest = null;
   this.preserveCurrent = true;
   this.loadLimit = inLoadLimit;
+  this.deferAdjacentLoadsUntilBufferedSeconds = Math.max(
+    0,
+    Number(inDeferAdjacentLoadsUntilBufferedSeconds) || 0,
+  );
+  this.adjacentLoadsReady = this.deferAdjacentLoadsUntilBufferedSeconds === 0;
 
   // PRIVATE METHODS
 
@@ -928,6 +949,7 @@ function Gapless5FileList(
     this.trackNumber = allowOverride
       ? updateShuffle(requestedIndex)
       : requestedIndex;
+    this.adjacentLoadsReady = this.deferAdjacentLoadsUntilBufferedSeconds === 0;
     log.debug(`Setting track number to ${this.trackNumber}`);
     this.updateLoading();
     player.scrub(0, true);
@@ -1099,11 +1121,12 @@ function Gapless5FileList(
 
   // returns set of actual indices (not shuffled)
   this.loadableTracks = () => {
+    const effectiveLoadLimit = this.adjacentLoadsReady ? this.loadLimit : 1;
     const loadableIndices = new Set(
       getLoadableTrackIndices(
         this.trackNumber,
         this.sources.length,
-        this.loadLimit,
+        effectiveLoadLimit,
       ),
     );
     if (player.queuedTrack !== null) {
@@ -1114,6 +1137,34 @@ function Gapless5FileList(
     }
     log.debug(`Loadable indices: ${JSON.stringify([...loadableIndices])}`);
     return loadableIndices;
+  };
+
+  this.maybeUnlockAdjacentLoading = () => {
+    if (this.adjacentLoadsReady || this.loadLimit === 1) {
+      return;
+    }
+    const source = this.currentSource();
+    if (!source) {
+      return;
+    }
+    const durationSeconds = source.getLength() / 1000;
+    const remainingSeconds = Math.max(
+      0,
+      durationSeconds - source.getPosition() / 1000,
+    );
+    const requiredBufferSeconds =
+      Number.isFinite(durationSeconds) && durationSeconds > 0
+        ? Math.min(
+            this.deferAdjacentLoadsUntilBufferedSeconds,
+            Math.max(1, durationSeconds / 2),
+            Math.max(3, remainingSeconds / 2),
+          )
+        : this.deferAdjacentLoadsUntilBufferedSeconds;
+    if (source.getBufferedAheadSeconds() < requiredBufferSeconds) {
+      return;
+    }
+    this.adjacentLoadsReady = true;
+    this.updateLoading();
   };
 
   this.updateLoading = () => {
@@ -1232,6 +1283,8 @@ function Gapless5FileList(
  *   useHTML5Audio (default = true)
  *   startingTrack (number or "random", default = 0)
  *   loadLimit (max number of tracks loaded at one time, default = -1, no limit)
+ *   deferAdjacentLoadsUntilBufferedSeconds (keep one live request until the
+ *     active HTML5 source has this much audio buffered, default = 0)
  *   logLevel (default = LogLevel.Info) minimum logging level
  *   shuffle (true or false): start the jukebox in shuffle mode
  *   shuffleButton (default = true): whether shuffle button appears or not in UI
@@ -1307,6 +1360,8 @@ function Gapless5(options = {}, deprecated = {}) {
   this.crossfade = options.crossfade || 0;
   this.crossfadeShape = options.crossfadeShape || CrossfadeShape.None;
   this.analyserPrecision = options.analyserPrecision || null;
+  this.switchToWebAudioDuringPlayback =
+    options.switchToWebAudioDuringPlayback !== false;
 
   // This is a hack to activate WebAudio on certain iOS versions
   const silenceWavData =
@@ -2174,6 +2229,7 @@ function Gapless5(options = {}, deprecated = {}) {
     const source = this.currentSource();
     if (source) {
       const loadedSpan = source.tick(true);
+      this.playlist.maybeUnlockAdjacentLoading();
       this.setLoadedSpan(loadedSpan);
       if (this.uiDirty) {
         this.uiDirty = false;
@@ -2353,6 +2409,7 @@ function Gapless5(options = {}, deprecated = {}) {
       options.loadLimit,
       items,
       startingTrack,
+      options.deferAdjacentLoadsUntilBufferedSeconds,
     );
   } else {
     this.playlist = new Gapless5FileList(
@@ -2360,6 +2417,9 @@ function Gapless5(options = {}, deprecated = {}) {
       log,
       options.shuffle,
       options.loadLimit,
+      [],
+      0,
+      options.deferAdjacentLoadsUntilBufferedSeconds,
     );
   }
 

--- a/app/listen/src/types/gapless5.d.ts
+++ b/app/listen/src/types/gapless5.d.ts
@@ -9,6 +9,8 @@ declare module "@/lib/gapless5/gapless5" {
     useHTML5Audio?: boolean;
     useWebAudio?: boolean;
     loadLimit?: number | null;
+    deferAdjacentLoadsUntilBufferedSeconds?: number;
+    switchToWebAudioDuringPlayback?: boolean;
     volume?: number;
     crossfade?: number;
     // Runtime values: None=1, Linear=2, EqualPower=3

--- a/app/tests/test_db.py
+++ b/app/tests/test_db.py
@@ -2851,6 +2851,63 @@ class TestLibraryCRUD:
         assert album["entity_uid"] is not None
         assert album["storage_id"] is None
 
+    def test_upsert_album_prefers_exact_path_over_shared_external_ids(self, pg_db):
+        from crate.db.tx import transaction_scope
+
+        pg_db.upsert_artist({"name": "Amenra"})
+        original_id = pg_db.upsert_album(
+            {
+                "artist": "Amenra",
+                "name": "Mass I",
+                "path": "/music/Amenra/Mass I",
+                "track_count": 5,
+            }
+        )
+        remastered_id = pg_db.upsert_album(
+            {
+                "artist": "Amenra",
+                "name": "Mass I (Remastered)",
+                "path": "/music/Amenra/Mass I (Remastered)",
+                "track_count": 0,
+            }
+        )
+        shared_release_mbid = str(uuid4())
+        shared_release_group_mbid = str(uuid4())
+        with transaction_scope() as session:
+            session.execute(
+                text(
+                    """
+                    UPDATE library_albums
+                    SET musicbrainz_albumid = :release_mbid,
+                        musicbrainz_releasegroupid = :release_group_mbid
+                    WHERE id IN (:original_id, :remastered_id)
+                    """
+                ),
+                {
+                    "release_mbid": shared_release_mbid,
+                    "release_group_mbid": shared_release_group_mbid,
+                    "original_id": original_id,
+                    "remastered_id": remastered_id,
+                },
+            )
+
+        updated_id = pg_db.upsert_album(
+            {
+                "artist": "Amenra",
+                "name": "Mass I (Remastered)",
+                "path": "/music/Amenra/Mass I (Remastered)",
+                "track_count": 6,
+                "musicbrainz_albumid": shared_release_mbid,
+                "musicbrainz_releasegroupid": shared_release_group_mbid,
+            }
+        )
+
+        assert updated_id == remastered_id
+        assert pg_db.get_library_album("Amenra", "Mass I")["track_count"] == 5
+        assert (
+            pg_db.get_library_album("Amenra", "Mass I (Remastered)")["track_count"] == 6
+        )
+
     def test_upsert_track(self, pg_db):
         from crate.db.tx import transaction_scope
 

--- a/app/tests/test_deploy_release_commands.py
+++ b/app/tests/test_deploy_release_commands.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import subprocess
 from pathlib import Path
 
+import pytest
 import yaml
 
 
@@ -28,6 +29,91 @@ def test_deploy_version_forwards_one_commit_to_the_release_script() -> None:
 
     assert "DEPLOY_VERSION='0123456789abcdef0123456789abcdef01234567'" in output
     assert "scripts/deploy.sh deploy" in output
+
+
+def test_build_workflow_promotes_a_complete_manifest_after_selective_builds() -> None:
+    workflow = (ROOT / ".github/workflows/build-images.yml").read_text()
+
+    assert "concurrency:" in workflow
+    assert "changes:" in workflow
+    assert "promote-release:" in workflow
+    assert "args=(detect --head" in workflow
+    assert 'scripts/release_manifest.py "${args[@]}"' in workflow
+    assert "scripts/release_manifest.py assemble" in workflow
+    assert "crate-release-manifest:stable" in workflow
+    assert "steps.build.outputs.digest" in workflow
+    assert "needs: changes" in workflow
+    assert "type=raw,value=latest" not in workflow
+    assert "artifact-metadata: write" in workflow
+    assert "Promote release manifest to stable" in workflow
+    assert workflow.index("Attest release manifest") < workflow.index(
+        "Promote release manifest to stable"
+    )
+
+
+@pytest.mark.parametrize(
+    ("compose_name", "service_name", "image_variable"),
+    [
+        ("docker-compose.yaml", "crate-api", "CRATE_API_IMAGE"),
+        ("docker-compose.yaml", "crate-readplane", "CRATE_READPLANE_IMAGE"),
+        ("docker-compose.yaml", "crate-worker", "CRATE_WORKER_IMAGE"),
+        ("docker-compose.yaml", "crate-projector", "CRATE_WORKER_IMAGE"),
+        ("docker-compose.yaml", "crate-maintenance-worker", "CRATE_WORKER_IMAGE"),
+        (
+            "docker-compose.yaml",
+            "crate-analysis-worker",
+            "CRATE_ANALYSIS_WORKER_IMAGE",
+        ),
+        (
+            "docker-compose.yaml",
+            "crate-playback-worker",
+            "CRATE_PLAYBACK_WORKER_IMAGE",
+        ),
+        ("docker-compose.yaml", "crate-media-worker", "CRATE_MEDIA_WORKER_IMAGE"),
+        ("docker-compose.yaml", "crate-ui", "CRATE_UI_IMAGE"),
+        ("docker-compose.yaml", "crate-listen", "CRATE_LISTEN_IMAGE"),
+        ("docker-compose.project.yaml", "crate-site", "CRATE_SITE_IMAGE"),
+        ("docker-compose.project.yaml", "crate-docs", "CRATE_DOCS_IMAGE"),
+        (
+            "docker-compose.home.yaml",
+            "crate-media-worker",
+            "CRATE_MEDIA_WORKER_IMAGE",
+        ),
+        ("docker-compose.home.yaml", "crate-api", "CRATE_API_IMAGE"),
+        (
+            "docker-compose.home.yaml",
+            "crate-readplane",
+            "CRATE_READPLANE_IMAGE",
+        ),
+        ("docker-compose.home.yaml", "crate-worker", "CRATE_WORKER_IMAGE"),
+        ("docker-compose.home.yaml", "crate-projector", "CRATE_WORKER_IMAGE"),
+        (
+            "docker-compose.home.yaml",
+            "crate-maintenance-worker",
+            "CRATE_WORKER_IMAGE",
+        ),
+        (
+            "docker-compose.home.yaml",
+            "crate-analysis-worker",
+            "CRATE_ANALYSIS_WORKER_IMAGE",
+        ),
+        (
+            "docker-compose.home.yaml",
+            "crate-playback-worker",
+            "CRATE_PLAYBACK_WORKER_IMAGE",
+        ),
+        ("docker-compose.home.yaml", "crate-ui", "CRATE_UI_IMAGE"),
+        ("docker-compose.home.yaml", "crate-listen", "CRATE_LISTEN_IMAGE"),
+    ],
+)
+def test_compose_supports_independent_immutable_image_references(
+    compose_name: str, service_name: str, image_variable: str
+) -> None:
+    compose = yaml.safe_load((ROOT / compose_name).read_text())
+    image = compose["services"][service_name]["image"]
+
+    assert image.startswith(f"${{{image_variable}:-")
+    assert "${CRATE_IMAGE_TAG:-latest}" in image
 
 
 def test_deploy_preflight_uses_the_same_versioned_release_contract() -> None:
@@ -61,6 +147,46 @@ def test_deploy_cannot_bypass_remote_release_preflight() -> None:
     assert deploy_body.index("remote_deploy release-preflight") < deploy_body.index(
         "remote_deploy backup"
     )
+
+
+def test_local_deploy_resolves_and_stages_an_immutable_release_manifest() -> None:
+    script = (ROOT / "scripts/deploy.sh").read_text()
+
+    assert "crate-release-manifest:${DEPLOY_IMAGE_SHA}" in script
+    assert "fetch_release_manifest" in script
+    assert 'scripts/release_manifest.py" validate' in script
+    assert 'scripts/release_manifest.py" env' in script
+    assert '"$TMP_DIR/release-manifest.json"' in script
+    assert '"$TMP_DIR/release.env"' in script
+    assert 'scripts/release_manifest.py" refs' in script
+
+
+def test_remote_deploy_only_pulls_and_restarts_changed_release_services() -> None:
+    script = (ROOT / "scripts/deploy-remote.sh").read_text()
+    config_body = script[script.index("cmd_config() {") : script.index("cmd_pull() {")]
+    pull_body = script[script.index("cmd_pull() {") : script.index("cmd_up() {")]
+    up_body = script[script.index("cmd_up() {") : script.index("cmd_verify() {")]
+
+    assert "record_changed_release_services" in config_body
+    assert "changed_image_refs" in pull_body
+    assert "PROJECT_IMAGES" not in pull_body
+    assert "changed_services" in up_body
+    assert "--no-deps" in up_body
+
+
+def test_image_rollback_restores_only_the_services_changed_by_the_release() -> None:
+    script = (ROOT / "scripts/deploy-remote.sh").read_text()
+    rollback_body = script[
+        script.index("cmd_rollback() {") : script.index("cmd_state_rollback() {")
+    ]
+    makefile = (ROOT / "Makefile").read_text()
+
+    assert "changed_services" in rollback_body
+    assert "--no-deps" in rollback_body
+    assert "release-manifest.json" in rollback_body
+    assert "deploy-image-rollback:" in makefile
+    assert 'test "$(CONFIRM)" = "rollback-images"' in makefile
+    assert "scripts/deploy.sh image-rollback" in makefile
 
 
 def test_production_compose_propagates_federation_identity_and_secrets() -> None:
@@ -137,6 +263,7 @@ def test_remote_recovery_snapshot_captures_database_and_durable_redis() -> None:
     )
     assert "chmod 600 /backup/redis-durable.tar.gz" in snapshot_body
     assert "docker-compose.yaml" in snapshot_body
+    assert ".deploy/release-manifest.json" in snapshot_body
     assert "recovery.env" in snapshot_body
     assert 'sha256sum "${checksum_files[@]}"' in snapshot_body
     assert "recovery_complete" in script

--- a/app/tests/test_release_manifest.py
+++ b/app/tests/test_release_manifest.py
@@ -1,0 +1,167 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+from copy import deepcopy
+from pathlib import Path
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[2]
+SPEC = importlib.util.spec_from_file_location(
+    "crate_release_manifest", ROOT / "scripts/release_manifest.py"
+)
+assert SPEC is not None and SPEC.loader is not None
+release_manifest = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = release_manifest
+SPEC.loader.exec_module(release_manifest)
+
+IMAGE_SPECS = release_manifest.IMAGE_SPECS
+ManifestError = release_manifest.ManifestError
+assemble_manifest = release_manifest.assemble_manifest
+detect_changed_images = release_manifest.detect_changed_images
+render_release_env = release_manifest.render_release_env
+validate_manifest = release_manifest.validate_manifest
+
+
+RELEASE_SHA = "b" * 40
+PREVIOUS_SHA = "a" * 40
+
+
+def _previous_manifest() -> dict:
+    images = {}
+    for index, (name, spec) in enumerate(IMAGE_SPECS.items(), start=1):
+        digest = f"sha256:{index:064x}"
+        images[name] = {
+            "repository": f"ghcr.io/thecrateapp/{spec.repository}",
+            "digest": digest,
+            "source_sha": PREVIOUS_SHA,
+            "environment": spec.environment,
+            "services": list(spec.services),
+        }
+    return {
+        "schema_version": 1,
+        "release_sha": PREVIOUS_SHA,
+        "images": images,
+    }
+
+
+def test_listen_change_only_selects_listen_image() -> None:
+    assert detect_changed_images(["app/listen/src/App.tsx"]) == {"listen"}
+
+
+def test_shared_frontend_change_selects_every_shared_consumer() -> None:
+    assert detect_changed_images(["app/shared/web/api.ts"]) == {
+        "docs",
+        "listen",
+        "site",
+        "ui",
+    }
+
+
+def test_backend_change_selects_backend_compatibility_group() -> None:
+    assert detect_changed_images(["app/crate/api/catalog.py"]) == {
+        "analysis-worker",
+        "api",
+        "playback-worker",
+        "worker",
+    }
+
+
+@pytest.mark.parametrize(
+    ("path", "expected"),
+    [
+        ("app/media-worker/src/main.rs", {"media-worker"}),
+        ("app/readplane/internal/server/server.go", {"readplane"}),
+        (
+            "app/Dockerfile",
+            {
+                "analysis-worker",
+                "api",
+                "media-worker",
+                "playback-worker",
+                "worker",
+            },
+        ),
+        (".github/workflows/build-images.yml", set(IMAGE_SPECS)),
+    ],
+)
+def test_change_classifier_covers_independent_build_inputs(
+    path: str, expected: set[str]
+) -> None:
+    assert detect_changed_images([path]) == expected
+
+
+def test_manual_backend_request_expands_compatibility_group() -> None:
+    assert detect_changed_images([], requested="backend") == {
+        "analysis-worker",
+        "api",
+        "playback-worker",
+        "worker",
+    }
+
+
+def test_assemble_manifest_replaces_changed_digest_and_preserves_others() -> None:
+    previous = _previous_manifest()
+    listen_digest = f"sha256:{999:064x}"
+
+    manifest = assemble_manifest(
+        release_sha=RELEASE_SHA,
+        registry="ghcr.io",
+        owner="thecrateapp",
+        previous=previous,
+        changed_digests={"listen": listen_digest},
+    )
+
+    assert manifest["release_sha"] == RELEASE_SHA
+    assert manifest["images"]["listen"]["digest"] == listen_digest
+    assert manifest["images"]["listen"]["source_sha"] == RELEASE_SHA
+    assert manifest["images"]["api"] == previous["images"]["api"]
+    validate_manifest(manifest, expected_release_sha=RELEASE_SHA)
+
+
+def test_assemble_manifest_requires_every_image_without_previous_release() -> None:
+    with pytest.raises(ManifestError, match="missing image"):
+        assemble_manifest(
+            release_sha=RELEASE_SHA,
+            registry="ghcr.io",
+            owner="thecrateapp",
+            previous=None,
+            changed_digests={"listen": f"sha256:{999:064x}"},
+        )
+
+
+def test_validation_rejects_repository_or_digest_tampering() -> None:
+    manifest = assemble_manifest(
+        release_sha=RELEASE_SHA,
+        registry="ghcr.io",
+        owner="thecrateapp",
+        previous=_previous_manifest(),
+        changed_digests={},
+    )
+    tampered_repository = deepcopy(manifest)
+    tampered_repository["images"]["listen"]["repository"] = "evil.invalid/listen"
+    with pytest.raises(ManifestError, match="repository"):
+        validate_manifest(tampered_repository, expected_release_sha=RELEASE_SHA)
+
+    tampered_digest = deepcopy(manifest)
+    tampered_digest["images"]["listen"]["digest"] = "latest"
+    with pytest.raises(ManifestError, match="digest"):
+        validate_manifest(tampered_digest, expected_release_sha=RELEASE_SHA)
+
+
+def test_release_environment_uses_immutable_digest_references() -> None:
+    manifest = assemble_manifest(
+        release_sha=RELEASE_SHA,
+        registry="ghcr.io",
+        owner="thecrateapp",
+        previous=_previous_manifest(),
+        changed_digests={},
+    )
+
+    rendered = render_release_env(manifest)
+
+    assert f"CRATE_RELEASE_SHA={RELEASE_SHA}" in rendered
+    assert "CRATE_LISTEN_IMAGE=ghcr.io/thecrateapp/crate-listen@sha256:" in rendered
+    assert ":latest" not in rendered

--- a/docker-compose.home.yaml
+++ b/docker-compose.home.yaml
@@ -209,7 +209,7 @@ services:
 
   crate-media-worker:
     logging: *default-logging
-    image: ${CRATE_IMAGE_REGISTRY:-ghcr.io}/${CRATE_IMAGE_OWNER:-thecrateapp}/crate-media-worker:${CRATE_IMAGE_TAG:-latest}
+    image: ${CRATE_MEDIA_WORKER_IMAGE:-${CRATE_IMAGE_REGISTRY:-ghcr.io}/${CRATE_IMAGE_OWNER:-thecrateapp}/crate-media-worker:${CRATE_IMAGE_TAG:-latest}}
     container_name: crate-media-worker
     restart: unless-stopped
     user: ${PUID:-1000}:${PGID:-1000}
@@ -232,7 +232,7 @@ services:
 
   crate-api:
     logging: *default-logging
-    image: ${CRATE_IMAGE_REGISTRY:-ghcr.io}/${CRATE_IMAGE_OWNER:-thecrateapp}/crate-api:${CRATE_IMAGE_TAG:-latest}
+    image: ${CRATE_API_IMAGE:-${CRATE_IMAGE_REGISTRY:-ghcr.io}/${CRATE_IMAGE_OWNER:-thecrateapp}/crate-api:${CRATE_IMAGE_TAG:-latest}}
     container_name: crate-api
     restart: unless-stopped
     user: ${PUID:-1000}:${PGID:-1000}
@@ -294,7 +294,7 @@ services:
 
   crate-readplane:
     logging: *default-logging
-    image: ${CRATE_IMAGE_REGISTRY:-ghcr.io}/${CRATE_IMAGE_OWNER:-thecrateapp}/crate-readplane:${CRATE_IMAGE_TAG:-latest}
+    image: ${CRATE_READPLANE_IMAGE:-${CRATE_IMAGE_REGISTRY:-ghcr.io}/${CRATE_IMAGE_OWNER:-thecrateapp}/crate-readplane:${CRATE_IMAGE_TAG:-latest}}
     container_name: crate-readplane
     restart: unless-stopped
     environment:
@@ -373,7 +373,7 @@ services:
 
   crate-worker:
     logging: *default-logging
-    image: ${CRATE_IMAGE_REGISTRY:-ghcr.io}/${CRATE_IMAGE_OWNER:-thecrateapp}/crate-worker:${CRATE_IMAGE_TAG:-latest}
+    image: ${CRATE_WORKER_IMAGE:-${CRATE_IMAGE_REGISTRY:-ghcr.io}/${CRATE_IMAGE_OWNER:-thecrateapp}/crate-worker:${CRATE_IMAGE_TAG:-latest}}
     container_name: crate-worker
     restart: unless-stopped
     user: ${PUID:-1000}:${PGID:-1000}
@@ -453,7 +453,7 @@ services:
 
   crate-projector:
     logging: *default-logging
-    image: ${CRATE_IMAGE_REGISTRY:-ghcr.io}/${CRATE_IMAGE_OWNER:-thecrateapp}/crate-worker:${CRATE_IMAGE_TAG:-latest}
+    image: ${CRATE_WORKER_IMAGE:-${CRATE_IMAGE_REGISTRY:-ghcr.io}/${CRATE_IMAGE_OWNER:-thecrateapp}/crate-worker:${CRATE_IMAGE_TAG:-latest}}
     container_name: crate-projector
     restart: unless-stopped
     user: ${PUID:-1000}:${PGID:-1000}
@@ -485,7 +485,7 @@ services:
 
   crate-maintenance-worker:
     logging: *default-logging
-    image: ${CRATE_IMAGE_REGISTRY:-ghcr.io}/${CRATE_IMAGE_OWNER:-thecrateapp}/crate-worker:${CRATE_IMAGE_TAG:-latest}
+    image: ${CRATE_WORKER_IMAGE:-${CRATE_IMAGE_REGISTRY:-ghcr.io}/${CRATE_IMAGE_OWNER:-thecrateapp}/crate-worker:${CRATE_IMAGE_TAG:-latest}}
     container_name: crate-maintenance-worker
     restart: unless-stopped
     user: ${PUID:-1000}:${PGID:-1000}
@@ -533,7 +533,7 @@ services:
 
   crate-analysis-worker:
     logging: *default-logging
-    image: ${CRATE_IMAGE_REGISTRY:-ghcr.io}/${CRATE_IMAGE_OWNER:-thecrateapp}/crate-analysis-worker:${CRATE_IMAGE_TAG:-latest}
+    image: ${CRATE_ANALYSIS_WORKER_IMAGE:-${CRATE_IMAGE_REGISTRY:-ghcr.io}/${CRATE_IMAGE_OWNER:-thecrateapp}/crate-analysis-worker:${CRATE_IMAGE_TAG:-latest}}
     container_name: crate-analysis-worker
     restart: unless-stopped
     user: ${PUID:-1000}:${PGID:-1000}
@@ -573,7 +573,7 @@ services:
 
   crate-playback-worker:
     logging: *default-logging
-    image: ${CRATE_IMAGE_REGISTRY:-ghcr.io}/${CRATE_IMAGE_OWNER:-thecrateapp}/crate-playback-worker:${CRATE_IMAGE_TAG:-latest}
+    image: ${CRATE_PLAYBACK_WORKER_IMAGE:-${CRATE_IMAGE_REGISTRY:-ghcr.io}/${CRATE_IMAGE_OWNER:-thecrateapp}/crate-playback-worker:${CRATE_IMAGE_TAG:-latest}}
     container_name: crate-playback-worker
     restart: unless-stopped
     user: ${PUID:-1000}:${PGID:-1000}
@@ -616,7 +616,7 @@ services:
 
   crate-ui:
     logging: *default-logging
-    image: ${CRATE_IMAGE_REGISTRY:-ghcr.io}/${CRATE_IMAGE_OWNER:-thecrateapp}/crate-ui:${CRATE_IMAGE_TAG:-latest}
+    image: ${CRATE_UI_IMAGE:-${CRATE_IMAGE_REGISTRY:-ghcr.io}/${CRATE_IMAGE_OWNER:-thecrateapp}/crate-ui:${CRATE_IMAGE_TAG:-latest}}
     container_name: crate-ui
     restart: unless-stopped
     depends_on:
@@ -637,7 +637,7 @@ services:
 
   crate-listen:
     logging: *default-logging
-    image: ${CRATE_IMAGE_REGISTRY:-ghcr.io}/${CRATE_IMAGE_OWNER:-thecrateapp}/crate-listen:${CRATE_IMAGE_TAG:-latest}
+    image: ${CRATE_LISTEN_IMAGE:-${CRATE_IMAGE_REGISTRY:-ghcr.io}/${CRATE_IMAGE_OWNER:-thecrateapp}/crate-listen:${CRATE_IMAGE_TAG:-latest}}
     container_name: crate-listen
     restart: unless-stopped
     depends_on:

--- a/docker-compose.project.yaml
+++ b/docker-compose.project.yaml
@@ -70,7 +70,7 @@ services:
     mem_limit: 4g
 
   crate-site:
-    image: ${CRATE_IMAGE_REGISTRY:-ghcr.io}/${CRATE_IMAGE_OWNER:-thecrateapp}/crate-site:${CRATE_IMAGE_TAG:-latest}
+    image: ${CRATE_SITE_IMAGE:-${CRATE_IMAGE_REGISTRY:-ghcr.io}/${CRATE_IMAGE_OWNER:-thecrateapp}/crate-site:${CRATE_IMAGE_TAG:-latest}}
     build:
       context: .
       dockerfile: app/site/Dockerfile
@@ -88,7 +88,7 @@ services:
       traefik.http.routers.site.tls.certresolver: letsencrypt
 
   crate-docs:
-    image: ${CRATE_IMAGE_REGISTRY:-ghcr.io}/${CRATE_IMAGE_OWNER:-thecrateapp}/crate-docs:${CRATE_IMAGE_TAG:-latest}
+    image: ${CRATE_DOCS_IMAGE:-${CRATE_IMAGE_REGISTRY:-ghcr.io}/${CRATE_IMAGE_OWNER:-thecrateapp}/crate-docs:${CRATE_IMAGE_TAG:-latest}}
     build:
       context: .
       dockerfile: app/docs/Dockerfile

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -255,7 +255,7 @@ services:
   # Crate — Music stack management
   crate-api:
     logging: *default-logging
-    image: ${CRATE_IMAGE_REGISTRY:-ghcr.io}/${CRATE_IMAGE_OWNER:-thecrateapp}/crate-api:${CRATE_IMAGE_TAG:-latest}
+    image: ${CRATE_API_IMAGE:-${CRATE_IMAGE_REGISTRY:-ghcr.io}/${CRATE_IMAGE_OWNER:-thecrateapp}/crate-api:${CRATE_IMAGE_TAG:-latest}}
     build:
       context: ./app
       target: api
@@ -375,7 +375,7 @@ services:
 
   crate-readplane:
     logging: *default-logging
-    image: ${CRATE_IMAGE_REGISTRY:-ghcr.io}/${CRATE_IMAGE_OWNER:-thecrateapp}/crate-readplane:${CRATE_IMAGE_TAG:-latest}
+    image: ${CRATE_READPLANE_IMAGE:-${CRATE_IMAGE_REGISTRY:-ghcr.io}/${CRATE_IMAGE_OWNER:-thecrateapp}/crate-readplane:${CRATE_IMAGE_TAG:-latest}}
     build:
       context: ./app/readplane
     container_name: crate-readplane
@@ -463,7 +463,7 @@ services:
 
   crate-worker:
     logging: *default-logging
-    image: ${CRATE_IMAGE_REGISTRY:-ghcr.io}/${CRATE_IMAGE_OWNER:-thecrateapp}/crate-worker:${CRATE_IMAGE_TAG:-latest}
+    image: ${CRATE_WORKER_IMAGE:-${CRATE_IMAGE_REGISTRY:-ghcr.io}/${CRATE_IMAGE_OWNER:-thecrateapp}/crate-worker:${CRATE_IMAGE_TAG:-latest}}
     build:
       context: ./app
       target: worker-core
@@ -600,7 +600,7 @@ services:
 
   crate-projector:
     logging: *default-logging
-    image: ${CRATE_IMAGE_REGISTRY:-ghcr.io}/${CRATE_IMAGE_OWNER:-thecrateapp}/crate-worker:${CRATE_IMAGE_TAG:-latest}
+    image: ${CRATE_WORKER_IMAGE:-${CRATE_IMAGE_REGISTRY:-ghcr.io}/${CRATE_IMAGE_OWNER:-thecrateapp}/crate-worker:${CRATE_IMAGE_TAG:-latest}}
     build:
       context: ./app
       target: worker-core
@@ -647,7 +647,7 @@ services:
 
   crate-maintenance-worker:
     logging: *default-logging
-    image: ${CRATE_IMAGE_REGISTRY:-ghcr.io}/${CRATE_IMAGE_OWNER:-thecrateapp}/crate-worker:${CRATE_IMAGE_TAG:-latest}
+    image: ${CRATE_WORKER_IMAGE:-${CRATE_IMAGE_REGISTRY:-ghcr.io}/${CRATE_IMAGE_OWNER:-thecrateapp}/crate-worker:${CRATE_IMAGE_TAG:-latest}}
     build:
       context: ./app
       target: worker-core
@@ -757,7 +757,7 @@ services:
 
   crate-analysis-worker:
     logging: *default-logging
-    image: ${CRATE_IMAGE_REGISTRY:-ghcr.io}/${CRATE_IMAGE_OWNER:-thecrateapp}/crate-analysis-worker:${CRATE_IMAGE_TAG:-latest}
+    image: ${CRATE_ANALYSIS_WORKER_IMAGE:-${CRATE_IMAGE_REGISTRY:-ghcr.io}/${CRATE_IMAGE_OWNER:-thecrateapp}/crate-analysis-worker:${CRATE_IMAGE_TAG:-latest}}
     build:
       context: ./app
       target: worker-analysis
@@ -837,7 +837,7 @@ services:
 
   crate-playback-worker:
     logging: *default-logging
-    image: ${CRATE_IMAGE_REGISTRY:-ghcr.io}/${CRATE_IMAGE_OWNER:-thecrateapp}/crate-playback-worker:${CRATE_IMAGE_TAG:-latest}
+    image: ${CRATE_PLAYBACK_WORKER_IMAGE:-${CRATE_IMAGE_REGISTRY:-ghcr.io}/${CRATE_IMAGE_OWNER:-thecrateapp}/crate-playback-worker:${CRATE_IMAGE_TAG:-latest}}
     build:
       context: ./app
       target: worker-playback
@@ -909,7 +909,7 @@ services:
 
   crate-media-worker:
     logging: *default-logging
-    image: ${CRATE_IMAGE_REGISTRY:-ghcr.io}/${CRATE_IMAGE_OWNER:-thecrateapp}/crate-media-worker:${CRATE_IMAGE_TAG:-latest}
+    image: ${CRATE_MEDIA_WORKER_IMAGE:-${CRATE_IMAGE_REGISTRY:-ghcr.io}/${CRATE_IMAGE_OWNER:-thecrateapp}/crate-media-worker:${CRATE_IMAGE_TAG:-latest}}
     build:
       context: ./app
       target: media-worker
@@ -937,7 +937,7 @@ services:
 
   crate-ui:
     logging: *default-logging
-    image: ${CRATE_IMAGE_REGISTRY:-ghcr.io}/${CRATE_IMAGE_OWNER:-thecrateapp}/crate-ui:${CRATE_IMAGE_TAG:-latest}
+    image: ${CRATE_UI_IMAGE:-${CRATE_IMAGE_REGISTRY:-ghcr.io}/${CRATE_IMAGE_OWNER:-thecrateapp}/crate-ui:${CRATE_IMAGE_TAG:-latest}}
     build:
       context: ./app
       dockerfile: ui/Dockerfile
@@ -958,7 +958,7 @@ services:
 
   crate-listen:
     logging: *default-logging
-    image: ${CRATE_IMAGE_REGISTRY:-ghcr.io}/${CRATE_IMAGE_OWNER:-thecrateapp}/crate-listen:${CRATE_IMAGE_TAG:-latest}
+    image: ${CRATE_LISTEN_IMAGE:-${CRATE_IMAGE_REGISTRY:-ghcr.io}/${CRATE_IMAGE_OWNER:-thecrateapp}/crate-listen:${CRATE_IMAGE_TAG:-latest}}
     build:
       context: ./app
       dockerfile: listen/Dockerfile

--- a/docs/technical/deployment-profiles.md
+++ b/docs/technical/deployment-profiles.md
@@ -58,9 +58,11 @@ it with irreplaceable media or user data.
 ## Project-hosted image-first deployment
 
 `make deploy` delegates to `scripts/deploy.sh`. By default it resolves
-`origin/main`, verifies GHCR manifests for every required image, copies only
-the compose/Traefik deployment payload, creates a remote rollback snapshot,
-pulls images and starts the compose stack with `--no-build`.
+`origin/main`, downloads its complete signed release manifest, verifies every
+immutable GHCR digest and copies only the compose/Traefik deployment payload.
+The remote deploy snapshots the previous release, pulls only changed images
+and recreates only services whose digest or Compose configuration changed.
+Images not rebuilt for a commit remain pinned to their last promoted digest.
 
 The remote profile combines `docker-compose.yaml` and
 `docker-compose.project.yaml`; it includes API, readplane, worker families,
@@ -71,6 +73,11 @@ Migration safety changes rollback semantics: after the updated stack has been
 started, automatic rollback is intentionally disabled because the database may
 already have advanced. Treat a failed post-start verification as a forward-fix
 or restore decision, not as permission to retag older images blindly.
+For a release that did not advance state, use
+`make deploy-image-rollback DEPLOY_ID=<id> CONFIRM=rollback-images` to restore
+only the application services changed by that deployment. The destructive
+`make deploy-rollback ... CONFIRM=restore-production` command remains the
+database and durable-Redis recovery path.
 
 `make deploy-build` and `make deploy-sync` are exceptional/manual workflows.
 Do not replace the image-first flow with a repository-wide `rsync --delete`:
@@ -82,8 +89,8 @@ Before any non-development deployment:
 
 1. Back up PostgreSQL and the deployment `.env`.
 2. Check `docker compose config -q` with the exact compose/profile files.
-3. Confirm music mount ownership, free disk, required secrets and image tags.
-4. Record the previous image tag and migration state.
+3. Confirm music mount ownership, free disk, required secrets and release digests.
+4. Record the previous release manifest and migration state.
 
 After startup, check container health, API status, readplane readiness,
 projector progress, worker queues and an authenticated Admin/Listen request.

--- a/scripts/deploy-remote.sh
+++ b/scripts/deploy-remote.sh
@@ -5,6 +5,7 @@ SERVER_PATH="${SERVER_PATH:?SERVER_PATH is required}"
 DEPLOY_ID="${DEPLOY_ID:?DEPLOY_ID is required}"
 DEPLOY_CANDIDATE_DIR="${DEPLOY_CANDIDATE_DIR:-}"
 DEPLOY_IMAGE_TAG="${DEPLOY_IMAGE_TAG:?DEPLOY_IMAGE_TAG is required}"
+DEPLOY_RELEASE_SHA="${DEPLOY_RELEASE_SHA:-}"
 DEPLOY_IMAGE_OWNER="${DEPLOY_IMAGE_OWNER:-thecrateapp}"
 DEPLOY_IMAGE_REGISTRY="${DEPLOY_IMAGE_REGISTRY:-ghcr.io}"
 DEPLOY_PUBLIC_CHECKS="${DEPLOY_PUBLIC_CHECKS:-1}"
@@ -27,17 +28,18 @@ PROJECT_SERVICES=(crate-api crate-readplane crate-worker crate-projector crate-m
 HEALTHY_SERVICES=(crate-redis crate-postgres crate-api)
 RUNNING_SERVICES=(crate-readplane crate-worker crate-projector crate-maintenance-worker crate-analysis-worker crate-playback-worker crate-media-worker crate-ui crate-listen crate-site crate-docs)
 QUIESCE_SERVICES=(crate-api crate-readplane crate-worker crate-projector crate-maintenance-worker crate-analysis-worker crate-playback-worker crate-media-worker)
-PROJECT_IMAGES=(
-  "${IMAGE_PREFIX}/crate-api"
-  "${IMAGE_PREFIX}/crate-readplane"
-  "${IMAGE_PREFIX}/crate-worker"
-  "${IMAGE_PREFIX}/crate-analysis-worker"
-  "${IMAGE_PREFIX}/crate-playback-worker"
-  "${IMAGE_PREFIX}/crate-media-worker"
-  "${IMAGE_PREFIX}/crate-ui"
-  "${IMAGE_PREFIX}/crate-listen"
-  "${IMAGE_PREFIX}/crate-site"
-  "${IMAGE_PREFIX}/crate-docs"
+RELEASE_ENV_KEYS=(
+  CRATE_RELEASE_SHA
+  CRATE_API_IMAGE
+  CRATE_READPLANE_IMAGE
+  CRATE_WORKER_IMAGE
+  CRATE_ANALYSIS_WORKER_IMAGE
+  CRATE_PLAYBACK_WORKER_IMAGE
+  CRATE_MEDIA_WORKER_IMAGE
+  CRATE_UI_IMAGE
+  CRATE_LISTEN_IMAGE
+  CRATE_SITE_IMAGE
+  CRATE_DOCS_IMAGE
 )
 
 declare -A SERVICE_IMAGE_REPOS=(
@@ -54,6 +56,30 @@ declare -A SERVICE_IMAGE_REPOS=(
   [crate-site]="${IMAGE_PREFIX}/crate-site"
   [crate-docs]="${IMAGE_PREFIX}/crate-docs"
 )
+declare -A RELEASE_ENV_REPOS=(
+  [CRATE_API_IMAGE]="${IMAGE_PREFIX}/crate-api"
+  [CRATE_READPLANE_IMAGE]="${IMAGE_PREFIX}/crate-readplane"
+  [CRATE_WORKER_IMAGE]="${IMAGE_PREFIX}/crate-worker"
+  [CRATE_ANALYSIS_WORKER_IMAGE]="${IMAGE_PREFIX}/crate-analysis-worker"
+  [CRATE_PLAYBACK_WORKER_IMAGE]="${IMAGE_PREFIX}/crate-playback-worker"
+  [CRATE_MEDIA_WORKER_IMAGE]="${IMAGE_PREFIX}/crate-media-worker"
+  [CRATE_UI_IMAGE]="${IMAGE_PREFIX}/crate-ui"
+  [CRATE_LISTEN_IMAGE]="${IMAGE_PREFIX}/crate-listen"
+  [CRATE_SITE_IMAGE]="${IMAGE_PREFIX}/crate-site"
+  [CRATE_DOCS_IMAGE]="${IMAGE_PREFIX}/crate-docs"
+)
+declare -A RELEASE_ENV_SERVICES=(
+  [CRATE_API_IMAGE]="crate-api"
+  [CRATE_READPLANE_IMAGE]="crate-readplane"
+  [CRATE_WORKER_IMAGE]="crate-worker crate-projector crate-maintenance-worker"
+  [CRATE_ANALYSIS_WORKER_IMAGE]="crate-analysis-worker"
+  [CRATE_PLAYBACK_WORKER_IMAGE]="crate-playback-worker"
+  [CRATE_MEDIA_WORKER_IMAGE]="crate-media-worker"
+  [CRATE_UI_IMAGE]="crate-ui"
+  [CRATE_LISTEN_IMAGE]="crate-listen"
+  [CRATE_SITE_IMAGE]="crate-site"
+  [CRATE_DOCS_IMAGE]="crate-docs"
+)
 
 log() {
   printf '\n[remote] %s\n' "$*"
@@ -63,15 +89,21 @@ dc() {
   "${COMPOSE[@]}" "$@"
 }
 
-env_value() {
-  local key="$1"
+env_file_value() {
+  local file="$1"
+  local key="$2"
   local value
-  value="$(grep -E "^${key}=" .env 2>/dev/null | tail -n 1 | cut -d= -f2- || true)"
+  value="$(grep -E "^${key}=" "$file" 2>/dev/null | tail -n 1 | cut -d= -f2- || true)"
   value="${value%\"}"
   value="${value#\"}"
   value="${value%\'}"
   value="${value#\'}"
   printf '%s' "$value"
+}
+
+env_value() {
+  local key="$1"
+  env_file_value .env "$key"
 }
 
 compose_has_service() {
@@ -97,21 +129,81 @@ stop_existing_services() {
   fi
 }
 
-set_env_value() {
-  local key="$1"
-  local value="$2"
+set_env_file_value() {
+  local file="$1"
+  local key="$2"
+  local value="$3"
   local tmp
 
   tmp="$(mktemp)"
-  if [[ -f .env && "$(grep -c -E "^${key}=" .env || true)" -gt 0 ]]; then
-    sed -E "s|^${key}=.*|${key}=${value}|" .env > "$tmp"
+  if [[ -f "$file" && "$(grep -c -E "^${key}=" "$file" || true)" -gt 0 ]]; then
+    sed -E "s|^${key}=.*|${key}=${value}|" "$file" > "$tmp"
   else
-    if [[ -f .env ]]; then
-      cp .env "$tmp"
+    if [[ -f "$file" ]]; then
+      cp "$file" "$tmp"
     fi
     printf '\n%s=%s\n' "$key" "$value" >> "$tmp"
   fi
-  mv "$tmp" .env
+  mv "$tmp" "$file"
+}
+
+set_env_value() {
+  local key="$1"
+  local value="$2"
+  set_env_file_value .env "$key" "$value"
+}
+
+is_release_env_key() {
+  local candidate="$1"
+  local key
+  for key in "${RELEASE_ENV_KEYS[@]}"; do
+    [[ "$candidate" == "$key" ]] && return 0
+  done
+  return 1
+}
+
+validate_release_env_file() {
+  local file="$1"
+  local key
+  local value
+  declare -A seen=()
+
+  test -f "$file"
+  while IFS='=' read -r key value; do
+    [[ -z "$key" ]] && continue
+    if ! is_release_env_key "$key"; then
+      log "Unexpected release environment key: ${key}"
+      return 1
+    fi
+    if [[ -n "${seen[$key]:-}" ]]; then
+      log "Duplicate release environment key: ${key}"
+      return 1
+    fi
+    if [[ "$key" == "CRATE_RELEASE_SHA" ]]; then
+      [[ "$value" =~ ^[0-9a-f]{40}$ ]] || return 1
+    elif [[ ! "$value" =~ ^[^[:space:]]+@sha256:[0-9a-f]{64}$ ]]; then
+      log "Release image reference is not immutable: ${key}"
+      return 1
+    fi
+    seen["$key"]=1
+  done < "$file"
+  for key in "${RELEASE_ENV_KEYS[@]}"; do
+    if [[ -z "${seen[$key]:-}" ]]; then
+      log "Missing release environment key: ${key}"
+      return 1
+    fi
+  done
+}
+
+apply_release_env() {
+  local file="$1"
+  local key
+  local value
+
+  validate_release_env_file "$file"
+  while IFS='=' read -r key value; do
+    [[ -n "$key" ]] && set_env_value "$key" "$value"
+  done < "$file"
 }
 
 assert_compose_redis_auth() {
@@ -182,6 +274,8 @@ cmd_release_preflight() {
   local available_kib
   local backup_running
   local public_api_url
+  local release_env
+  local release_sha
 
   log "Checking production release prerequisites"
   assert_deploy_id
@@ -195,6 +289,14 @@ cmd_release_preflight() {
   fi
   test -f "$DEPLOY_CANDIDATE_DIR/docker-compose.yaml"
   test -f "$DEPLOY_CANDIDATE_DIR/docker-compose.project.yaml"
+  test -f "$DEPLOY_CANDIDATE_DIR/release-manifest.json"
+  release_env="$DEPLOY_CANDIDATE_DIR/release.env"
+  validate_release_env_file "$release_env"
+  release_sha="$(env_file_value "$release_env" CRATE_RELEASE_SHA)"
+  if [[ -n "$DEPLOY_RELEASE_SHA" && "$release_sha" != "$DEPLOY_RELEASE_SHA" ]]; then
+    log "Candidate release SHA does not match the requested release"
+    return 1
+  fi
 
   assert_required_env REDIS_PASSWORD 16
   assert_required_env CRATE_POSTGRES_USER
@@ -226,6 +328,17 @@ cmd_release_preflight() {
   fi
 
   log "Validating candidate compose with the production environment"
+  CRATE_RELEASE_SHA="$release_sha" \
+  CRATE_API_IMAGE="$(env_file_value "$release_env" CRATE_API_IMAGE)" \
+  CRATE_READPLANE_IMAGE="$(env_file_value "$release_env" CRATE_READPLANE_IMAGE)" \
+  CRATE_WORKER_IMAGE="$(env_file_value "$release_env" CRATE_WORKER_IMAGE)" \
+  CRATE_ANALYSIS_WORKER_IMAGE="$(env_file_value "$release_env" CRATE_ANALYSIS_WORKER_IMAGE)" \
+  CRATE_PLAYBACK_WORKER_IMAGE="$(env_file_value "$release_env" CRATE_PLAYBACK_WORKER_IMAGE)" \
+  CRATE_MEDIA_WORKER_IMAGE="$(env_file_value "$release_env" CRATE_MEDIA_WORKER_IMAGE)" \
+  CRATE_UI_IMAGE="$(env_file_value "$release_env" CRATE_UI_IMAGE)" \
+  CRATE_LISTEN_IMAGE="$(env_file_value "$release_env" CRATE_LISTEN_IMAGE)" \
+  CRATE_SITE_IMAGE="$(env_file_value "$release_env" CRATE_SITE_IMAGE)" \
+  CRATE_DOCS_IMAGE="$(env_file_value "$release_env" CRATE_DOCS_IMAGE)" \
   CRATE_IMAGE_TAG="$DEPLOY_IMAGE_TAG" \
   CRATE_IMAGE_OWNER="$DEPLOY_IMAGE_OWNER" \
   CRATE_IMAGE_REGISTRY="$DEPLOY_IMAGE_REGISTRY" \
@@ -404,6 +517,11 @@ cmd_backup() {
       cp -a "$file" "$BACKUP_DIR/$file"
     fi
   done
+  if [[ -f .deploy/release-manifest.json ]]; then
+    mkdir -p "$BACKUP_DIR/.deploy"
+    cp -a .deploy/release-manifest.json \
+      "$BACKUP_DIR/.deploy/release-manifest.json"
+  fi
   if [[ -f deploy/traefik/federation-readplane.yml ]]; then
     mkdir -p "$BACKUP_DIR/deploy/traefik"
     cp -a deploy/traefik/federation-readplane.yml \
@@ -557,6 +675,9 @@ cmd_recovery_snapshot() {
     recovery.env
     recovery_running_services
   )
+  if [[ -f "$BACKUP_DIR/.deploy/release-manifest.json" ]]; then
+    checksum_files+=(.deploy/release-manifest.json)
+  fi
   if [[ -f "$BACKUP_DIR/deploy/traefik/federation-readplane.yml" ]]; then
     checksum_files+=(deploy/traefik/federation-readplane.yml)
   fi
@@ -571,11 +692,57 @@ cmd_recovery_snapshot() {
   log "Run the pinned deploy now, or explicitly restore this recovery set"
 }
 
+record_changed_release_services() {
+  local candidate_env=".deploy/release.env.candidate"
+  local old_env=".env"
+  local force_all=0
+  local key
+  local new_ref
+  local old_ref
+  local service
+  local services=()
+
+  if [[ -f "$BACKUP_DIR/.env" ]]; then
+    old_env="$BACKUP_DIR/.env"
+  fi
+  if ! cmp -s "$BACKUP_DIR/docker-compose.yaml" docker-compose.yaml \
+    || ! cmp -s "$BACKUP_DIR/docker-compose.project.yaml" docker-compose.project.yaml; then
+    force_all=1
+  fi
+
+  : > "$BACKUP_DIR/changed_image_refs"
+  : > "$BACKUP_DIR/changed_services"
+  for key in "${RELEASE_ENV_KEYS[@]}"; do
+    [[ "$key" == "CRATE_RELEASE_SHA" ]] && continue
+    new_ref="$(env_file_value "$candidate_env" "$key")"
+    old_ref="$(env_file_value "$old_env" "$key")"
+    if [[ -z "$old_ref" ]]; then
+      old_ref="${RELEASE_ENV_REPOS[$key]}:$(env_file_value "$old_env" CRATE_IMAGE_TAG)"
+    fi
+    if [[ "$force_all" != "1" && "$new_ref" == "$old_ref" ]]; then
+      continue
+    fi
+    printf '%s\n' "$new_ref" >> "$BACKUP_DIR/changed_image_refs"
+    read -r -a services <<< "${RELEASE_ENV_SERVICES[$key]}"
+    for service in "${services[@]}"; do
+      printf '%s\n' "$service" >> "$BACKUP_DIR/changed_services"
+    done
+  done
+  sort -u -o "$BACKUP_DIR/changed_image_refs" "$BACKUP_DIR/changed_image_refs"
+  sort -u -o "$BACKUP_DIR/changed_services" "$BACKUP_DIR/changed_services"
+}
+
 cmd_config() {
-  log "Validating compose configuration for ${IMAGE_PREFIX}/*:${DEPLOY_IMAGE_TAG}"
+  local candidate_env=".deploy/release.env.candidate"
+
+  log "Validating immutable release configuration"
+  validate_release_env_file "$candidate_env"
+  record_changed_release_services
   set_env_value CRATE_IMAGE_TAG "$DEPLOY_IMAGE_TAG"
   set_env_value CRATE_IMAGE_OWNER "$DEPLOY_IMAGE_OWNER"
   set_env_value CRATE_IMAGE_REGISTRY "$DEPLOY_IMAGE_REGISTRY"
+  apply_release_env "$candidate_env"
+  cp -a .deploy/release-manifest.json.candidate .deploy/release-manifest.json
   dc config -q
   assert_compose_redis_auth
   assert_music_mount_ready
@@ -585,17 +752,24 @@ cmd_pull() {
   local start
   local failures
   local image
+  local changed_image_refs="$BACKUP_DIR/changed_image_refs"
 
-  log "Pulling ${IMAGE_PREFIX} images for tag ${DEPLOY_IMAGE_TAG}"
+  if [[ ! -s "$changed_image_refs" ]]; then
+    log "No application image changed; skipping image pulls"
+    return 0
+  fi
+
+  log "Pulling only immutable images changed by this release"
   start="$SECONDS"
 
   while true; do
     failures=0
-    for image in "${PROJECT_IMAGES[@]}"; do
-      if ! docker pull -q "${image}:${DEPLOY_IMAGE_TAG}" >/dev/null; then
+    while IFS= read -r image; do
+      [[ -z "$image" ]] && continue
+      if ! docker pull -q "$image" >/dev/null; then
         failures=$((failures + 1))
       fi
-    done
+    done < "$changed_image_refs"
 
     if [[ "$failures" -eq 0 ]]; then
       break
@@ -606,36 +780,24 @@ cmd_pull() {
       return 1
     fi
 
-    log "Waiting for GitHub images to become available (${failures} missing)"
+    log "Waiting for ${failures} changed image(s) to become available"
     sleep "$DEPLOY_IMAGE_WAIT_INTERVAL"
   done
-
-  log "Pulling external images"
-  dc pull --ignore-buildable --ignore-pull-failures
-}
-
-ensure_project_images_for_tag() {
-  local tag="$1"
-  local failures=0
-  local image
-
-  for image in "${PROJECT_IMAGES[@]}"; do
-    if docker image inspect "${image}:${tag}" >/dev/null 2>&1; then
-      continue
-    fi
-    if docker pull -q "${image}:${tag}" >/dev/null 2>&1; then
-      continue
-    fi
-    log "Image unavailable for rollback: ${image}:${tag}"
-    failures=$((failures + 1))
-  done
-
-  [[ "$failures" -eq 0 ]]
 }
 
 cmd_up() {
-  log "Starting updated stack without building on the server"
-  dc up -d --no-build --remove-orphans
+  local changed_services="$BACKUP_DIR/changed_services"
+  local services=()
+
+  if [[ -f "$changed_services" ]]; then
+    mapfile -t services < "$changed_services"
+  fi
+  if (( ${#services[@]} == 0 )); then
+    log "No application service changed; leaving the running stack untouched"
+    return 0
+  fi
+  log "Restarting only ${#services[@]} changed application service(s)"
+  dc up -d --no-build --no-deps --remove-orphans "${services[@]}"
 }
 
 cmd_verify() {
@@ -678,8 +840,7 @@ cmd_verify() {
 }
 
 cmd_rollback() {
-  local rollback_tag
-  local target_tag
+  local changed_services="$BACKUP_DIR/changed_services"
   local rollback_services=()
   local service
 
@@ -688,9 +849,14 @@ cmd_rollback() {
     return 1
   fi
 
-  rollback_tag="$(cat "$BACKUP_DIR/rollback_tag" 2>/dev/null || true)"
-  if [[ -z "$rollback_tag" ]]; then
-    rollback_tag="$ROLLBACK_TAG"
+  if [[ -f "$changed_services" ]]; then
+    mapfile -t rollback_services < "$changed_services"
+  else
+    for service in "${PROJECT_SERVICES[@]}"; do
+      if compose_has_service "$service"; then
+        rollback_services+=("$service")
+      fi
+    done
   fi
 
   log "Restoring compose/env from rollback snapshot ${DEPLOY_ID}"
@@ -704,24 +870,24 @@ cmd_rollback() {
     cp -a "$BACKUP_DIR/deploy/traefik/federation-readplane.yml" \
       deploy/traefik/federation-readplane.yml
   fi
-
-  target_tag="$(env_value CRATE_IMAGE_TAG)"
-  if [[ -z "$target_tag" ]]; then
-    target_tag="$rollback_tag"
+  if [[ -f "$BACKUP_DIR/.deploy/release-manifest.json" ]]; then
+    mkdir -p .deploy
+    cp -a "$BACKUP_DIR/.deploy/release-manifest.json" \
+      .deploy/release-manifest.json
+  else
+    rm -f .deploy/release-manifest.json
   fi
-  set_env_value CRATE_IMAGE_TAG "$target_tag"
   dc config -q
 
-  log "Checking rollback images for CRATE_IMAGE_TAG=${target_tag}"
-  ensure_project_images_for_tag "$target_tag"
-
-  log "Restarting previous images with CRATE_IMAGE_TAG=${target_tag}"
-  for service in "${PROJECT_SERVICES[@]}"; do
-    if compose_has_service "$service"; then
-      rollback_services+=("$service")
-    fi
-  done
-  CRATE_IMAGE_TAG="$target_tag" "${COMPOSE[@]}" up -d --no-build --remove-orphans "${rollback_services[@]}"
+  if (( ${#rollback_services[@]} == 0 )); then
+    log "No application service changed; rollback only restored release configuration"
+    DEPLOY_PUBLIC_CHECKS=0 cmd_verify
+    return 0
+  fi
+  log "Restoring ${#rollback_services[@]} service(s) changed by the failed release"
+  dc pull --ignore-buildable "${rollback_services[@]}" >/dev/null 2>&1 || \
+    log "Registry pull failed during rollback; using preserved local images"
+  "${COMPOSE[@]}" up -d --no-build --no-deps --remove-orphans "${rollback_services[@]}"
   DEPLOY_PUBLIC_CHECKS=0 cmd_verify
 }
 
@@ -775,6 +941,13 @@ cmd_state_rollback() {
     cp -a "$BACKUP_DIR/deploy/traefik/federation-readplane.yml" \
       deploy/traefik/federation-readplane.yml
   fi
+  if [[ -f "$BACKUP_DIR/.deploy/release-manifest.json" ]]; then
+    mkdir -p .deploy
+    cp -a "$BACKUP_DIR/.deploy/release-manifest.json" \
+      .deploy/release-manifest.json
+  else
+    rm -f .deploy/release-manifest.json
+  fi
 
   pg_user="$(env_value CRATE_POSTGRES_USER)"
   pg_password="$(env_value CRATE_POSTGRES_PASSWORD)"
@@ -821,15 +994,12 @@ cmd_state_rollback() {
   docker start "$redis_service" >/dev/null
   wait_for_container_healthy "$redis_service"
 
-  target_tag="$(env_value CRATE_IMAGE_TAG)"
-  if [[ -z "$target_tag" ]]; then
-    log "Recovery configuration has no CRATE_IMAGE_TAG"
-    return 1
-  fi
-  ensure_project_images_for_tag "$target_tag"
-
+  target_tag="$(env_value CRATE_RELEASE_SHA)"
+  target_tag="${target_tag:-$(env_value CRATE_IMAGE_TAG)}"
   log "Restarting recovered release ${target_tag}"
-  CRATE_IMAGE_TAG="$target_tag" dc up -d --no-build --remove-orphans
+  dc pull --ignore-buildable "${PROJECT_SERVICES[@]}" >/dev/null 2>&1 || \
+    log "Registry pull failed during state rollback; using preserved local images"
+  dc up -d --no-build --remove-orphans
   DEPLOY_PUBLIC_CHECKS=0 cmd_verify
   log "State rollback ${DEPLOY_ID} completed at schema ${expected_schema}"
 }

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -21,18 +21,6 @@ REMOTE_SCRIPT_PATH="${SERVER_PATH}/.deploy/deploy-remote.sh"
 DEPLOY_CANDIDATE_DIR=""
 TMP_DIR=""
 ROLLBACK_ENABLED=1
-REQUIRED_IMAGE_NAMES=(
-  crate-api
-  crate-readplane
-  crate-worker
-  crate-analysis-worker
-  crate-playback-worker
-  crate-media-worker
-  crate-ui
-  crate-listen
-  crate-site
-  crate-docs
-)
 
 log() {
   printf '\n==> %s\n' "$*"
@@ -61,7 +49,7 @@ ssh_remote() {
 
 remote_deploy() {
   ssh_remote \
-    "SERVER_PATH='$SERVER_PATH' DEPLOY_ID='$DEPLOY_ID' DEPLOY_CANDIDATE_DIR='$DEPLOY_CANDIDATE_DIR' DEPLOY_IMAGE_TAG='$DEPLOY_IMAGE_TAG' DEPLOY_IMAGE_OWNER='$DEPLOY_IMAGE_OWNER' DEPLOY_IMAGE_REGISTRY='$DEPLOY_IMAGE_REGISTRY' DEPLOY_CONFIRM='$DEPLOY_CONFIRM' DEPLOY_PUBLIC_CHECKS='$DEPLOY_PUBLIC_CHECKS' DEPLOY_IMAGE_WAIT_SECONDS='$DEPLOY_IMAGE_WAIT_SECONDS' DEPLOY_IMAGE_WAIT_INTERVAL='$DEPLOY_IMAGE_WAIT_INTERVAL' DEPLOY_HEALTH_WAIT_SECONDS='${DEPLOY_HEALTH_WAIT_SECONDS:-420}' '$REMOTE_SCRIPT_PATH' '$1'"
+    "SERVER_PATH='$SERVER_PATH' DEPLOY_ID='$DEPLOY_ID' DEPLOY_CANDIDATE_DIR='$DEPLOY_CANDIDATE_DIR' DEPLOY_IMAGE_TAG='$DEPLOY_IMAGE_TAG' DEPLOY_RELEASE_SHA='${DEPLOY_IMAGE_SHA:-}' DEPLOY_IMAGE_OWNER='$DEPLOY_IMAGE_OWNER' DEPLOY_IMAGE_REGISTRY='$DEPLOY_IMAGE_REGISTRY' DEPLOY_CONFIRM='$DEPLOY_CONFIRM' DEPLOY_PUBLIC_CHECKS='$DEPLOY_PUBLIC_CHECKS' DEPLOY_IMAGE_WAIT_SECONDS='$DEPLOY_IMAGE_WAIT_SECONDS' DEPLOY_IMAGE_WAIT_INTERVAL='$DEPLOY_IMAGE_WAIT_INTERVAL' DEPLOY_HEALTH_WAIT_SECONDS='${DEPLOY_HEALTH_WAIT_SECONDS:-420}' '$REMOTE_SCRIPT_PATH' '$1'"
 }
 
 env_file_value() {
@@ -175,6 +163,8 @@ stage_remote_preflight_payload() {
   scp \
     "$TMP_DIR/docker-compose.yaml" \
     "$TMP_DIR/docker-compose.project.yaml" \
+    "$TMP_DIR/release-manifest.json" \
+    "$TMP_DIR/release.env" \
     "$REMOTE:$DEPLOY_CANDIDATE_DIR/"
 }
 
@@ -211,16 +201,42 @@ prepare_payload() {
   fi
 
   cp "$ROOT_DIR/.env" "$TMP_DIR/.env"
+  fetch_release_manifest
   set_env_value "$TMP_DIR/.env" CRATE_IMAGE_TAG "$DEPLOY_IMAGE_TAG"
   set_env_value "$TMP_DIR/.env" CRATE_IMAGE_OWNER "$DEPLOY_IMAGE_OWNER"
   set_env_value "$TMP_DIR/.env" CRATE_IMAGE_REGISTRY "$DEPLOY_IMAGE_REGISTRY"
+  while IFS='=' read -r key value; do
+    [[ -n "$key" ]] && set_env_value "$TMP_DIR/.env" "$key" "$value"
+  done < "$TMP_DIR/release.env"
+}
+
+fetch_release_manifest() {
+  local container_id
+  local manifest_image="${DEPLOY_IMAGE_REGISTRY}/${DEPLOY_IMAGE_OWNER}/crate-release-manifest:${DEPLOY_IMAGE_SHA}"
+
+  require_command docker
+  log "Resolving immutable release manifest ${manifest_image}"
+  docker pull -q "$manifest_image" >/dev/null
+  container_id="$(docker create "$manifest_image" true)"
+  if ! docker cp "$container_id:/release-manifest.json" "$TMP_DIR/release-manifest.json"; then
+    docker rm -f "$container_id" >/dev/null 2>&1 || true
+    fail "release manifest image does not contain /release-manifest.json"
+  fi
+  docker rm -f "$container_id" >/dev/null
+
+  "$ROOT_DIR/scripts/release_manifest.py" validate \
+    --manifest "$TMP_DIR/release-manifest.json" \
+    --release-sha "$DEPLOY_IMAGE_SHA" \
+    --registry "$DEPLOY_IMAGE_REGISTRY" \
+    --owner "$DEPLOY_IMAGE_OWNER"
+  "$ROOT_DIR/scripts/release_manifest.py" env \
+    --manifest "$TMP_DIR/release-manifest.json" \
+    --output "$TMP_DIR/release.env"
 }
 
 check_image_manifests() {
   local image
-  local image_name
   local failures=0
-  local prefix="${DEPLOY_IMAGE_REGISTRY}/${DEPLOY_IMAGE_OWNER}"
 
   if [[ "$DEPLOY_SKIP_IMAGE_CHECK" == "1" ]]; then
     log "Skipping local image manifest checks"
@@ -228,18 +244,21 @@ check_image_manifests() {
   fi
 
   require_command docker
-  log "Checking image manifests for ${prefix}/*:${DEPLOY_IMAGE_TAG}"
+  log "Checking every immutable image referenced by the release manifest"
 
-  for image_name in "${REQUIRED_IMAGE_NAMES[@]}"; do
-    image="${prefix}/${image_name}:${DEPLOY_IMAGE_TAG}"
+  while IFS= read -r image; do
+    [[ -z "$image" ]] && continue
     if ! docker manifest inspect "$image" >/dev/null 2>&1; then
       printf 'Missing or inaccessible image: %s\n' "$image" >&2
       failures=$((failures + 1))
     fi
-  done
+  done < <(
+    "$ROOT_DIR/scripts/release_manifest.py" refs \
+      --manifest "$TMP_DIR/release-manifest.json"
+  )
 
   if [[ "$failures" -gt 0 ]]; then
-    fail "${failures} required image manifest(s) are missing or not pullable. Check that the image workflow finished and GHCR packages are public/pullable, or set DEPLOY_SKIP_IMAGE_CHECK=1 only if the remote host is authenticated to the registry."
+    fail "${failures} immutable release image(s) are missing or not pullable. Check that the image workflow promoted the complete release manifest."
   fi
 }
 
@@ -268,7 +287,7 @@ local_preflight() {
   fi
 
   check_image_manifests
-  log "Deploying ${DEPLOY_IMAGE_REGISTRY}/${DEPLOY_IMAGE_OWNER} image tag ${DEPLOY_IMAGE_TAG}${DEPLOY_IMAGE_SHA:+ (${DEPLOY_IMAGE_SHA})}"
+  log "Deploying immutable release ${DEPLOY_IMAGE_SHA} (${DEPLOY_IMAGE_TAG})"
 }
 
 sync_config() {
@@ -280,6 +299,9 @@ sync_config() {
     "$TMP_DIR/docker-compose.project.yaml" \
     "$REMOTE:$SERVER_PATH/"
   scp "$TMP_DIR/.env" "$REMOTE:$SERVER_PATH/.deploy/env.candidate"
+  scp "$TMP_DIR/release.env" "$REMOTE:$SERVER_PATH/.deploy/release.env.candidate"
+  scp "$TMP_DIR/release-manifest.json" \
+    "$REMOTE:$SERVER_PATH/.deploy/release-manifest.json.candidate"
   scp "$TMP_DIR/deploy/traefik/federation-readplane.yml" \
     "$REMOTE:$SERVER_PATH/deploy/traefik/federation-readplane.yml"
   ssh_remote "if [ ! -f '$SERVER_PATH/.env' ]; then cp '$SERVER_PATH/.deploy/env.candidate' '$SERVER_PATH/.env' && chmod 600 '$SERVER_PATH/.env'; fi"
@@ -374,12 +396,24 @@ run_rollback() {
   log "Production rollback ${DEPLOY_ID} completed"
 }
 
+run_image_rollback() {
+  require_deploy_id
+  if [[ "$DEPLOY_CONFIRM" != "rollback-images" ]]; then
+    fail "image-rollback requires DEPLOY_CONFIRM=rollback-images"
+  fi
+  prepare_remote_script
+  resolve_remote_release_settings
+  remote_deploy rollback
+  log "Application image rollback ${DEPLOY_ID} completed"
+}
+
 case "$ACTION" in
   deploy) run_deploy ;;
   preflight) run_preflight ;;
   recovery-snapshot) run_recovery_snapshot ;;
   rollback) run_rollback ;;
+  image-rollback) run_image_rollback ;;
   *)
-    fail "unknown action '${ACTION}' (expected deploy, preflight, recovery-snapshot or rollback)"
+    fail "unknown action '${ACTION}' (expected deploy, preflight, recovery-snapshot, rollback or image-rollback)"
     ;;
 esac

--- a/scripts/release_manifest.py
+++ b/scripts/release_manifest.py
@@ -1,0 +1,410 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import fnmatch
+import json
+import re
+import subprocess
+from copy import deepcopy
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable
+
+
+SCHEMA_VERSION = 1
+SHA_RE = re.compile(r"^[0-9a-f]{40}$")
+DIGEST_RE = re.compile(r"^sha256:[0-9a-f]{64}$")
+GLOBAL_BUILD_PATTERNS = (
+    ".github/workflows/build-images.yml",
+    ".github/actions/**",
+)
+
+
+@dataclass(frozen=True)
+class ImageSpec:
+    repository: str
+    environment: str
+    services: tuple[str, ...]
+    patterns: tuple[str, ...]
+
+
+BACKEND_PATTERNS = (
+    "app/crate/**",
+    "app/scripts/**",
+    "app/bin/**",
+    "app/alembic.ini",
+    "app/requirements-api.txt",
+    "app/Dockerfile",
+    "app/.dockerignore",
+)
+
+IMAGE_SPECS: dict[str, ImageSpec] = {
+    "api": ImageSpec(
+        repository="crate-api",
+        environment="CRATE_API_IMAGE",
+        services=("crate-api",),
+        patterns=BACKEND_PATTERNS,
+    ),
+    "readplane": ImageSpec(
+        repository="crate-readplane",
+        environment="CRATE_READPLANE_IMAGE",
+        services=("crate-readplane",),
+        patterns=("app/readplane/**",),
+    ),
+    "worker": ImageSpec(
+        repository="crate-worker",
+        environment="CRATE_WORKER_IMAGE",
+        services=("crate-worker", "crate-projector", "crate-maintenance-worker"),
+        patterns=(
+            *BACKEND_PATTERNS,
+            "app/requirements-worker-core.txt",
+            "tools/crate-cli/**",
+        ),
+    ),
+    "analysis-worker": ImageSpec(
+        repository="crate-analysis-worker",
+        environment="CRATE_ANALYSIS_WORKER_IMAGE",
+        services=("crate-analysis-worker",),
+        patterns=(
+            *BACKEND_PATTERNS,
+            "app/requirements-worker-core.txt",
+            "app/requirements-worker-analysis.txt",
+            "tools/crate-cli/**",
+        ),
+    ),
+    "playback-worker": ImageSpec(
+        repository="crate-playback-worker",
+        environment="CRATE_PLAYBACK_WORKER_IMAGE",
+        services=("crate-playback-worker",),
+        patterns=BACKEND_PATTERNS,
+    ),
+    "media-worker": ImageSpec(
+        repository="crate-media-worker",
+        environment="CRATE_MEDIA_WORKER_IMAGE",
+        services=("crate-media-worker",),
+        patterns=("app/media-worker/**", "app/Dockerfile", "app/.dockerignore"),
+    ),
+    "ui": ImageSpec(
+        repository="crate-ui",
+        environment="CRATE_UI_IMAGE",
+        services=("crate-ui",),
+        patterns=("app/ui/**", "app/shared/**"),
+    ),
+    "listen": ImageSpec(
+        repository="crate-listen",
+        environment="CRATE_LISTEN_IMAGE",
+        services=("crate-listen",),
+        patterns=("app/listen/**", "app/shared/**"),
+    ),
+    "site": ImageSpec(
+        repository="crate-site",
+        environment="CRATE_SITE_IMAGE",
+        services=("crate-site",),
+        patterns=("app/site/**", "app/shared/**", "install.sh"),
+    ),
+    "docs": ImageSpec(
+        repository="crate-docs",
+        environment="CRATE_DOCS_IMAGE",
+        services=("crate-docs",),
+        patterns=("app/docs/**", "app/shared/**", "docs/**"),
+    ),
+}
+
+REQUEST_ALIASES = {
+    "all": frozenset(IMAGE_SPECS),
+    "backend": frozenset({"api", "worker", "analysis-worker", "playback-worker"}),
+}
+
+
+class ManifestError(ValueError):
+    pass
+
+
+def _matches(path: str, patterns: Iterable[str]) -> bool:
+    return any(fnmatch.fnmatchcase(path, pattern) for pattern in patterns)
+
+
+def detect_changed_images(
+    paths: Iterable[str], *, requested: str | None = None
+) -> set[str]:
+    if requested:
+        selected: set[str] = set()
+        for raw_name in requested.split(","):
+            name = raw_name.strip()
+            if not name:
+                continue
+            if name in REQUEST_ALIASES:
+                selected.update(REQUEST_ALIASES[name])
+                continue
+            if name not in IMAGE_SPECS:
+                raise ManifestError(f"unknown image selection: {name}")
+            selected.add(name)
+        return selected
+
+    normalized_paths = [
+        path.strip()[2:] if path.strip().startswith("./") else path.strip()
+        for path in paths
+        if path.strip()
+    ]
+    if any(_matches(path, GLOBAL_BUILD_PATTERNS) for path in normalized_paths):
+        return set(IMAGE_SPECS)
+    return {
+        name
+        for name, spec in IMAGE_SPECS.items()
+        if any(_matches(path, spec.patterns) for path in normalized_paths)
+    }
+
+
+def _expected_repository(registry: str, owner: str, spec: ImageSpec) -> str:
+    return f"{registry.rstrip('/')}/{owner.strip('/')}/{spec.repository}"
+
+
+def validate_manifest(
+    manifest: dict,
+    *,
+    expected_release_sha: str | None = None,
+    registry: str | None = None,
+    owner: str | None = None,
+) -> None:
+    if manifest.get("schema_version") != SCHEMA_VERSION:
+        raise ManifestError("unsupported manifest schema_version")
+    release_sha = manifest.get("release_sha")
+    if not isinstance(release_sha, str) or not SHA_RE.fullmatch(release_sha):
+        raise ManifestError("release_sha must be a full lowercase commit SHA")
+    if expected_release_sha is not None and release_sha != expected_release_sha:
+        raise ManifestError(
+            f"release_sha {release_sha} does not match {expected_release_sha}"
+        )
+    images = manifest.get("images")
+    if not isinstance(images, dict):
+        raise ManifestError("images must be an object")
+    missing = set(IMAGE_SPECS).difference(images)
+    extra = set(images).difference(IMAGE_SPECS)
+    if missing:
+        raise ManifestError(f"missing image entries: {', '.join(sorted(missing))}")
+    if extra:
+        raise ManifestError(f"unknown image entries: {', '.join(sorted(extra))}")
+
+    repository_prefix: str | None = None
+    for name, spec in IMAGE_SPECS.items():
+        entry = images[name]
+        if not isinstance(entry, dict):
+            raise ManifestError(f"{name} image entry must be an object")
+        repository = entry.get("repository")
+        if not isinstance(repository, str):
+            raise ManifestError(f"{name} repository is missing")
+        expected_repository = (
+            _expected_repository(registry, owner, spec)
+            if registry is not None and owner is not None
+            else None
+        )
+        if expected_repository is not None and repository != expected_repository:
+            raise ManifestError(f"{name} repository does not match release registry")
+        if repository.rsplit("/", 1)[-1] != spec.repository:
+            raise ManifestError(f"{name} repository is invalid")
+        prefix = repository.rsplit("/", 1)[0]
+        if repository_prefix is None:
+            repository_prefix = prefix
+        elif prefix != repository_prefix:
+            raise ManifestError(f"{name} repository uses a different registry owner")
+        digest = entry.get("digest")
+        if not isinstance(digest, str) or not DIGEST_RE.fullmatch(digest):
+            raise ManifestError(f"{name} digest must be a sha256 OCI digest")
+        source_sha = entry.get("source_sha")
+        if not isinstance(source_sha, str) or not SHA_RE.fullmatch(source_sha):
+            raise ManifestError(f"{name} source_sha is invalid")
+        if entry.get("environment") != spec.environment:
+            raise ManifestError(f"{name} environment mapping is invalid")
+        if entry.get("services") != list(spec.services):
+            raise ManifestError(f"{name} service mapping is invalid")
+
+
+def assemble_manifest(
+    *,
+    release_sha: str,
+    registry: str,
+    owner: str,
+    previous: dict | None,
+    changed_digests: dict[str, str],
+) -> dict:
+    if not SHA_RE.fullmatch(release_sha):
+        raise ManifestError("release_sha must be a full lowercase commit SHA")
+    unknown = set(changed_digests).difference(IMAGE_SPECS)
+    if unknown:
+        raise ManifestError(f"unknown changed images: {', '.join(sorted(unknown))}")
+    if previous is not None:
+        validate_manifest(previous, registry=registry, owner=owner)
+
+    images: dict[str, dict] = {}
+    for name, spec in IMAGE_SPECS.items():
+        digest = changed_digests.get(name)
+        if digest is not None:
+            if not DIGEST_RE.fullmatch(digest):
+                raise ManifestError(f"{name} digest must be a sha256 OCI digest")
+            images[name] = {
+                "repository": _expected_repository(registry, owner, spec),
+                "digest": digest,
+                "source_sha": release_sha,
+                "environment": spec.environment,
+                "services": list(spec.services),
+            }
+            continue
+        if previous is None or name not in previous["images"]:
+            raise ManifestError(f"missing image entry for {name}")
+        images[name] = deepcopy(previous["images"][name])
+
+    manifest = {
+        "schema_version": SCHEMA_VERSION,
+        "release_sha": release_sha,
+        "images": images,
+    }
+    validate_manifest(
+        manifest,
+        expected_release_sha=release_sha,
+        registry=registry,
+        owner=owner,
+    )
+    return manifest
+
+
+def render_release_env(manifest: dict) -> str:
+    validate_manifest(manifest)
+    lines = [f"CRATE_RELEASE_SHA={manifest['release_sha']}"]
+    for name, spec in IMAGE_SPECS.items():
+        entry = manifest["images"][name]
+        lines.append(f"{spec.environment}={entry['repository']}@{entry['digest']}")
+    return "\n".join(lines) + "\n"
+
+
+def _load_manifest(path: str | None) -> dict | None:
+    if not path:
+        return None
+    return json.loads(Path(path).read_text(encoding="utf-8"))
+
+
+def _git_changed_paths(base: str | None, head: str) -> list[str]:
+    if not base:
+        return []
+    result = subprocess.run(
+        ["git", "diff", "--name-only", base, head],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return result.stdout.splitlines()
+
+
+def _parse_digest_values(values: list[str]) -> dict[str, str]:
+    parsed: dict[str, str] = {}
+    for value in values:
+        name, separator, digest = value.partition("=")
+        if not separator:
+            raise ManifestError(f"invalid digest assignment: {value}")
+        if digest:
+            parsed[name] = digest
+    return parsed
+
+
+def _write_or_print(value: str, output: str | None) -> None:
+    if output:
+        Path(output).write_text(value, encoding="utf-8")
+    else:
+        print(value, end="")
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser()
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    detect_parser = subparsers.add_parser("detect")
+    detect_parser.add_argument("--base")
+    detect_parser.add_argument("--head", required=True)
+    detect_parser.add_argument("--requested")
+
+    assemble_parser = subparsers.add_parser("assemble")
+    assemble_parser.add_argument("--release-sha", required=True)
+    assemble_parser.add_argument("--registry", required=True)
+    assemble_parser.add_argument("--owner", required=True)
+    assemble_parser.add_argument("--previous")
+    assemble_parser.add_argument("--digest", action="append", default=[])
+    assemble_parser.add_argument("--output", required=True)
+
+    validate_parser = subparsers.add_parser("validate")
+    validate_parser.add_argument("--manifest", required=True)
+    validate_parser.add_argument("--release-sha")
+    validate_parser.add_argument("--registry")
+    validate_parser.add_argument("--owner")
+
+    env_parser = subparsers.add_parser("env")
+    env_parser.add_argument("--manifest", required=True)
+    env_parser.add_argument("--output")
+
+    refs_parser = subparsers.add_parser("refs")
+    refs_parser.add_argument("--manifest", required=True)
+
+    base_parser = subparsers.add_parser("base-sha")
+    base_parser.add_argument("--manifest", required=True)
+    return parser
+
+
+def main() -> int:
+    args = _build_parser().parse_args()
+    if args.command == "detect":
+        if args.requested:
+            selected = detect_changed_images([], requested=args.requested)
+        elif args.base:
+            selected = detect_changed_images(_git_changed_paths(args.base, args.head))
+        else:
+            selected = set(IMAGE_SPECS)
+        for name in IMAGE_SPECS:
+            output_name = name.replace("-", "_")
+            print(f"{output_name}={'true' if name in selected else 'false'}")
+        print(f"any={'true' if selected else 'false'}")
+        return 0
+    if args.command == "assemble":
+        manifest = assemble_manifest(
+            release_sha=args.release_sha,
+            registry=args.registry,
+            owner=args.owner,
+            previous=_load_manifest(args.previous),
+            changed_digests=_parse_digest_values(args.digest),
+        )
+        _write_or_print(
+            json.dumps(manifest, indent=2, sort_keys=True) + "\n", args.output
+        )
+        return 0
+    if args.command == "validate":
+        manifest = _load_manifest(args.manifest)
+        assert manifest is not None
+        validate_manifest(
+            manifest,
+            expected_release_sha=args.release_sha,
+            registry=args.registry,
+            owner=args.owner,
+        )
+        return 0
+    if args.command == "env":
+        manifest = _load_manifest(args.manifest)
+        assert manifest is not None
+        _write_or_print(render_release_env(manifest), args.output)
+        return 0
+    if args.command == "refs":
+        manifest = _load_manifest(args.manifest)
+        assert manifest is not None
+        validate_manifest(manifest)
+        for name in IMAGE_SPECS:
+            entry = manifest["images"][name]
+            print(f"{entry['repository']}@{entry['digest']}")
+        return 0
+    if args.command == "base-sha":
+        manifest = _load_manifest(args.manifest)
+        assert manifest is not None
+        validate_manifest(manifest)
+        print(manifest["release_sha"])
+        return 0
+    raise AssertionError(f"unhandled command: {args.command}")
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

- stabilizes mobile/WebView queue handoffs, MediaSession ownership, adjacent-track preload, and AudioContext resume
- preserves distinct local albums when multiple paths share MusicBrainz release identifiers
- publishes immutable, complete per-service release manifests and deploys or rolls back only changed services

## Root causes fixed

- native and browser playback lifecycle handlers could compete at track boundaries, while the adjacent source window was too small for degraded connections
- album upsert lookup used an OR identity match, allowing a shared external ID to select the wrong local path
- a shared image tag forced every service to rebuild and restart for unrelated changes

## Validation

- Listen: 1,543 Vitest cases passed, 4 skipped; ESLint, TypeScript, i18n and production/Capacitor builds passed
- Android: Gradle unit tests passed on Java 21
- backend: PostgreSQL album identity regression tests passed
- deploy: 53 manifest/deploy tests passed; actionlint, ShellCheck, compose validation and scratch-manifest extraction passed

## Rollout and rollback

The first successful main build bootstraps all immutable image references because no stable manifest exists yet. Later builds are selective. Production deploys the exact merge SHA manifest. Image rollback restores only changed service references; full state recovery remains available separately.

After deployment, the affected Amenra library sync and catalog reconciliation will be checked before publishing v2.3.2-beta.