### PR TITLE
fix(deploy): support arm64 release operators

### DIFF
--- a/app/tests/test_deploy_release_commands.py
+++ b/app/tests/test_deploy_release_commands.py
@@ -51,6 +51,28 @@ def test_build_workflow_promotes_a_complete_manifest_after_selective_builds() ->
     )
 
 
+def test_deploy_extracts_release_manifest_for_production_platform() -> None:
+    deploy_script = (ROOT / "scripts/deploy.sh").read_text()
+
+    assert (
+        'docker pull -q --platform "$DEPLOY_IMAGE_PLATFORM" "$manifest_image"'
+        in deploy_script
+    )
+    assert (
+        'docker create --platform "$DEPLOY_IMAGE_PLATFORM" "$manifest_image" true'
+        in deploy_script
+    )
+
+
+def test_deploy_builds_candidate_from_the_remote_production_environment() -> None:
+    deploy_script = (ROOT / "scripts/deploy.sh").read_text()
+
+    assert 'scp "$REMOTE:$SERVER_PATH/.env" "$TMP_DIR/.env"' in deploy_script
+    assert 'chmod 600 "$TMP_DIR/.env"' in deploy_script
+    assert 'cp "$ROOT_DIR/.env" "$TMP_DIR/.env"' not in deploy_script
+    assert 'test -f "$ROOT_DIR/.env"' not in deploy_script
+
+
 @pytest.mark.parametrize(
     ("compose_name", "service_name", "image_variable"),
     [

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -13,6 +13,7 @@ DEPLOY_REF="${DEPLOY_REF:-origin/main}"
 DEPLOY_CONFIRM="${DEPLOY_CONFIRM:-}"
 DEPLOY_IMAGE_OWNER="${DEPLOY_IMAGE_OWNER:-}"
 DEPLOY_IMAGE_REGISTRY="${DEPLOY_IMAGE_REGISTRY:-}"
+DEPLOY_IMAGE_PLATFORM="${DEPLOY_IMAGE_PLATFORM:-linux/amd64}"
 DEPLOY_PUBLIC_CHECKS="${DEPLOY_PUBLIC_CHECKS:-1}"
 DEPLOY_SKIP_IMAGE_CHECK="${DEPLOY_SKIP_IMAGE_CHECK:-0}"
 DEPLOY_IMAGE_WAIT_SECONDS="${DEPLOY_IMAGE_WAIT_SECONDS:-900}"
@@ -200,7 +201,8 @@ prepare_payload() {
       | tar -x -C "$TMP_DIR"
   fi
 
-  cp "$ROOT_DIR/.env" "$TMP_DIR/.env"
+  scp "$REMOTE:$SERVER_PATH/.env" "$TMP_DIR/.env"
+  chmod 600 "$TMP_DIR/.env"
   fetch_release_manifest
   set_env_value "$TMP_DIR/.env" CRATE_IMAGE_TAG "$DEPLOY_IMAGE_TAG"
   set_env_value "$TMP_DIR/.env" CRATE_IMAGE_OWNER "$DEPLOY_IMAGE_OWNER"
@@ -216,8 +218,10 @@ fetch_release_manifest() {
 
   require_command docker
   log "Resolving immutable release manifest ${manifest_image}"
-  docker pull -q "$manifest_image" >/dev/null
-  container_id="$(docker create "$manifest_image" true)"
+  docker pull -q --platform "$DEPLOY_IMAGE_PLATFORM" "$manifest_image" >/dev/null
+  container_id="$(
+    docker create --platform "$DEPLOY_IMAGE_PLATFORM" "$manifest_image" true
+  )"
   if ! docker cp "$container_id:/release-manifest.json" "$TMP_DIR/release-manifest.json"; then
     docker rm -f "$container_id" >/dev/null 2>&1 || true
     fail "release manifest image does not contain /release-manifest.json"
@@ -268,11 +272,6 @@ local_preflight() {
   require_command ssh
   require_command scp
   require_command tar
-
-  test -f "$ROOT_DIR/.env" || fail ".env not found"
-  if [[ -z "$(env_file_value "$ROOT_DIR/.env" REDIS_PASSWORD)" ]]; then
-    fail "REDIS_PASSWORD must be set in .env before deploying"
-  fi
 
   resolve_image_tag
   prepare_payload


### PR DESCRIPTION
## Summary

- pulls and extracts release-manifest images explicitly for the production `linux/amd64` platform
- builds the local candidate compose from the current remote production environment instead of a developer `.env`
- preserves remote secrets while only overlaying immutable release image references

## Regression coverage

- release/deploy suite: 55 passed
- bash syntax and ShellCheck passed
- real preflight against `fd9d4c9c542984ca4e55879835951a494a99f100` passed, including all ten image digests and remote compose validation

No production services were changed while diagnosing these preflight failures.