### PR TITLE
fix(listen): remove stale lodash build alias

### DIFF
--- a/app/listen/src/app-shell/AppRouter.bundle.test.tsx
+++ b/app/listen/src/app-shell/AppRouter.bundle.test.tsx
@@ -92,5 +92,12 @@ describe("AppRouter mobile bundle boundary", () => {
     expect(listenPackage.dependencies).not.toHaveProperty("lucide-react");
     expect(listenPackage.dependencies).not.toHaveProperty("iconoir-react");
     expect(listenPackage.dependencies).not.toHaveProperty("lodash-es");
+
+    const viteConfig = readFileSync(
+      path.join(process.cwd(), "vite.config.ts"),
+      "utf8",
+    );
+    expect(viteConfig).not.toContain("lodash-es");
+    expect(viteConfig).not.toContain("createRequire");
   });
 });

--- a/app/listen/vite.config.ts
+++ b/app/listen/vite.config.ts
@@ -1,13 +1,9 @@
-import { createRequire } from "node:module";
 import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
 import tailwindcss from "@tailwindcss/vite";
 import path from "path";
 
 import { translationDevPlugin } from "./src/i18n/dev/translation-dev-plugin";
-
-const require = createRequire(import.meta.url);
-const lodashEsRoot = path.dirname(require.resolve("lodash-es/package.json"));
 
 export default defineConfig({
   plugins: [
@@ -54,7 +50,6 @@ export default defineConfig({
   resolve: {
     alias: {
       "@": path.resolve(__dirname, "./src"),
-      lodash: lodashEsRoot,
     },
   },
   optimizeDeps: {


### PR DESCRIPTION
## Summary

- removes the stale `lodash-es` resolver/alias from Listen's Vite config
- adds a bundle-contract regression so a removed dependency cannot remain referenced by build configuration

## Root cause

`lodash-es` was removed from `app/listen/package.json`, but `vite.config.ts` still resolved its package path. Root workspace installs masked the error locally; the isolated Listen Docker build installs only the package's declared dependencies and failed with `Cannot find module 'lodash-es/package.json'`.

## Verification

- regression test fails before the fix and passes after it
- Listen production build passes
- initial JS remains 162,837 gzip bytes (300 KB budget)
- exact `docker build --file app/listen/Dockerfile app` passes
- Prettier and Listen ESLint pass
