### PR TITLE
fix: stabilize mobile playback sessions

### DIFF
--- a/app/crate/api/playback_telemetry.py
+++ b/app/crate/api/playback_telemetry.py
@@ -37,11 +37,16 @@ def _allow_qoe_events(user_id: int, event_count: int) -> bool:
 
 
 def _metric_tags(event) -> dict[str, str]:
-    return {
+    tags = {
         "origin": event.origin,
         "requested_policy": event.requested_policy,
         "effective_policy": event.effective_policy,
     }
+    if event.runtime is not None:
+        tags["runtime"] = event.runtime
+    if event.engine is not None:
+        tags["engine"] = event.engine
+    return tags
 
 
 def _record_qoe_event(event) -> None:

--- a/app/crate/api/schemas/playback_telemetry.py
+++ b/app/crate/api/schemas/playback_telemetry.py
@@ -8,6 +8,10 @@ from pydantic import BaseModel, ConfigDict, Field
 PlaybackQoeEventName = Literal["startup", "stall_start", "stall_end", "recovery"]
 PlaybackQoeOrigin = Literal["local", "remote", "imported"]
 PlaybackQoePolicy = Literal["original", "balanced", "data_saver"]
+PlaybackQoeRuntime = Literal[
+    "desktop_web", "mobile_web", "android_native", "ios_native", "tauri"
+]
+PlaybackQoeEngine = Literal["gapless", "media3"]
 
 
 class PlaybackQoeEventRequest(BaseModel):
@@ -22,6 +26,8 @@ class PlaybackQoeEventRequest(BaseModel):
     duration_ms: int | None = Field(default=None, ge=0, le=600_000)
     buffered_ahead_seconds: float | None = Field(default=None, ge=0, le=7_200)
     attempt: int | None = Field(default=None, ge=1, le=3)
+    runtime: PlaybackQoeRuntime | None = None
+    engine: PlaybackQoeEngine | None = None
 
 
 class PlaybackQoeBatchRequest(BaseModel):

--- a/app/listen/src/components/player/AuthenticatedMediaImage.test.tsx
+++ b/app/listen/src/components/player/AuthenticatedMediaImage.test.tsx
@@ -1,0 +1,68 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mediaVersion, ensureMediaAccessUrlMock } = vi.hoisted(() => ({
+  mediaVersion: { value: 1 },
+  ensureMediaAccessUrlMock: vi.fn(),
+}));
+
+vi.mock("@/hooks/use-media-access-version", () => ({
+  useMediaAccessVersion: () => mediaVersion.value,
+}));
+
+vi.mock("@/lib/api", () => ({
+  ensureMediaAccessUrl: ensureMediaAccessUrlMock,
+  resolveMaybeApiAssetUrl: (url: string | null | undefined) =>
+    url ? `${url}?ticket-version=${mediaVersion.value}` : null,
+}));
+
+import { AuthenticatedMediaImage } from "./AuthenticatedMediaImage";
+
+describe("AuthenticatedMediaImage", () => {
+  beforeEach(() => {
+    mediaVersion.value = 1;
+    ensureMediaAccessUrlMock.mockReset();
+    ensureMediaAccessUrlMock.mockResolvedValue(
+      "/api/albums/1/cover?media_ticket=renewed",
+    );
+  });
+
+  it("re-resolves the source when media tickets change", () => {
+    const { rerender } = render(
+      <AuthenticatedMediaImage src="/api/albums/1/cover" alt="Cover" />,
+    );
+    expect(screen.getByRole("img", { name: "Cover" })).toHaveAttribute(
+      "src",
+      "/api/albums/1/cover?ticket-version=1",
+    );
+
+    mediaVersion.value = 2;
+    rerender(<AuthenticatedMediaImage src="/api/albums/1/cover" alt="Cover" />);
+
+    expect(screen.getByRole("img", { name: "Cover" })).toHaveAttribute(
+      "src",
+      "/api/albums/1/cover?ticket-version=2",
+    );
+  });
+
+  it("renews a failed protected image once", async () => {
+    render(<AuthenticatedMediaImage src="/api/albums/1/cover" alt="Cover" />);
+
+    fireEvent.error(screen.getByRole("img", { name: "Cover" }));
+
+    await waitFor(() =>
+      expect(ensureMediaAccessUrlMock).toHaveBeenCalledWith(
+        "/api/albums/1/cover",
+        "artwork",
+        { forceRefresh: true },
+      ),
+    );
+    expect(screen.getByRole("img", { name: "Cover" })).toHaveAttribute(
+      "src",
+      "/api/albums/1/cover?media_ticket=renewed",
+    );
+
+    fireEvent.error(screen.getByRole("img", { name: "Cover" }));
+    expect(ensureMediaAccessUrlMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/app/listen/src/components/player/AuthenticatedMediaImage.tsx
+++ b/app/listen/src/components/player/AuthenticatedMediaImage.tsx
@@ -1,0 +1,55 @@
+import {
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type ImgHTMLAttributes,
+} from "react";
+
+import { useMediaAccessVersion } from "@/hooks/use-media-access-version";
+import { ensureMediaAccessUrl, resolveMaybeApiAssetUrl } from "@/lib/api";
+
+interface AuthenticatedMediaImageProps
+  extends Omit<ImgHTMLAttributes<HTMLImageElement>, "src"> {
+  src: string | null | undefined;
+}
+
+export function AuthenticatedMediaImage({
+  src,
+  onError,
+  ...props
+}: AuthenticatedMediaImageProps) {
+  const ticketVersion = useMediaAccessVersion();
+  const resolvedSource = useMemo(
+    () => resolveMaybeApiAssetUrl(src),
+    [src, ticketVersion],
+  );
+  const [recoveredSource, setRecoveredSource] = useState<string | null>(null);
+  const recoveryAttemptedFor = useRef<string | null>(null);
+
+  useEffect(() => {
+    setRecoveredSource(null);
+    recoveryAttemptedFor.current = null;
+  }, [src, ticketVersion]);
+
+  if (!resolvedSource && !recoveredSource) return null;
+
+  return (
+    <img
+      {...props}
+      src={recoveredSource || resolvedSource || undefined}
+      onError={(event) => {
+        onError?.(event);
+        if (!src || recoveryAttemptedFor.current === src) return;
+        recoveryAttemptedFor.current = src;
+        void ensureMediaAccessUrl(src, "artwork", {
+          forceRefresh: true,
+        })
+          .then(setRecoveredSource)
+          .catch(() => {
+            // The caller's placeholder remains visible after one bounded retry.
+          });
+      }}
+    />
+  );
+}

--- a/app/listen/src/components/player/PlayerBar.tsx
+++ b/app/listen/src/components/player/PlayerBar.tsx
@@ -74,6 +74,7 @@ import {
 import { PlayerTrackMenu } from "@/components/player/bar/PlayerTrackMenu";
 import { PlayerVolumeControl } from "@/components/player/bar/PlayerVolumeControl";
 import { WaveformCanvas } from "@/components/player/bar/WaveformCanvas";
+import { AuthenticatedMediaImage } from "@/components/player/AuthenticatedMediaImage";
 import { SpectrumPlayButton } from "@/components/player/SpectrumPlayButton";
 import { PlaybackTargetMenu } from "@/components/player/PlaybackTargetMenu";
 import type { PlaybackTargetContext } from "@/lib/playback-targets";
@@ -1132,7 +1133,7 @@ export function PlayerBar() {
                 {displayCrossfadeTransition ? (
                   <>
                     {displayCrossfadeTransition.outgoing.albumCover ? (
-                      <img
+                      <AuthenticatedMediaImage
                         src={displayCrossfadeTransition.outgoing.albumCover}
                         alt=""
                         className="absolute inset-0 w-full h-full object-cover"
@@ -1140,7 +1141,7 @@ export function PlayerBar() {
                       />
                     ) : null}
                     {displayCrossfadeTransition.incoming.albumCover ? (
-                      <img
+                      <AuthenticatedMediaImage
                         src={displayCrossfadeTransition.incoming.albumCover}
                         alt=""
                         className="absolute inset-0 w-full h-full object-cover"
@@ -1149,7 +1150,7 @@ export function PlayerBar() {
                     ) : null}
                   </>
                 ) : displayTrack.albumCover ? (
-                  <img
+                  <AuthenticatedMediaImage
                     src={displayTrack.albumCover}
                     alt=""
                     className="w-full h-full object-cover"

--- a/app/listen/src/contexts/PlayerContext.tsx
+++ b/app/listen/src/contexts/PlayerContext.tsx
@@ -101,6 +101,7 @@ import {
 } from "@/lib/playback-network-quality";
 import { getPlaybackDeliveryProvenance } from "@/lib/playback-provenance";
 import {
+  getPlaybackQoeRuntime,
   installPlaybackQoeFlush,
   recordPlaybackQoe,
   type PlaybackQoeEventName,
@@ -444,6 +445,8 @@ export function PlayerProvider({ children }: { children: ReactNode }) {
           (track.origin === "remote" ? "remote" : "local"),
         requestedPolicy: provenance?.requestedPolicy ?? policy,
         effectivePolicy: provenance?.effectivePolicy ?? policy,
+        runtime: getPlaybackQoeRuntime(),
+        engine: shouldUseAndroidNativePlayer() ? "media3" : "gapless",
         ...details,
       });
     },

--- a/app/listen/src/contexts/player-engine-adapter.test.ts
+++ b/app/listen/src/contexts/player-engine-adapter.test.ts
@@ -1,18 +1,25 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const { apiMock, authState, ensureFreshAuthTokenMock, offlineUrlState } =
-  vi.hoisted(() => ({
-    apiMock: vi.fn(),
-    authState: { token: "listen-token" },
-    ensureFreshAuthTokenMock: vi.fn(),
-    offlineUrlState: { url: null as string | null },
-  }));
+const {
+  apiMock,
+  authState,
+  ensureFreshAuthTokenMock,
+  ensureMediaAccessUrlMock,
+  offlineUrlState,
+} = vi.hoisted(() => ({
+  apiMock: vi.fn(),
+  authState: { token: "listen-token" },
+  ensureFreshAuthTokenMock: vi.fn(),
+  ensureMediaAccessUrlMock: vi.fn(),
+  offlineUrlState: { url: null as string | null },
+}));
 
 vi.mock("@/lib/api", () => ({
   api: apiMock,
   getApiBase: () => "https://listen.example",
   getAuthToken: () => authState.token,
   ensureFreshAuthToken: ensureFreshAuthTokenMock,
+  ensureMediaAccessUrl: ensureMediaAccessUrlMock,
   apiStreamUrl: (url: string) => url,
   resolveMaybeApiStreamUrl: (url: string | null | undefined) =>
     url?.startsWith("/api/") ? `https://listen.example${url}` : url ?? null,
@@ -45,6 +52,8 @@ describe("player engine adapter", () => {
     apiMock.mockReset();
     ensureFreshAuthTokenMock.mockReset();
     ensureFreshAuthTokenMock.mockResolvedValue(true);
+    ensureMediaAccessUrlMock.mockReset();
+    ensureMediaAccessUrlMock.mockImplementation(async (url: string) => url);
     offlineUrlState.url = null;
   });
 
@@ -198,22 +207,38 @@ describe("player engine adapter", () => {
     );
   });
 
-  it("resolves only the active global track before loading a queue", async () => {
-    apiMock.mockResolvedValueOnce({
-      stream_url: "/api/federation/remote/streams/ticket-current",
-      requested_policy: "original",
-      effective_policy: "balanced",
-      source: {},
-      delivery: {},
-      transcoded: false,
-      cache_hit: false,
-      preparing: false,
-      task_id: null,
-      variant_id: null,
-      variant_status: null,
-      playback_session: "signed-current-playback",
-      content_origin: "remote",
-    });
+  it("resolves and tickets the active and next web tracks before loading a queue", async () => {
+    apiMock
+      .mockResolvedValueOnce({
+        stream_url: "/api/federation/remote/streams/ticket-current",
+        requested_policy: "original",
+        effective_policy: "balanced",
+        source: {},
+        delivery: {},
+        transcoded: false,
+        cache_hit: false,
+        preparing: false,
+        task_id: null,
+        variant_id: null,
+        variant_status: null,
+        playback_session: "signed-current-playback",
+        content_origin: "remote",
+      })
+      .mockResolvedValueOnce({
+        stream_url: "/api/federation/remote/streams/ticket-next",
+        requested_policy: "original",
+        effective_policy: "balanced",
+        source: {},
+        delivery: {},
+        transcoded: false,
+        cache_hit: false,
+        preparing: false,
+        task_id: null,
+        variant_id: null,
+        variant_status: null,
+        playback_session: "signed-next-playback",
+        content_origin: "remote",
+      });
     const queue = [
       {
         id: "global-track-current",
@@ -231,13 +256,25 @@ describe("player engine adapter", () => {
 
     const tracks = await toStartupEngineTracks(queue, 0);
 
-    expect(apiMock).toHaveBeenCalledTimes(1);
+    expect(apiMock).toHaveBeenCalledTimes(2);
     expect(apiMock).toHaveBeenCalledWith(
       "/api/catalog/tracks/global-track-current/playback",
     );
     expect(tracks[0]?.url).toContain("ticket-current");
-    expect(tracks[1]?.url).toContain(
-      "/api/catalog/tracks/global-track-next/stream",
+    expect(apiMock).toHaveBeenCalledWith(
+      "/api/catalog/tracks/global-track-next/playback",
+    );
+    expect(tracks[1]?.url).toContain("ticket-next");
+    expect(ensureMediaAccessUrlMock).toHaveBeenCalledTimes(2);
+    expect(ensureMediaAccessUrlMock).toHaveBeenNthCalledWith(
+      1,
+      "https://listen.example/api/federation/remote/streams/ticket-current",
+      "stream",
+    );
+    expect(ensureMediaAccessUrlMock).toHaveBeenNthCalledWith(
+      2,
+      "https://listen.example/api/federation/remote/streams/ticket-next",
+      "stream",
     );
   });
 });

--- a/app/listen/src/contexts/player-engine-adapter.ts
+++ b/app/listen/src/contexts/player-engine-adapter.ts
@@ -6,6 +6,7 @@ import {
 } from "@/contexts/player-utils";
 import {
   ensureFreshAuthToken,
+  ensureMediaAccessUrl,
   getApiBase,
   getAuthToken,
   resolveMaybeApiAssetUrl,
@@ -149,14 +150,21 @@ export async function toStartupEngineTracks(
     0,
     Math.min(Math.trunc(activeIndex), tracks.length - 1),
   );
-  const activeTrack = tracks[normalizedIndex];
-  if (!activeTrack) return engineTracks;
-
-  engineTracks[normalizedIndex] = toEngineTrack(
-    activeTrack,
-    eqGainsByTrackId?.get(activeTrack.id),
-    await resolveFreshEngineStreamUrl(activeTrack, options),
-    options,
+  const startupIndices = new Set([
+    normalizedIndex,
+    Math.min(normalizedIndex + 1, tracks.length - 1),
+  ]);
+  await Promise.all(
+    Array.from(startupIndices).map(async (index) => {
+      const track = tracks[index];
+      if (!track) return;
+      engineTracks[index] = toEngineTrack(
+        track,
+        eqGainsByTrackId?.get(track.id),
+        await resolveFreshEngineStreamUrl(track, options),
+        options,
+      );
+    }),
   );
   return engineTracks;
 }
@@ -173,15 +181,23 @@ async function resolveFreshEngineStreamUrl(
 ): Promise<string> {
   const offlineUrl = getOfflineStreamUrl(track, options);
   if (offlineUrl) return offlineUrl;
-  if (hasFreshRemoteStream(track)) return getStreamUrl(track, options);
-  if (!track.globalTrackUid) return getStreamUrl(track, options);
-
-  const playback = await fetchTrackPlayback(
-    track,
-    getEffectivePlaybackDeliveryPolicy(),
-  );
-  if (!playback) return getStreamUrl(track, options);
-  setPlaybackSession(track, playback.playback_session);
-  setPlaybackDeliveryProvenance(track, playback);
-  return resolveMaybeApiStreamUrl(playback.stream_url) || playback.stream_url;
+  let resolvedUrl: string;
+  if (hasFreshRemoteStream(track) || !track.globalTrackUid) {
+    resolvedUrl = getStreamUrl(track, options);
+  } else {
+    const playback = await fetchTrackPlayback(
+      track,
+      getEffectivePlaybackDeliveryPolicy(),
+    );
+    if (!playback) {
+      resolvedUrl = getStreamUrl(track, options);
+    } else {
+      setPlaybackSession(track, playback.playback_session);
+      setPlaybackDeliveryProvenance(track, playback);
+      resolvedUrl =
+        resolveMaybeApiStreamUrl(playback.stream_url) || playback.stream_url;
+    }
+  }
+  if (options.target === "android-native") return resolvedUrl;
+  return ensureMediaAccessUrl(resolvedUrl, "stream");
 }

--- a/app/listen/src/contexts/player-utils.test.ts
+++ b/app/listen/src/contexts/player-utils.test.ts
@@ -8,8 +8,6 @@ import type { PlaySource, Track } from "./player-types";
 import { getOfflineNativePlaybackUrl } from "@/lib/offline";
 import { setPlaybackDeliveryPolicyPreference } from "@/lib/player-playback-prefs";
 import {
-  ANDROID_CONTINUOUS_ALBUM_CROSSFADE_SECONDS,
-  ANDROID_MEDIA_SESSION_HANDOFF_SECONDS,
   getEffectiveCrossfadeSeconds,
   getStoredQueue,
   getStreamUrl,
@@ -316,7 +314,7 @@ describe("getEffectiveCrossfadeSeconds", () => {
     ).toBe(0);
   });
 
-  it("uses a short Android mask for continuous album playback when WebAudio gapless is unavailable", () => {
+  it("disables crossfade for Android native album playback", () => {
     expect(
       getEffectiveCrossfadeSeconds(
         ALBUM_TRACK_A,
@@ -327,10 +325,10 @@ describe("getEffectiveCrossfadeSeconds", () => {
         true,
         { androidNative: true },
       ),
-    ).toBe(ANDROID_CONTINUOUS_ALBUM_CROSSFADE_SECONDS);
+    ).toBe(0);
   });
 
-  it("uses the same short mask for iOS/Safari HTML5 playback", () => {
+  it("disables crossfade for mobile HTML5 playback", () => {
     expect(
       getEffectiveCrossfadeSeconds(
         ALBUM_TRACK_A,
@@ -341,10 +339,10 @@ describe("getEffectiveCrossfadeSeconds", () => {
         true,
         { html5OnlyPlayback: true },
       ),
-    ).toBe(ANDROID_CONTINUOUS_ALBUM_CROSSFADE_SECONDS);
+    ).toBe(0);
   });
 
-  it("keeps a minimal HTML5 mask for continuous albums even when crossfade preference is off", () => {
+  it("does not add a hidden mobile album overlap when crossfade is off", () => {
     expect(
       getEffectiveCrossfadeSeconds(
         ALBUM_TRACK_A,
@@ -355,10 +353,10 @@ describe("getEffectiveCrossfadeSeconds", () => {
         true,
         { html5OnlyPlayback: true },
       ),
-    ).toBe(ANDROID_CONTINUOUS_ALBUM_CROSSFADE_SECONDS);
+    ).toBe(0);
   });
 
-  it("keeps a minimal HTML5 handoff for non-album queues when crossfade is off", () => {
+  it("does not add a hidden mobile playlist overlap when crossfade is off", () => {
     expect(
       getEffectiveCrossfadeSeconds(
         TRACK_A,
@@ -369,7 +367,7 @@ describe("getEffectiveCrossfadeSeconds", () => {
         true,
         { html5OnlyPlayback: true },
       ),
-    ).toBe(ANDROID_MEDIA_SESSION_HANDOFF_SECONDS);
+    ).toBe(0);
   });
 
   it("keeps true gapless album playback when enhanced mobile audio is enabled", () => {

--- a/app/listen/src/contexts/player-utils.ts
+++ b/app/listen/src/contexts/player-utils.ts
@@ -3,7 +3,10 @@ import { apiStreamUrl, getApiBase, resolveMaybeApiAssetUrl } from "@/lib/api";
 import { isNative } from "@/lib/capacitor-runtime";
 import { recordDevLog, redactUrl } from "@/lib/dev-logs";
 import { trackStreamApiPath } from "@/lib/library-routes";
-import { stableMobileAudioPipeline } from "@/lib/mobile-audio-mode";
+import {
+  isMobileAudioRuntime,
+  stableMobileAudioPipeline,
+} from "@/lib/mobile-audio-mode";
 import { getOfflineNativePlaybackUrl } from "@/lib/offline";
 import { getEffectivePlaybackDeliveryPolicy } from "@/lib/player-playback-prefs";
 
@@ -509,6 +512,13 @@ export function getEffectiveCrossfadeSeconds(
     mobileEnhancedAudio?: boolean;
   } = {},
 ): number {
+  if (
+    isMobileAudioRuntime ||
+    options.androidNative ||
+    options.html5OnlyPlayback
+  ) {
+    return 0;
+  }
   const clampedSeconds = Math.max(0, configuredSeconds || 0);
   const continuousAlbumTransition = isContinuousAlbumTransition(
     currentTrack,

--- a/app/listen/src/contexts/use-media-session.ts
+++ b/app/listen/src/contexts/use-media-session.ts
@@ -3,6 +3,7 @@ import type { Track } from "./player-types";
 import { shouldUseAndroidNativePlayer } from "@/lib/android-native-engine";
 import { resolveMaybeApiAssetUrl } from "@/lib/api";
 import { isNative } from "@/lib/capacitor-runtime";
+import { useMediaAccessVersion } from "@/hooks/use-media-access-version";
 import { syncDesktopMediaSession } from "@/lib/desktop-tray";
 import {
   onNativeMediaControl,
@@ -37,6 +38,7 @@ export function useMediaSession({
   prev: () => void;
   seek: (time: number) => void;
 }) {
+  const mediaAccessVersion = useMediaAccessVersion();
   const actionsRef = useRef({
     pause,
     resume,
@@ -127,6 +129,7 @@ export function useMediaSession({
     currentTrack?.album,
     currentTrack?.albumCover,
     isPlaying,
+    mediaAccessVersion,
   ]);
 
   // Update playback state
@@ -188,6 +191,7 @@ export function useMediaSession({
     currentTrack?.albumCover,
     duration,
     isPlaying,
+    mediaAccessVersion,
     nativePositionSeconds,
   ]);
 
@@ -217,6 +221,7 @@ export function useMediaSession({
     currentTrack?.albumCover,
     duration,
     isPlaying,
+    mediaAccessVersion,
     nativePositionSeconds,
   ]);
 

--- a/app/listen/src/lib/android-native-engine.test.ts
+++ b/app/listen/src/lib/android-native-engine.test.ts
@@ -67,18 +67,18 @@ describe("android native engine flags", () => {
     expect(shouldUseAndroidNativePlayer()).toBe(false);
   });
 
-  it("keeps the native player disabled while web crossfade is active", async () => {
+  it("keeps the native player enabled with a legacy crossfade preference", async () => {
     vi.doMock("@/lib/capacitor-runtime", () => ({ isAndroidNative: true }));
-    const { setCrossfadeDurationPreference } = await import(
-      "@/lib/player-playback-prefs"
-    );
+    localStorage.setItem("listen-player-crossfade-seconds", "4");
+    localStorage.setItem("crate-native-player-crossfade-enabled", "true");
     const { shouldUseAndroidNativePlayer } = await import(
       "@/lib/android-native-engine"
     );
 
-    setCrossfadeDurationPreference(4);
-
-    expect(shouldUseAndroidNativePlayer()).toBe(false);
+    expect(shouldUseAndroidNativePlayer()).toBe(true);
+    expect(
+      localStorage.getItem("crate-native-player-crossfade-enabled"),
+    ).toBeNull();
   });
 
   it("sends the active queue revision with native queue mutations", async () => {
@@ -114,7 +114,7 @@ describe("android native engine flags", () => {
       positionMs: 0,
       autoplay: false,
       repeat: "off",
-      crossfadeMs: 0,
+      crossfadeMs: 4000,
       volume: 1,
     });
     await engine.appendTracks([track]);
@@ -128,6 +128,14 @@ describe("android native engine flags", () => {
     ).toMatchObject({
       url: "https://listen.example/api/tracks/1/stream",
       authorization: "Bearer secret-token",
+    });
+    expect(nativePlaybackMock.setQueue).toHaveBeenCalledWith(
+      expect.objectContaining({ crossfadeMs: 0 }),
+    );
+
+    await engine.setCrossfadeMs(5000);
+    expect(nativePlaybackMock.setCrossfadeMs).toHaveBeenCalledWith({
+      crossfadeMs: 0,
     });
   });
 

--- a/app/listen/src/lib/android-native-engine.ts
+++ b/app/listen/src/lib/android-native-engine.ts
@@ -5,7 +5,6 @@ import {
 } from "@capacitor/core";
 
 import { isAndroidNative } from "@/lib/capacitor-runtime";
-import { getCrossfadeDurationPreference } from "@/lib/player-playback-prefs";
 import type {
   EngineEventListener,
   EngineEventMap,
@@ -90,7 +89,7 @@ export function isAndroidNativePlayerAvailable(): boolean {
 export function shouldUseAndroidNativePlayer(): boolean {
   if (!isAndroidNativePlayerAvailable()) return false;
   try {
-    if (getCrossfadeDurationPreference() > 0) return false;
+    localStorage.removeItem(NATIVE_PLAYER_CROSSFADE_KEY);
     return localStorage.getItem(NATIVE_PLAYER_DISABLED_KEY) !== "true";
   } catch {
     return true;
@@ -107,14 +106,6 @@ export function setAndroidNativePlayerEnabled(enabled: boolean): void {
     window.dispatchEvent(new CustomEvent("crate:native-player-pref-changed"));
   } catch {
     // Preference changes are best-effort in constrained storage modes.
-  }
-}
-
-export function isAndroidNativeCrossfadeEnabled(): boolean {
-  try {
-    return localStorage.getItem(NATIVE_PLAYER_CROSSFADE_KEY) === "true";
-  } catch {
-    return false;
   }
 }
 
@@ -204,7 +195,7 @@ export class AndroidNativeEngine implements PlaybackEngine {
       await this.ensureNotificationPermission();
     }
     this.queueRevision = snapshot.revision;
-    return nativePlayback.setQueue(snapshot);
+    return nativePlayback.setQueue({ ...snapshot, crossfadeMs: 0 });
   }
 
   async play(): Promise<EngineState> {
@@ -280,8 +271,9 @@ export class AndroidNativeEngine implements PlaybackEngine {
   }
 
   async setCrossfadeMs(crossfadeMs: number): Promise<EngineState> {
+    void crossfadeMs;
     await this.ensureReady();
-    return nativePlayback.setCrossfadeMs({ crossfadeMs });
+    return nativePlayback.setCrossfadeMs({ crossfadeMs: 0 });
   }
 
   async setVolume(volume: number): Promise<EngineState> {

--- a/app/listen/src/lib/api.test.ts
+++ b/app/listen/src/lib/api.test.ts
@@ -1104,6 +1104,84 @@ describe("native (configurable server) mode", () => {
         ),
       ).toBe("fresh-artwork-ticket");
     });
+
+    it("waits for a cold exact-path ticket before returning a protected URL", async () => {
+      mediaAccess.clearMediaAccessTickets();
+      const expiresAt = new Date(Date.now() + 60_000).toISOString();
+      vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+        mockJsonResponse({
+          tickets: [
+            {
+              audience: "stream",
+              path: "/api/tracks/42/stream",
+              ticket: "cold-stream-ticket",
+              expires_at: expiresAt,
+            },
+          ],
+        }),
+      );
+      setupServer();
+      mediaAccess.clearMediaAccessTickets();
+
+      await expect(
+        apiMod.ensureMediaAccessUrl(
+          "/api/tracks/42/stream?delivery=balanced",
+          "stream",
+        ),
+      ).resolves.toBe(
+        "https://api.example.com/api/tracks/42/stream?delivery=balanced&media_ticket=cold-stream-ticket",
+      );
+    });
+
+    it("deduplicates concurrent ticket acquisition for the same target", async () => {
+      const server = setupServer();
+      mediaAccess.clearMediaAccessTickets();
+      const expiresAt = new Date(Date.now() + 60_000).toISOString();
+      const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+        mockJsonResponse({
+          tickets: [
+            {
+              audience: "artwork",
+              path: "/api/albums/42/cover",
+              ticket: "shared-artwork-ticket",
+              expires_at: expiresAt,
+            },
+          ],
+        }),
+      );
+
+      const [first, second] = await Promise.all([
+        apiMod.ensureMediaAccessUrl("/api/albums/42/cover", "artwork"),
+        apiMod.ensureMediaAccessUrl("/api/albums/42/cover", "artwork"),
+      ]);
+
+      expect(first).toContain("media_ticket=shared-artwork-ticket");
+      expect(second).toContain("media_ticket=shared-artwork-ticket");
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+      expect(
+        mediaAccess.getMediaAccessTicket(
+          "artwork",
+          "/api/albums/42/cover",
+          server.id,
+        ),
+      ).toBe("shared-artwork-ticket");
+    });
+
+    it("rejects instead of returning an unticketed protected URL", async () => {
+      setupServer();
+      mediaAccess.clearMediaAccessTickets();
+      vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+        mockFetchResponse(503),
+      );
+
+      await expect(
+        apiMod.ensureMediaAccessUrl("/api/tracks/42/stream", "stream"),
+      ).rejects.toMatchObject({
+        name: "MediaAccessTicketError",
+        audience: "stream",
+        path: "/api/tracks/42/stream",
+      });
+    });
   });
 
   describe("apiStreamUrl", () => {

--- a/app/listen/src/lib/api.ts
+++ b/app/listen/src/lib/api.ts
@@ -350,6 +350,19 @@ const queuedMediaAccessTargets = new Map<
 >();
 const scheduledMediaAccessScopes = new Set<string>();
 const mediaAccessRefreshPromises = new Map<string, Promise<boolean>>();
+const ensuredMediaAccessPromises = new Map<string, Promise<string>>();
+
+export class MediaAccessTicketError extends Error {
+  readonly audience: MediaAccessAudience;
+  readonly path: string;
+
+  constructor(audience: MediaAccessAudience, path: string) {
+    super(`Could not acquire ${audience} access for ${path}`);
+    this.name = "MediaAccessTicketError";
+    this.audience = audience;
+    this.path = path;
+  }
+}
 
 function mediaAccessTargetKey(target: MediaAccessTarget): string {
   return `${target.audience}:${target.path}`;
@@ -437,6 +450,83 @@ export async function refreshMediaAccessTickets(
     queueMediaAccessTarget(target.audience, target.path, server.id);
   }
   return flushMediaAccessTargets(server.id);
+}
+
+/**
+ * Resolve a protected media URL only after its exact-path ticket is available.
+ *
+ * Synchronous URL helpers remain suitable for lazy page artwork, where a
+ * ticket refresh can trigger a rerender. Audio engines and other connection
+ * boundaries must use this function so they never receive a cold unticketed
+ * URL in configurable-server runtimes.
+ */
+export async function ensureMediaAccessUrl(
+  url: string,
+  audience: MediaAccessAudience,
+  options: { forceRefresh?: boolean } = {},
+): Promise<string> {
+  const baseUrl = isAbsoluteHttpUrl(url) ? url : apiUrl(url);
+  if (!isApiUrl(baseUrl)) return baseUrl;
+  if (!usesConfigurableServer) {
+    return withMediaAccessTicket(baseUrl, audience);
+  }
+
+  const server = getCurrentServer();
+  if (!server?.token || !server.id) {
+    return withMediaAccessTicket(baseUrl, audience);
+  }
+
+  let parsed: URL;
+  let serverOrigin: URL;
+  try {
+    parsed = new URL(baseUrl, server.url);
+    serverOrigin = new URL(server.url);
+  } catch {
+    return baseUrl;
+  }
+  parsed.searchParams.delete("token");
+  parsed.searchParams.delete("media_ticket");
+  if (
+    parsed.origin !== serverOrigin.origin ||
+    !parsed.pathname.startsWith("/api/")
+  ) {
+    return parsed.toString();
+  }
+  const currentTicket = getMediaAccessTicket(
+    audience,
+    parsed.pathname,
+    server.id,
+  );
+  if (currentTicket && !options.forceRefresh) {
+    parsed.searchParams.set("media_ticket", currentTicket);
+    return parsed.toString();
+  }
+
+  const key = `${server.id}:${audience}:${parsed.pathname}:${
+    options.forceRefresh ? "refresh" : "ensure"
+  }`;
+  const existing = ensuredMediaAccessPromises.get(key);
+  if (existing) return existing;
+
+  const pending = (async () => {
+    const refreshed = await refreshMediaAccessTickets([
+      { audience, path: parsed.pathname },
+    ]);
+    const currentServer = getCurrentServer();
+    const ticket =
+      refreshed && currentServer?.id === server.id
+        ? getMediaAccessTicket(audience, parsed.pathname, server.id)
+        : null;
+    if (!ticket) {
+      throw new MediaAccessTicketError(audience, parsed.pathname);
+    }
+    parsed.searchParams.set("media_ticket", ticket);
+    return parsed.toString();
+  })().finally(() => {
+    ensuredMediaAccessPromises.delete(key);
+  });
+  ensuredMediaAccessPromises.set(key, pending);
+  return pending;
 }
 
 export function startMediaAccessTicketRefresh(): () => void {

--- a/app/listen/src/lib/gapless-player-audio-recovery.test.ts
+++ b/app/listen/src/lib/gapless-player-audio-recovery.test.ts
@@ -157,6 +157,7 @@ vi.mock("@/lib/gapless5/gapless5", () => ({
 }));
 
 vi.mock("@/lib/mobile-audio-mode", () => ({
+  isMobileAudioRuntime: false,
   stableMobileAudioPipeline: false,
 }));
 

--- a/app/listen/src/lib/gapless-player.test.ts
+++ b/app/listen/src/lib/gapless-player.test.ts
@@ -11,6 +11,7 @@ vi.mock("@/lib/gapless5/gapless5", () => ({
 }));
 
 vi.mock("@/lib/mobile-audio-mode", () => ({
+  isMobileAudioRuntime: false,
   stableMobileAudioPipeline: false,
 }));
 
@@ -178,8 +179,8 @@ describe("getCurrentBufferedAheadSeconds", () => {
 });
 
 describe("initPlayer", () => {
-  it("keeps the previous HTML5 element alive across mobile auto-advance", () => {
-    expect(getPlaybackLoadLimit(true)).toBe(3);
+  it("uses one decoder owner for the persistent mobile transport", () => {
+    expect(getPlaybackLoadLimit(true)).toBe(1);
   });
 
   it("creates a Gapless5 instance with expected options", () => {

--- a/app/listen/src/lib/gapless-player.ts
+++ b/app/listen/src/lib/gapless-player.ts
@@ -6,7 +6,10 @@
  */
 
 import { Gapless5 } from "@/lib/gapless5/gapless5";
-import { stableMobileAudioPipeline } from "@/lib/mobile-audio-mode";
+import {
+  isMobileAudioRuntime,
+  stableMobileAudioPipeline,
+} from "@/lib/mobile-audio-mode";
 import {
   createEqChain,
   isFlatGains,
@@ -46,10 +49,7 @@ type WindowWithGaplessContext = Window & {
 const GAPLESS_LOG_LEVEL_WARNING = 3;
 const GAPLESS_CROSSFADE_EQUAL_POWER = 3;
 const DESKTOP_DECODE_TRACK_LIMIT = 2;
-// Keep the previous element alive while the current and next tracks overlap.
-// Android Chrome can otherwise drop its MediaSession when the ended element
-// is unloaded during the transition.
-const MOBILE_HTML5_TRACK_LIMIT = 3;
+const MOBILE_HTML5_TRACK_LIMIT = 1;
 const ADJACENT_LOAD_BUFFER_SECONDS = 15;
 const RESUMED_AUDIO_CONTEXT_RAMP_MS = 24;
 
@@ -243,12 +243,15 @@ export function initPlayer(callbacks: GaplessPlayerCallbacks = {}): Gapless5 {
     analyserPrecision: preferHtml5Audio ? null : 2048,
     crossfade: getCrossfadeMs(),
     crossfadeShape: GAPLESS_CROSSFADE_EQUAL_POWER,
+    persistentHTML5Audio: isMobileAudioRuntime,
     volume: lastVolume,
     logLevel: GAPLESS_LOG_LEVEL_WARNING,
     // Keep the next mobile <audio> source ready before the active element
     // reaches ended, but only after the current stream has a safe buffer.
     // Starting both FLAC requests together can starve Android's active decoder.
-    loadLimit: getPlaybackLoadLimit(preferHtml5Audio),
+    loadLimit: isMobileAudioRuntime
+      ? MOBILE_HTML5_TRACK_LIMIT
+      : getPlaybackLoadLimit(preferHtml5Audio),
     deferAdjacentLoadsUntilBufferedSeconds: ADJACENT_LOAD_BUFFER_SECONDS,
     // Switching an audible source from HTML5 to WebAudio mid-track can click
     // even when both clocks are aligned. Decoded buffers remain available for

--- a/app/listen/src/lib/gapless5/gapless5-buffering.test.ts
+++ b/app/listen/src/lib/gapless5/gapless5-buffering.test.ts
@@ -96,6 +96,75 @@ describe("Gapless5.replaceTrack", () => {
 });
 
 describe("Gapless5 mobile background auto-advance", () => {
+  it("reuses one persistent media element across track transitions", async () => {
+    vi.useFakeTimers();
+    const instances: FakeAudio[] = [];
+
+    class FakeAudio extends EventTarget {
+      buffered = ranges([[0, 180]]);
+      controls = false;
+      crossOrigin: string | null = null;
+      currentTime = 0;
+      duration = 180;
+      error: MediaError | null = null;
+      loop = false;
+      networkState = 1;
+      paused = true;
+      playbackRate = 1;
+      preload = "auto";
+      preservesPitch = true;
+      readyState = 4;
+      seekable = ranges([[0, 180]]);
+      src = "";
+      srcObject: MediaProvider | null = null;
+      volume = 1;
+
+      constructor() {
+        super();
+        instances.push(this);
+      }
+
+      load() {}
+
+      pause() {
+        this.paused = true;
+      }
+
+      play() {
+        this.paused = false;
+        return Promise.resolve();
+      }
+    }
+
+    vi.stubGlobal("Audio", FakeAudio);
+    const player = new Gapless5({
+      tracks: ["one", "two"],
+      useHTML5Audio: true,
+      useWebAudio: false,
+      loadLimit: 1,
+      persistentHTML5Audio: true,
+    });
+    const mediaElement = instances.find((audio) => audio.src === "one");
+    expect(mediaElement).toBeDefined();
+    const createdAfterFirstLoad = instances.length;
+    mediaElement!.dispatchEvent(new Event("loadedmetadata"));
+    mediaElement!.dispatchEvent(new Event("loadeddata"));
+
+    player.play();
+    await Promise.resolve();
+    mediaElement!.dispatchEvent(new Event("ended"));
+
+    expect(player.getIndex()).toBe(1);
+    expect(mediaElement!.src).toBe("two");
+    expect(instances).toHaveLength(createdAfterFirstLoad);
+    mediaElement!.dispatchEvent(new Event("loadedmetadata"));
+    mediaElement!.dispatchEvent(new Event("loadeddata"));
+    await Promise.resolve();
+    expect(mediaElement!.paused).toBe(false);
+
+    player.removeAllTracks();
+  });
+
   it("defers the next request until the active stream has a safe buffer", () => {
     vi.useFakeTimers();
     const instances: FakeAudio[] = [];

--- a/app/listen/src/lib/gapless5/gapless5.js
+++ b/app/listen/src/lib/gapless5/gapless5.js
@@ -200,6 +200,94 @@ function Gapless5Source(parentPlayer, parentLog, inAudioPath) {
     return getBufferedAheadSeconds(audio);
   };
 
+  const onHtml5LoadedDataDebug = () => {
+    if (!audio) return;
+    devLog(
+      "gapless5",
+      "html5 loadeddata",
+      {
+        path: this.audioPath,
+        readyState: audio.readyState,
+        networkState: audio.networkState,
+      },
+      "debug",
+    );
+  };
+
+  const onHtml5CanPlayDebug = () => {
+    if (!audio) return;
+    devLog(
+      "gapless5",
+      "html5 canplay",
+      {
+        path: this.audioPath,
+        readyState: audio.readyState,
+        networkState: audio.networkState,
+      },
+      "debug",
+    );
+  };
+
+  const onHtml5Error = (err) => {
+    if (!audio) return;
+    if (buffer !== null && state === Gapless5State.Play) {
+      log.warn(
+        `HTML5 audio error ignored (WebAudio is live): ${this.audioPath}`,
+      );
+      return;
+    }
+    if (player.useWebAudio && request !== null && audio.error?.code === 4) {
+      log.warn(
+        `HTML5 audio cannot play ${this.audioPath}; waiting for WebAudio decode`,
+      );
+      devLog(
+        "gapless5",
+        "html5 unsupported; waiting for webaudio",
+        {
+          path: this.audioPath,
+          readyState: audio.readyState,
+          networkState: audio.networkState,
+        },
+        "warn",
+      );
+      return;
+    }
+    devLog(
+      "gapless5",
+      "html5 error",
+      {
+        path: this.audioPath,
+        code: audio.error?.code ?? null,
+        message: audio.error?.message ?? null,
+        readyState: audio.readyState,
+        networkState: audio.networkState,
+      },
+      "error",
+    );
+    onError(err);
+  };
+
+  const detachHtml5Listeners = (audioObj) => {
+    audioObj.removeEventListener(
+      "loadedmetadata",
+      onLoadedHTML5Metadata,
+      false,
+    );
+    audioObj.removeEventListener("loadeddata", onLoadedHTML5Audio, false);
+    audioObj.removeEventListener("canplay", onLoadedHTML5Audio, false);
+    audioObj.removeEventListener("canplaythrough", onLoadedHTML5Audio, false);
+    audioObj.removeEventListener("ended", onEnded, false);
+    audioObj.removeEventListener("loadeddata", onHtml5LoadedDataDebug, false);
+    audioObj.removeEventListener("canplay", onHtml5CanPlayDebug, false);
+    audioObj.removeEventListener("error", onHtml5Error, false);
+  };
+
+  this.releasePersistentHTML5Audio = () => {
+    if (!audio) return;
+    detachHtml5Listeners(audio);
+    audio = null;
+  };
+
   this.unload = (isError) => {
     this.stop();
     setState(isError ? Gapless5State.Error : Gapless5State.None);
@@ -207,17 +295,18 @@ function Gapless5Source(parentPlayer, parentLog, inAudioPath) {
       request.abort();
     }
     if (audio) {
-      audio.removeEventListener("loadedmetadata", onLoadedHTML5Metadata, false);
-      audio.removeEventListener("loadeddata", onLoadedHTML5Audio, false);
-      audio.removeEventListener("canplay", onLoadedHTML5Audio, false);
-      audio.removeEventListener("canplaythrough", onLoadedHTML5Audio, false);
-      audio.removeEventListener("ended", onEnded, false);
-      try {
-        audio.removeAttribute?.("src");
-        audio.srcObject = null;
-        audio.load();
-      } catch {
-        // Releasing a detached media element is best-effort.
+      const audioObj = audio;
+      detachHtml5Listeners(audioObj);
+      if (player.persistentHTML5Audio) {
+        player.releasePersistentHTML5Audio(this, true);
+      } else {
+        try {
+          audioObj.removeAttribute?.("src");
+          audioObj.srcObject = null;
+          audioObj.load();
+        } catch {
+          // Releasing a detached media element is best-effort.
+        }
       }
     }
     audio = null;
@@ -545,7 +634,10 @@ function Gapless5Source(parentPlayer, parentLog, inAudioPath) {
         }
       }
       if (audio !== null) {
-        audio.volume = this.getVolume();
+        const nextVolume = this.getVolume();
+        if (Math.abs(audio.volume - nextVolume) > 0.001) {
+          audio.volume = nextVolume;
+        }
       }
       if (gainNode !== null) {
         const { currentTime } = window.gapless5AudioContext;
@@ -734,7 +826,9 @@ function Gapless5Source(parentPlayer, parentLog, inAudioPath) {
     }
     if (player.useHTML5Audio) {
       const getHtml5Audio = () => {
-        const audioObj = new Audio();
+        const audioObj = player.persistentHTML5Audio
+          ? player.acquirePersistentHTML5Audio(this)
+          : new Audio();
         audioObj.controls = false;
         audioObj.preload = "auto";
         audioObj.crossOrigin = "anonymous";
@@ -754,36 +848,8 @@ function Gapless5Source(parentPlayer, parentLog, inAudioPath) {
         // to drop the browser MediaSession. The media element's native ended
         // event remains the authoritative fallback while audio is active.
         audioObj.addEventListener("ended", onEnded, false);
-        audioObj.addEventListener(
-          "loadeddata",
-          () =>
-            devLog(
-              "gapless5",
-              "html5 loadeddata",
-              {
-                path: audioPath,
-                readyState: audioObj.readyState,
-                networkState: audioObj.networkState,
-              },
-              "debug",
-            ),
-          false,
-        );
-        audioObj.addEventListener(
-          "canplay",
-          () =>
-            devLog(
-              "gapless5",
-              "html5 canplay",
-              {
-                path: audioPath,
-                readyState: audioObj.readyState,
-                networkState: audioObj.networkState,
-              },
-              "debug",
-            ),
-          false,
-        );
+        audioObj.addEventListener("loadeddata", onHtml5LoadedDataDebug, false);
+        audioObj.addEventListener("canplay", onHtml5CanPlayDebug, false);
         // [vendored patch] Once WebAudio has taken over (buffer !== null
         // + state === Play), the HTML5 element is dormant: source of
         // sound is the decoded RAM buffer, not the <audio> tag. A
@@ -791,51 +857,7 @@ function Gapless5Source(parentPlayer, parentLog, inAudioPath) {
         // the browser is still chewing on the stream) is irrelevant
         // and must NOT kill playback. If WebAudio hasn't switched yet,
         // the HTML5 element IS the source and we do want to escalate.
-        audioObj.addEventListener(
-          "error",
-          (err) => {
-            if (buffer !== null && state === Gapless5State.Play) {
-              log.warn(
-                `HTML5 audio error ignored (WebAudio is live): ${audioPath}`,
-              );
-              return;
-            }
-            if (
-              player.useWebAudio &&
-              request !== null &&
-              audioObj.error?.code === 4
-            ) {
-              log.warn(
-                `HTML5 audio cannot play ${audioPath}; waiting for WebAudio decode`,
-              );
-              devLog(
-                "gapless5",
-                "html5 unsupported; waiting for webaudio",
-                {
-                  path: audioPath,
-                  readyState: audioObj.readyState,
-                  networkState: audioObj.networkState,
-                },
-                "warn",
-              );
-              return;
-            }
-            devLog(
-              "gapless5",
-              "html5 error",
-              {
-                path: audioPath,
-                code: audioObj.error?.code ?? null,
-                message: audioObj.error?.message ?? null,
-                readyState: audioObj.readyState,
-                networkState: audioObj.networkState,
-              },
-              "error",
-            );
-            onError(err);
-          },
-          false,
-        );
+        audioObj.addEventListener("error", onHtml5Error, false);
         // TODO: switch to audio.networkState, now that it's universally supported
         return audioObj;
       };
@@ -1384,6 +1406,35 @@ function Gapless5(options = {}, deprecated = {}) {
   // these default to true if not defined
   this.useWebAudio = options.useWebAudio !== false;
   this.useHTML5Audio = options.useHTML5Audio !== false;
+  this.persistentHTML5Audio =
+    this.useHTML5Audio && options.persistentHTML5Audio === true;
+  this.persistentAudioElement = this.persistentHTML5Audio ? new Audio() : null;
+  this.persistentAudioOwner = null;
+  this.acquirePersistentHTML5Audio = (owner) => {
+    if (!this.persistentAudioElement) {
+      return new Audio();
+    }
+    if (this.persistentAudioOwner && this.persistentAudioOwner !== owner) {
+      this.persistentAudioElement.pause();
+      this.persistentAudioOwner.releasePersistentHTML5Audio();
+    }
+    this.persistentAudioOwner = owner;
+    return this.persistentAudioElement;
+  };
+  this.releasePersistentHTML5Audio = (owner, clearMedia = false) => {
+    if (!this.persistentAudioElement || this.persistentAudioOwner !== owner) {
+      return;
+    }
+    this.persistentAudioOwner = null;
+    if (!clearMedia) return;
+    try {
+      this.persistentAudioElement.removeAttribute?.("src");
+      this.persistentAudioElement.srcObject = null;
+      this.persistentAudioElement.load();
+    } catch {
+      // Releasing the final persistent media source is best-effort.
+    }
+  };
   this.playbackRate = options.playbackRate || 1.0;
   this.id = options.guiId || Math.floor((1 + Math.random()) * 0x10000);
   window.gapless5Players[this.id] = this;

--- a/app/listen/src/lib/playback-engine-factory.test.ts
+++ b/app/listen/src/lib/playback-engine-factory.test.ts
@@ -36,6 +36,7 @@ vi.mock("@/lib/gapless5/gapless5", () => ({
 }));
 
 vi.mock("@/lib/mobile-audio-mode", () => ({
+  isMobileAudioRuntime: false,
   stableMobileAudioPipeline: false,
 }));
 

--- a/app/listen/src/lib/playback-qoe.test.ts
+++ b/app/listen/src/lib/playback-qoe.test.ts
@@ -42,6 +42,8 @@ describe("playback QoE", () => {
         url: "https://peer.example/private-ticket",
         downlinkMbps: 0.5,
         rttMs: 900,
+        runtime: "android_native",
+        engine: "media3",
       }),
     ).toEqual({
       event: "startup",
@@ -50,6 +52,8 @@ describe("playback QoE", () => {
       effective_policy: "data_saver",
       duration_ms: 240,
       buffered_ahead_seconds: 2.5,
+      runtime: "android_native",
+      engine: "media3",
     });
   });
 

--- a/app/listen/src/lib/playback-qoe.ts
+++ b/app/listen/src/lib/playback-qoe.ts
@@ -1,4 +1,11 @@
 import { apiFetch, getApiBase } from "@/lib/api";
+import {
+  isAndroidBrowser,
+  isAndroidNative,
+  isIosBrowser,
+  isIosNative,
+} from "@/lib/capacitor-runtime";
+import { isTauriRuntime } from "@/lib/platform";
 import type { ConcretePlaybackDeliveryPolicy } from "@/lib/playback-network-quality";
 
 export type PlaybackQoeEventName =
@@ -7,6 +14,13 @@ export type PlaybackQoeEventName =
   | "stall_end"
   | "recovery";
 export type PlaybackQoeOrigin = "local" | "remote" | "imported";
+export type PlaybackQoeRuntime =
+  | "desktop_web"
+  | "mobile_web"
+  | "android_native"
+  | "ios_native"
+  | "tauri";
+export type PlaybackQoeEngine = "gapless" | "media3";
 
 export interface PlaybackQoeInput {
   event: PlaybackQoeEventName;
@@ -16,6 +30,8 @@ export interface PlaybackQoeInput {
   durationMs?: number;
   bufferedAheadSeconds?: number;
   attempt?: number;
+  runtime?: PlaybackQoeRuntime;
+  engine?: PlaybackQoeEngine;
 }
 
 export interface PlaybackQoeEvent {
@@ -26,6 +42,8 @@ export interface PlaybackQoeEvent {
   duration_ms?: number;
   buffered_ahead_seconds?: number;
   attempt?: number;
+  runtime?: PlaybackQoeRuntime;
+  engine?: PlaybackQoeEngine;
 }
 
 const MAX_EVENTS_PER_SESSION = 24;
@@ -66,6 +84,28 @@ function isConcretePolicy(
   return ["original", "balanced", "data_saver"].includes(String(value));
 }
 
+function isRuntime(value: unknown): value is PlaybackQoeRuntime {
+  return [
+    "desktop_web",
+    "mobile_web",
+    "android_native",
+    "ios_native",
+    "tauri",
+  ].includes(String(value));
+}
+
+function isEngine(value: unknown): value is PlaybackQoeEngine {
+  return ["gapless", "media3"].includes(String(value));
+}
+
+export function getPlaybackQoeRuntime(): PlaybackQoeRuntime {
+  if (isAndroidNative) return "android_native";
+  if (isIosNative) return "ios_native";
+  if (isTauriRuntime) return "tauri";
+  if (isAndroidBrowser || isIosBrowser) return "mobile_web";
+  return "desktop_web";
+}
+
 /** Shape telemetry explicitly, discarding every identifier and network hint. */
 export function shapePlaybackQoeEvent(
   input: PlaybackQoeInput | Record<string, unknown>,
@@ -97,6 +137,8 @@ export function shapePlaybackQoeEvent(
     event.buffered_ahead_seconds = bufferedAheadSeconds;
   }
   if (attempt !== undefined) event.attempt = attempt;
+  if (isRuntime(input.runtime)) event.runtime = input.runtime;
+  if (isEngine(input.engine)) event.engine = input.engine;
   return event;
 }
 

--- a/app/listen/src/lib/player-playback-prefs.test.ts
+++ b/app/listen/src/lib/player-playback-prefs.test.ts
@@ -20,6 +20,10 @@ import {
 
 beforeEach(() => {
   localStorage.clear();
+  Object.defineProperty(window, "innerWidth", {
+    configurable: true,
+    value: 1024,
+  });
 });
 
 afterEach(() => {
@@ -56,6 +60,37 @@ describe("crossfade", () => {
     expect(handler).toHaveBeenCalled();
     window.removeEventListener(PLAYER_PLAYBACK_PREFS_EVENT, handler);
   });
+
+  it("ignores and clears a legacy crossfade value on mobile", () => {
+    Object.defineProperty(window, "innerWidth", {
+      configurable: true,
+      value: 390,
+    });
+    localStorage.setItem("listen-player-crossfade-seconds", "4");
+
+    expect(getCrossfadeDurationPreference()).toBe(0);
+    expect(localStorage.getItem("listen-player-crossfade-seconds")).toBeNull();
+  });
+
+  it("cannot enable crossfade on mobile", () => {
+    Object.defineProperty(window, "innerWidth", {
+      configurable: true,
+      value: 390,
+    });
+    const handler = vi.fn();
+    window.addEventListener(PLAYER_PLAYBACK_PREFS_EVENT, handler);
+
+    setCrossfadeDurationPreference(5);
+
+    expect(getCrossfadeDurationPreference()).toBe(0);
+    expect(localStorage.getItem("listen-player-crossfade-seconds")).toBeNull();
+    expect(handler).toHaveBeenCalledWith(
+      expect.objectContaining({
+        detail: { crossfadeSeconds: 0 },
+      }),
+    );
+    window.removeEventListener(PLAYER_PLAYBACK_PREFS_EVENT, handler);
+  });
 });
 
 describe("smart crossfade", () => {
@@ -71,6 +106,22 @@ describe("smart crossfade", () => {
   it("round-trips", () => {
     setSmartCrossfadePreference(false);
     expect(getSmartCrossfadePreference()).toBe(false);
+  });
+
+  it("cannot enable smart transitions on mobile", () => {
+    Object.defineProperty(window, "innerWidth", {
+      configurable: true,
+      value: 390,
+    });
+    localStorage.setItem("listen-player-smart-crossfade", "true");
+
+    expect(getSmartCrossfadePreference()).toBe(false);
+    expect(localStorage.getItem("listen-player-smart-crossfade")).toBeNull();
+
+    setSmartCrossfadePreference(true);
+
+    expect(getSmartCrossfadePreference()).toBe(false);
+    expect(localStorage.getItem("listen-player-smart-crossfade")).toBeNull();
   });
 });
 
@@ -180,5 +231,18 @@ describe("mobile enhanced audio", () => {
   it("round-trips", () => {
     setMobileEnhancedAudioPreference(true);
     expect(getMobileEnhancedAudioPreference()).toBe(true);
+  });
+
+  it("ignores and clears the experimental pipeline on mobile", () => {
+    Object.defineProperty(window, "innerWidth", {
+      configurable: true,
+      value: 390,
+    });
+    localStorage.setItem("listen-player-mobile-enhanced-audio", "true");
+
+    expect(getMobileEnhancedAudioPreference()).toBe(false);
+    expect(
+      localStorage.getItem("listen-player-mobile-enhanced-audio"),
+    ).toBeNull();
   });
 });

--- a/app/listen/src/lib/player-playback-prefs.ts
+++ b/app/listen/src/lib/player-playback-prefs.ts
@@ -34,7 +34,7 @@ const PLAYBACK_DELIVERY_POLICIES = new Set<PlaybackDeliveryPreference>([
   "data_saver",
 ]);
 
-function isMobileRuntime(): boolean {
+export function isMobilePlaybackRuntime(): boolean {
   if (typeof window === "undefined" || typeof navigator === "undefined")
     return false;
   const ua = navigator.userAgent || "";
@@ -69,7 +69,7 @@ function normalizePlaybackDeliveryPolicy(
 }
 
 export function getDefaultPlaybackDeliveryPolicy(): PlaybackDeliveryPolicy {
-  return isMobileRuntime() ? "balanced" : "original";
+  return isMobilePlaybackRuntime() ? "balanced" : "original";
 }
 
 export function getPlaybackDeliveryPolicyPreference(): PlaybackDeliveryPreference {
@@ -132,6 +132,10 @@ export function setPlaybackDeliveryPolicyPreference(
 
 export function getMobileEnhancedAudioPreference(): boolean {
   try {
+    if (isMobilePlaybackRuntime()) {
+      localStorage.removeItem(MOBILE_ENHANCED_AUDIO_KEY);
+      return false;
+    }
     return localStorage.getItem(MOBILE_ENHANCED_AUDIO_KEY) === "true";
   } catch {
     return false;
@@ -140,10 +144,18 @@ export function getMobileEnhancedAudioPreference(): boolean {
 
 export function setMobileEnhancedAudioPreference(enabled: boolean) {
   try {
-    localStorage.setItem(MOBILE_ENHANCED_AUDIO_KEY, enabled ? "true" : "false");
+    const effectiveEnabled = isMobilePlaybackRuntime() ? false : enabled;
+    if (isMobilePlaybackRuntime()) {
+      localStorage.removeItem(MOBILE_ENHANCED_AUDIO_KEY);
+    } else {
+      localStorage.setItem(
+        MOBILE_ENHANCED_AUDIO_KEY,
+        effectiveEnabled ? "true" : "false",
+      );
+    }
     window.dispatchEvent(
       new CustomEvent(PLAYER_PLAYBACK_PREFS_EVENT, {
-        detail: { mobileEnhancedAudioEnabled: enabled },
+        detail: { mobileEnhancedAudioEnabled: effectiveEnabled },
       }),
     );
   } catch {
@@ -153,6 +165,10 @@ export function setMobileEnhancedAudioPreference(enabled: boolean) {
 
 export function getCrossfadeDurationPreference(): number {
   try {
+    if (isMobilePlaybackRuntime()) {
+      localStorage.removeItem(CROSSFADE_DURATION_KEY);
+      return 0;
+    }
     const raw = localStorage.getItem(CROSSFADE_DURATION_KEY);
     if (!raw) return 0;
     const parsed = Number.parseFloat(raw);
@@ -164,9 +180,15 @@ export function getCrossfadeDurationPreference(): number {
 }
 
 export function setCrossfadeDurationPreference(seconds: number) {
-  const value = Math.max(0, Math.min(seconds, 12));
+  const value = isMobilePlaybackRuntime()
+    ? 0
+    : Math.max(0, Math.min(seconds, 12));
   try {
-    localStorage.setItem(CROSSFADE_DURATION_KEY, String(value));
+    if (value === 0 && isMobilePlaybackRuntime()) {
+      localStorage.removeItem(CROSSFADE_DURATION_KEY);
+    } else {
+      localStorage.setItem(CROSSFADE_DURATION_KEY, String(value));
+    }
     window.dispatchEvent(
       new CustomEvent(PLAYER_PLAYBACK_PREFS_EVENT, {
         detail: { crossfadeSeconds: value },
@@ -179,6 +201,10 @@ export function setCrossfadeDurationPreference(seconds: number) {
 
 export function getSmartCrossfadePreference(): boolean {
   try {
+    if (isMobilePlaybackRuntime()) {
+      localStorage.removeItem(SMART_CROSSFADE_KEY);
+      return false;
+    }
     const raw = localStorage.getItem(SMART_CROSSFADE_KEY);
     if (raw == null) return true;
     return raw !== "false";
@@ -189,10 +215,18 @@ export function getSmartCrossfadePreference(): boolean {
 
 export function setSmartCrossfadePreference(enabled: boolean) {
   try {
-    localStorage.setItem(SMART_CROSSFADE_KEY, enabled ? "true" : "false");
+    const effectiveEnabled = isMobilePlaybackRuntime() ? false : enabled;
+    if (isMobilePlaybackRuntime()) {
+      localStorage.removeItem(SMART_CROSSFADE_KEY);
+    } else {
+      localStorage.setItem(
+        SMART_CROSSFADE_KEY,
+        effectiveEnabled ? "true" : "false",
+      );
+    }
     window.dispatchEvent(
       new CustomEvent(PLAYER_PLAYBACK_PREFS_EVENT, {
-        detail: { smartCrossfadeEnabled: enabled },
+        detail: { smartCrossfadeEnabled: effectiveEnabled },
       }),
     );
   } catch {

--- a/app/listen/src/pages/Settings.test.tsx
+++ b/app/listen/src/pages/Settings.test.tsx
@@ -37,6 +37,10 @@ vi.mock("@/lib/api", async (importOriginal) => {
 describe("Settings", () => {
   beforeEach(() => {
     localStorage.clear();
+    Object.defineProperty(window, "innerWidth", {
+      configurable: true,
+      value: 1024,
+    });
   });
 
   it("localizes the settings page chrome", () => {
@@ -84,6 +88,28 @@ describe("Settings", () => {
 
     await user.click(auto);
     expect(localStorage.getItem("listen-player-delivery-policy")).toBe("auto");
+  });
+
+  it("hides crossfade controls on mobile", () => {
+    Object.defineProperty(window, "innerWidth", {
+      configurable: true,
+      value: 390,
+    });
+
+    renderWithListenProviders(<Settings />, { locale: "en" });
+
+    expect(screen.queryByText("Crossfade")).not.toBeInTheDocument();
+    expect(screen.queryByText("Smart transitions")).not.toBeInTheDocument();
+    expect(
+      screen.queryByText("Enhanced mobile audio (EQ)"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("keeps crossfade controls on desktop", () => {
+    renderWithListenProviders(<Settings />, { locale: "en" });
+
+    expect(screen.getByText("Crossfade")).toBeInTheDocument();
+    expect(screen.getByText("Smart transitions")).toBeInTheDocument();
   });
 
   it("keeps remote scrobbling opt-in and persists an explicit toggle", async () => {

--- a/app/listen/src/pages/Settings.tsx
+++ b/app/listen/src/pages/Settings.tsx
@@ -1,12 +1,11 @@
 import {
   getCrossfadeDurationPreference,
   getInfinitePlaybackPreference,
-  getMobileEnhancedAudioPreference,
+  isMobilePlaybackRuntime,
   getPlaybackDeliveryPolicyPreference,
   getSmartCrossfadePreference,
   getSmartPlaylistSuggestionsCadencePreference,
   getSmartPlaylistSuggestionsPreference,
-  setMobileEnhancedAudioPreference,
   setPlaybackDeliveryPolicyPreference,
   setInfinitePlaybackPreference,
   setCrossfadeDurationPreference,
@@ -55,7 +54,6 @@ import {
 import { ServersSection } from "@/components/settings/ServersSection";
 import { ConnectDevicesSection } from "@/components/settings/ConnectDevicesSection";
 import { api } from "@/lib/api";
-import { isMobileAudioRuntime } from "@/lib/mobile-audio-mode";
 import { isTauriRuntime } from "@/lib/platform";
 import {
   subscribeSleepTimer,
@@ -317,9 +315,7 @@ export function Settings() {
   const [playbackDeliveryPolicy, setPlaybackDeliveryPolicy] = useState(
     getPlaybackDeliveryPolicyPreference,
   );
-  const [mobileEnhancedAudioEnabled, setMobileEnhancedAudioEnabled] = useState(
-    getMobileEnhancedAudioPreference,
-  );
+  const mobilePlaybackRuntime = isMobilePlaybackRuntime();
   const publicProfilePath = useMemo(() => {
     return user?.username ? `/users/${user.username}` : "/people";
   }, [user?.username]);
@@ -384,22 +380,6 @@ export function Settings() {
             })}
           </div>
         </div>
-        {isMobileAudioRuntime ? (
-          <ToggleRow
-            label={t("settings.playback.enhancedMobileAudio")}
-            description={t("settings.playback.enhancedMobileAudioDescription")}
-            checked={mobileEnhancedAudioEnabled}
-            onChange={(value) => {
-              setMobileEnhancedAudioEnabled(value);
-              setMobileEnhancedAudioPreference(value);
-              toast.info(
-                value
-                  ? t("settings.playback.toasts.enhancedMobileEnabled")
-                  : t("settings.playback.toasts.enhancedMobileDisabled"),
-              );
-            }}
-          />
-        ) : null}
         <ToggleRow
           label={t("settings.playback.infinitePlayback")}
           description={t("settings.playback.infinitePlaybackDescription")}
@@ -409,32 +389,36 @@ export function Settings() {
             setInfinitePlaybackPreference(value);
           }}
         />
-        <ToggleRow
-          label={t("settings.playback.smartTransitions")}
-          description={t("settings.playback.smartTransitionsDescription")}
-          checked={smartCrossfadeEnabled}
-          onChange={(value) => {
-            setSmartCrossfadeEnabled(value);
-            setSmartCrossfadePreference(value);
-          }}
-        />
-        <RangeRow
-          label={t("settings.playback.crossfade")}
-          description={t("settings.playback.crossfadeDescription")}
-          value={crossfadeSeconds}
-          min={0}
-          max={12}
-          step={1}
-          displayValue={
-            crossfadeSeconds === 0
-              ? t("common.off")
-              : t("common.secondsShort", { count: crossfadeSeconds })
-          }
-          onChange={(value) => {
-            setCrossfadeSeconds(value);
-            setCrossfadeDurationPreference(value);
-          }}
-        />
+        {!mobilePlaybackRuntime ? (
+          <>
+            <ToggleRow
+              label={t("settings.playback.smartTransitions")}
+              description={t("settings.playback.smartTransitionsDescription")}
+              checked={smartCrossfadeEnabled}
+              onChange={(value) => {
+                setSmartCrossfadeEnabled(value);
+                setSmartCrossfadePreference(value);
+              }}
+            />
+            <RangeRow
+              label={t("settings.playback.crossfade")}
+              description={t("settings.playback.crossfadeDescription")}
+              value={crossfadeSeconds}
+              min={0}
+              max={12}
+              step={1}
+              displayValue={
+                crossfadeSeconds === 0
+                  ? t("common.off")
+                  : t("common.secondsShort", { count: crossfadeSeconds })
+              }
+              onChange={(value) => {
+                setCrossfadeSeconds(value);
+                setCrossfadeDurationPreference(value);
+              }}
+            />
+          </>
+        ) : null}
         <ToggleRow
           label={t("settings.playback.smartPlaylistSuggestions")}
           description={t(

--- a/app/listen/src/types/gapless5.d.ts
+++ b/app/listen/src/types/gapless5.d.ts
@@ -15,6 +15,7 @@ declare module "@/lib/gapless5/gapless5" {
     crossfade?: number;
     // Runtime values: None=1, Linear=2, EqualPower=3
     crossfadeShape?: number;
+    persistentHTML5Audio?: boolean;
     playbackRate?: number;
     // Runtime values: Debug=1, Info=2, Warning=3, Error=4, None=5
     logLevel?: number;

--- a/app/tests/test_playback_telemetry.py
+++ b/app/tests/test_playback_telemetry.py
@@ -50,6 +50,8 @@ def test_qoe_ingestion_records_only_low_cardinality_metrics(monkeypatch):
                     "requested_policy": "original",
                     "effective_policy": "original",
                     "duration_ms": 215,
+                    "runtime": "android_native",
+                    "engine": "media3",
                 },
                 {
                     "event": "stall_start",
@@ -80,6 +82,8 @@ def test_qoe_ingestion_records_only_low_cardinality_metrics(monkeypatch):
                 "origin": "local",
                 "requested_policy": "original",
                 "effective_policy": "original",
+                "runtime": "android_native",
+                "engine": "media3",
             },
         ),
         (

--- a/app/tests/test_storage_runtime_contract.py
+++ b/app/tests/test_storage_runtime_contract.py
@@ -106,17 +106,13 @@ def test_deploy_cleanup_retains_rollback_and_prunes_unused_images_and_build_cach
 @pytest.mark.parametrize(
     "compose_name", ["docker-compose.yaml", "docker-compose.home.yaml"]
 )
-def test_traefik_logs_are_bounded_and_use_container_log_rotation(compose_name):
+def test_traefik_logs_exclude_sensitive_request_urls(compose_name):
     traefik = yaml.safe_load((ROOT / compose_name).read_text())["services"]["traefik"]
     command = set(traefik.get("command") or [])
 
     assert "--log.level=INFO" in command
     assert "--log.filePath=" in command
-    assert "--accesslog.filePath=" in command
-    assert "--accesslog.filters.statusCodes=400-599" in command
-    assert "--accesslog.filters.retryAttempts=true" in command
-    assert "--accesslog.filters.minDuration=1s" in command
-    assert "--accesslog.fields.headers.defaultMode=drop" in command
+    assert not any(option.startswith("--accesslog") for option in command)
 
 
 def test_storage_retention_runbook_documents_cache_and_image_safety_controls():

--- a/docker-compose.home.yaml
+++ b/docker-compose.home.yaml
@@ -101,11 +101,6 @@ services:
     command:
       - --log.level=INFO
       - --log.filePath=
-      - --accesslog.filePath=
-      - --accesslog.filters.statusCodes=400-599
-      - --accesslog.filters.retryAttempts=true
-      - --accesslog.filters.minDuration=1s
-      - --accesslog.fields.headers.defaultMode=drop
     security_opt:
       - "no-new-privileges:true"
     environment:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -17,11 +17,6 @@ services:
     command:
       - --log.level=INFO
       - --log.filePath=
-      - --accesslog.filePath=
-      - --accesslog.filters.statusCodes=400-599
-      - --accesslog.filters.retryAttempts=true
-      - --accesslog.filters.minDuration=1s
-      - --accesslog.fields.headers.defaultMode=drop
     security_opt:
       - "no-new-privileges:true"
     networks:

--- a/docs/technical/listen-media-access.md
+++ b/docs/technical/listen-media-access.md
@@ -64,4 +64,8 @@ does not need tickets or URL credentials.
 Both `token` and `media_ticket` query values are sensitive. Backend and native
 playback redactors replace their values before a URL reaches logs, errors or
 bridge payloads. Federation and Cast tickets retain their existing,
-independent trust contracts.
+independent trust contracts. Traefik request access logging is disabled because
+its standard format cannot reliably redact selected query parameters; Crate
+retains application metrics and structured error logs without full request
+URLs. Do not re-enable proxy access logs until the sink strips query strings
+before persistence.


### PR DESCRIPTION
## Summary

- disable and hide crossfade and smart transitions on every mobile runtime while preserving desktop behavior
- keep Android Capacitor on Media3 and clamp native queue/crossfade commands to zero
- preserve one HTML media element across web-mobile track changes to keep MediaSession and Bluetooth ownership stable
- acquire exact-path media tickets before handing streams to the web engine and renew protected artwork deterministically
- label playback QoE by runtime/engine and disable Traefik access logs that could expose query tickets

## Root cause

Mobile playback could switch away from Media3 because of a stale crossfade preference. In web-mobile, Gapless5 replaced and unloaded HTML media elements during queue transitions, which could detach the browser MediaSession. Protected stream and artwork URLs could also cross into playback/UI boundaries before their exact-path ticket was ready.

## User impact

- mobile crossfade is temporarily unavailable and removed from Settings until the Cut 2 native crossfade work
- Android uses the stable Media3 path unless the explicit kill switch is enabled
- web-mobile keeps MediaSession ownership across track changes
- cold stream and artwork access waits for valid path-bound credentials instead of failing transiently

## Validation

- Listen Vitest: 199 files, 1,611 passed, 4 skipped
- focused P0 Vitest: 14 files, 331 passed
- backend Pytest: 16 passed
- Listen typecheck and ESLint passed
- pre-commit Ruff, Prettier and ESLint passed
- Capacitor production build and Android/iOS sync passed
- local Gradle verification unavailable because the host has no JDK; GitHub Android CI remains the authoritative native build check
