### PR TITLE
fix(deploy): include fast worker in releases

### DIFF
--- a/app/tests/test_deploy_release_commands.py
+++ b/app/tests/test_deploy_release_commands.py
@@ -196,6 +196,26 @@ def test_remote_deploy_only_pulls_and_restarts_changed_release_services() -> Non
     assert "--no-deps" in up_body
 
 
+def test_worker_release_manages_every_production_worker_role() -> None:
+    script = (ROOT / "scripts/deploy-remote.sh").read_text()
+
+    for array_name in (
+        "PROJECT_SERVICES",
+        "RUNNING_SERVICES",
+        "QUIESCE_SERVICES",
+    ):
+        assignment = next(
+            line for line in script.splitlines() if line.startswith(f"{array_name}=(")
+        )
+        assert "crate-fast-worker" in assignment
+
+    assert '[crate-fast-worker]="${IMAGE_PREFIX}/crate-worker"' in script
+    assert (
+        '[CRATE_WORKER_IMAGE]="crate-worker crate-fast-worker '
+        'crate-projector crate-maintenance-worker"'
+    ) in script
+
+
 def test_image_rollback_restores_only_the_services_changed_by_the_release() -> None:
     script = (ROOT / "scripts/deploy-remote.sh").read_text()
     rollback_body = script[

--- a/scripts/deploy-remote.sh
+++ b/scripts/deploy-remote.sh
@@ -24,10 +24,10 @@ IMAGE_PREFIX="${DEPLOY_IMAGE_REGISTRY}/${DEPLOY_IMAGE_OWNER}"
 cd "$SERVER_PATH"
 
 COMPOSE=(docker compose -f docker-compose.yaml -f docker-compose.project.yaml)
-PROJECT_SERVICES=(crate-api crate-readplane crate-worker crate-projector crate-maintenance-worker crate-analysis-worker crate-playback-worker crate-media-worker crate-ui crate-listen crate-site crate-docs)
+PROJECT_SERVICES=(crate-api crate-readplane crate-worker crate-fast-worker crate-projector crate-maintenance-worker crate-analysis-worker crate-playback-worker crate-media-worker crate-ui crate-listen crate-site crate-docs)
 HEALTHY_SERVICES=(crate-redis crate-postgres crate-api)
-RUNNING_SERVICES=(crate-readplane crate-worker crate-projector crate-maintenance-worker crate-analysis-worker crate-playback-worker crate-media-worker crate-ui crate-listen crate-site crate-docs)
-QUIESCE_SERVICES=(crate-api crate-readplane crate-worker crate-projector crate-maintenance-worker crate-analysis-worker crate-playback-worker crate-media-worker)
+RUNNING_SERVICES=(crate-readplane crate-worker crate-fast-worker crate-projector crate-maintenance-worker crate-analysis-worker crate-playback-worker crate-media-worker crate-ui crate-listen crate-site crate-docs)
+QUIESCE_SERVICES=(crate-api crate-readplane crate-worker crate-fast-worker crate-projector crate-maintenance-worker crate-analysis-worker crate-playback-worker crate-media-worker)
 RELEASE_ENV_KEYS=(
   CRATE_RELEASE_SHA
   CRATE_API_IMAGE
@@ -46,6 +46,7 @@ declare -A SERVICE_IMAGE_REPOS=(
   [crate-api]="${IMAGE_PREFIX}/crate-api"
   [crate-readplane]="${IMAGE_PREFIX}/crate-readplane"
   [crate-worker]="${IMAGE_PREFIX}/crate-worker"
+  [crate-fast-worker]="${IMAGE_PREFIX}/crate-worker"
   [crate-projector]="${IMAGE_PREFIX}/crate-worker"
   [crate-maintenance-worker]="${IMAGE_PREFIX}/crate-worker"
   [crate-analysis-worker]="${IMAGE_PREFIX}/crate-analysis-worker"
@@ -71,7 +72,7 @@ declare -A RELEASE_ENV_REPOS=(
 declare -A RELEASE_ENV_SERVICES=(
   [CRATE_API_IMAGE]="crate-api"
   [CRATE_READPLANE_IMAGE]="crate-readplane"
-  [CRATE_WORKER_IMAGE]="crate-worker crate-projector crate-maintenance-worker"
+  [CRATE_WORKER_IMAGE]="crate-worker crate-fast-worker crate-projector crate-maintenance-worker"
   [CRATE_ANALYSIS_WORKER_IMAGE]="crate-analysis-worker"
   [CRATE_PLAYBACK_WORKER_IMAGE]="crate-playback-worker"
   [CRATE_MEDIA_WORKER_IMAGE]="crate-media-worker"
@@ -1092,7 +1093,7 @@ cmd_ps() {
 
 cmd_diagnose() {
   dc ps || true
-  dc logs --tail=120 crate-api crate-readplane crate-worker crate-projector crate-maintenance-worker crate-analysis-worker crate-playback-worker crate-media-worker crate-ui crate-listen crate-site crate-docs || true
+  dc logs --tail=120 crate-api crate-readplane crate-worker crate-fast-worker crate-projector crate-maintenance-worker crate-analysis-worker crate-playback-worker crate-media-worker crate-ui crate-listen crate-site crate-docs || true
 }
 
 case "${1:-}" in


### PR DESCRIPTION
## Summary

- includes `crate-fast-worker` in selective deploy, health verification, quiesce, recovery and rollback inventories
- maps it to the immutable `crate-worker` release image alongside the other worker roles
- includes its logs in deployment diagnostics
- adds a regression test covering every production worker role

## Why

The first immutable selective production deployment correctly updated `crate-worker`, `crate-projector` and `crate-maintenance-worker`, but `crate-fast-worker` was absent from the deploy inventory and retained the previous mutable image tag. This closes that coverage gap before publishing the Android beta release.

## Validation

- `56 passed` in deploy/release tests
- `bash -n scripts/deploy-remote.sh`
- Ruff check and format
- ShellCheck with warning severity
- pre-commit on changed files
