### PR TITLE
fix(android): restore playback safely after process death

### DIFF
--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -1,7 +1,7 @@
 name: Build Android
 
-# Tag pushes publish signed, shrunk release artifacts. Manual dispatches build
-# a debug APK only and can never replace the stable release download.
+# Pull requests, main pushes, and manual dispatches validate the mobile app.
+# Only tag pushes build and publish signed, shrunk end-user artifacts.
 on:
   push:
     branches:
@@ -131,48 +131,34 @@ jobs:
         run: ./gradlew bundleRelease assembleRelease lintRelease --no-daemon
         working-directory: app/listen/android
 
-      - name: Build debug APK and instrumentation tests
-        if: ${{ !startsWith(github.ref, 'refs/tags/v') }}
-        run: ./gradlew :app:assembleDebug :app:assembleDebugAndroidTest --no-daemon
-        working-directory: app/listen/android
-
-      - name: Locate Android artifacts
+      - name: Locate Android release artifacts
+        if: startsWith(github.ref, 'refs/tags/v')
         id: locate
         run: |
-          if [[ "$GITHUB_REF" == refs/tags/v* ]]; then
-            APK_PATH=$(find app/listen/android/app/build/outputs/apk/release -name '*.apk' | head -n1)
-            AAB_PATH=$(find app/listen/android/app/build/outputs/bundle/release -name '*.aab' | head -n1)
-            test -n "$AAB_PATH"
-            echo "aab_path=$AAB_PATH" >> "$GITHUB_OUTPUT"
-          else
-            APK_PATH=$(find app/listen/android/app/build/outputs/apk/debug -name '*.apk' | head -n1)
-          fi
+          APK_PATH=$(find app/listen/android/app/build/outputs/apk/release -name '*.apk' | head -n1)
+          AAB_PATH=$(find app/listen/android/app/build/outputs/bundle/release -name '*.aab' | head -n1)
           test -n "$APK_PATH"
+          test -n "$AAB_PATH"
           echo "apk_path=$APK_PATH" >> "$GITHUB_OUTPUT"
-          ls -la "$APK_PATH"
+          echo "aab_path=$AAB_PATH" >> "$GITHUB_OUTPUT"
+          ls -la "$APK_PATH" "$AAB_PATH"
 
-      - name: Prepare published artifacts
+      - name: Prepare published release artifacts
+        if: startsWith(github.ref, 'refs/tags/v')
         id: rename
         run: |
-          TAG_NAME="${GITHUB_REF_NAME}"
-          if [[ "$TAG_NAME" == "" || "$TAG_NAME" == "main" ]]; then
-            TAG_NAME="dev"
-          fi
-          SAFE_TAG_NAME=$(printf '%s' "$TAG_NAME" | sed 's#[^A-Za-z0-9._-]#-#g')
-          if [[ "$SAFE_TAG_NAME" == "" ]]; then
-            SAFE_TAG_NAME="dev"
-          fi
+          SAFE_TAG_NAME=$(printf '%s' "$GITHUB_REF_NAME" | sed 's#[^A-Za-z0-9._-]#-#g')
+          test -n "$SAFE_TAG_NAME"
           APK_DEST="crate-${SAFE_TAG_NAME}.apk"
+          AAB_DEST="crate-${SAFE_TAG_NAME}.aab"
           cp "${{ steps.locate.outputs.apk_path }}" "$APK_DEST"
+          cp "${{ steps.locate.outputs.aab_path }}" "$AAB_DEST"
+          cp "$APK_DEST" "crate.apk"
           echo "apk_dest=$APK_DEST" >> "$GITHUB_OUTPUT"
-          if [[ "$GITHUB_REF" == refs/tags/v* ]]; then
-            AAB_DEST="crate-${SAFE_TAG_NAME}.aab"
-            cp "${{ steps.locate.outputs.aab_path }}" "$AAB_DEST"
-            cp "$APK_DEST" "crate.apk"
-            echo "aab_dest=$AAB_DEST" >> "$GITHUB_OUTPUT"
-          fi
+          echo "aab_dest=$AAB_DEST" >> "$GITHUB_OUTPUT"
 
-      - name: Upload APK build artifact
+      - name: Upload signed APK build artifact
+        if: startsWith(github.ref, 'refs/tags/v')
         uses: actions/upload-artifact@v7
         with:
           name: ${{ steps.rename.outputs.apk_dest }}

--- a/app/crate/api/__init__.py
+++ b/app/crate/api/__init__.py
@@ -118,6 +118,27 @@ def _queue_artwork_variant_backfill() -> None:
     )
 
 
+def _queue_artwork_manifest_permission_repair() -> None:
+    """Queue the one-time cache manifest mode repair for readplane access."""
+    from crate.artwork_tasks import ARTWORK_MANIFEST_PERMISSIONS_VERSION
+    from crate.db.cache_settings import get_setting
+    from crate.db.repositories.tasks import create_task_dedup
+
+    if (
+        get_setting("artwork_manifest_permissions_version")
+        == ARTWORK_MANIFEST_PERMISSIONS_VERSION
+    ):
+        return
+    create_task_dedup(
+        "repair_artwork_variants",
+        {"max_assets": 100_000, "repair_manifest_permissions": True},
+        dedup_key=(
+            "bootstrap:artwork-manifest-permissions:"
+            f"v{ARTWORK_MANIFEST_PERMISSIONS_VERSION}"
+        ),
+    )
+
+
 def _queue_stats_dashboard_backfill() -> None:
     """Prewarm the canonical dashboard projection for every active user."""
     from crate.db.user_stats_dashboard_surface import (
@@ -165,6 +186,7 @@ async def lifespan(app: FastAPI):
     _bootstrap_federation_identity()
     _queue_global_catalog_bootstrap()
     _queue_artwork_variant_backfill()
+    _queue_artwork_manifest_permission_repair()
     _queue_stats_dashboard_backfill()
     _queue_artist_top_track_ranking_backfill()
     from crate.utils import init_musicbrainz

--- a/app/crate/artwork_maintenance.py
+++ b/app/crate/artwork_maintenance.py
@@ -137,6 +137,25 @@ def find_corrupt_artwork_assets(*, max_assets: int = 1000) -> list[ArtworkAsset]
     return corrupt
 
 
+def repair_artwork_manifest_permissions(*, max_assets: int = 1000) -> dict[str, int]:
+    result = {"assets_checked": 0, "permissions_repaired": 0}
+    for asset in _iter_assets(max(1, int(max_assets))):
+        result["assets_checked"] += 1
+        manifest = (
+            artwork_variant_root() / asset.kind / asset.entity_key / "current.json"
+        )
+        try:
+            if not manifest.is_file():
+                continue
+            if manifest.stat().st_mode & 0o777 == 0o644:
+                continue
+            manifest.chmod(0o644)
+            result["permissions_repaired"] += 1
+        except OSError:
+            continue
+    return result
+
+
 def cleanup_artwork_variants(*, max_assets: int = 1000) -> dict[str, int]:
     now = time.time()
     result = {
@@ -189,4 +208,5 @@ __all__ = [
     "cleanup_artwork_variants",
     "find_corrupt_artwork_assets",
     "inspect_artwork_variants",
+    "repair_artwork_manifest_permissions",
 ]

--- a/app/crate/artwork_tasks.py
+++ b/app/crate/artwork_tasks.py
@@ -6,6 +6,7 @@ from crate.artwork_variants import ArtworkAsset
 from crate.db.repositories.tasks import create_task_dedup
 
 ARTWORK_BACKFILL_VERSION = "1"
+ARTWORK_MANIFEST_PERMISSIONS_VERSION = "1"
 
 
 def queue_artwork_materialization(asset: ArtworkAsset, *, reason: str) -> str | None:
@@ -16,4 +17,8 @@ def queue_artwork_materialization(asset: ArtworkAsset, *, reason: str) -> str | 
     )
 
 
-__all__ = ["ARTWORK_BACKFILL_VERSION", "queue_artwork_materialization"]
+__all__ = [
+    "ARTWORK_BACKFILL_VERSION",
+    "ARTWORK_MANIFEST_PERMISSIONS_VERSION",
+    "queue_artwork_materialization",
+]

--- a/app/crate/artwork_variants.py
+++ b/app/crate/artwork_variants.py
@@ -122,6 +122,7 @@ def publish_manifest_atomically(asset: ArtworkAsset, manifest: dict) -> None:
     )
     temporary_path = Path(temporary_name)
     try:
+        os.fchmod(descriptor, 0o644)
         with os.fdopen(descriptor, "w", encoding="utf-8") as handle:
             json.dump(manifest, handle, sort_keys=True, separators=(",", ":"))
             handle.flush()

--- a/app/crate/worker_handlers/artwork.py
+++ b/app/crate/worker_handlers/artwork.py
@@ -9,10 +9,14 @@ from crate.artwork_materializer import materialize_artwork
 from crate.artwork_maintenance import (
     cleanup_artwork_variants,
     find_corrupt_artwork_assets,
+    repair_artwork_manifest_permissions,
 )
 from crate.artwork_sources import resolve_artwork_source
 from crate.artwork_tasks import queue_artwork_materialization
-from crate.artwork_tasks import ARTWORK_BACKFILL_VERSION
+from crate.artwork_tasks import (
+    ARTWORK_BACKFILL_VERSION,
+    ARTWORK_MANIFEST_PERMISSIONS_VERSION,
+)
 from crate.artwork_variants import (
     ARTWORK_KINDS,
     ArtworkAsset,
@@ -234,7 +238,22 @@ def _handle_repair_artwork_variants(task_id: str, params: dict, config: dict) ->
     corrupt = find_corrupt_artwork_assets(max_assets=max_assets)
     for asset in corrupt:
         queue_artwork_materialization(asset, reason="integrity-repair")
-    return {"assets_checked": max_assets, "requeued": len(corrupt)}
+    result = {"assets_checked": max_assets, "requeued": len(corrupt)}
+    if bool(params.get("repair_manifest_permissions")):
+        permissions = repair_artwork_manifest_permissions(max_assets=max_assets)
+        result.update(
+            {
+                "manifest_assets_checked": permissions["assets_checked"],
+                "permissions_repaired": permissions["permissions_repaired"],
+            }
+        )
+        from crate.db.cache_settings import set_setting
+
+        set_setting(
+            "artwork_manifest_permissions_version",
+            ARTWORK_MANIFEST_PERMISSIONS_VERSION,
+        )
+    return result
 
 
 def _handle_resolve_external_artist_artwork(

--- a/app/listen/android/app/src/androidTest/java/app/cratemusic/crate/CrateApplicationInstrumentedTest.java
+++ b/app/listen/android/app/src/androidTest/java/app/cratemusic/crate/CrateApplicationInstrumentedTest.java
@@ -1,11 +1,14 @@
 package app.cratemusic.crate;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
 
 import android.content.Context;
 
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 import androidx.test.platform.app.InstrumentationRegistry;
+import androidx.media3.common.MediaItem;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -17,5 +20,28 @@ public class CrateApplicationInstrumentedTest {
         Context appContext = InstrumentationRegistry.getInstrumentation().getTargetContext();
 
         assertEquals("app.cratemusic.crate", appContext.getPackageName());
+    }
+
+    @Test
+    public void restoredPlaybackItemHasAnOpaqueLocalConfiguration() {
+        CrateNativePlaybackService.NativeTrack track =
+            new CrateNativePlaybackService.NativeTrack(
+                "track-1",
+                "",
+                "",
+                "Track",
+                "Artist",
+                "Album",
+                "https://api.example/artwork/1?media_ticket=secret",
+                180_000L,
+                null
+            );
+
+        MediaItem item = CrateNativePlaybackService.toCheckpointMediaItem(track);
+
+        assertNotNull(item.localConfiguration);
+        assertEquals("crate-resume", item.localConfiguration.uri.getScheme());
+        assertFalse(item.localConfiguration.uri.toString().contains("secret"));
+        assertFalse(item.localConfiguration.uri.toString().contains("api.example"));
     }
 }

--- a/app/listen/android/app/src/main/java/app/cratemusic/crate/CrateNativePlaybackService.java
+++ b/app/listen/android/app/src/main/java/app/cratemusic/crate/CrateNativePlaybackService.java
@@ -928,7 +928,7 @@ public class CrateNativePlaybackService extends MediaSessionService {
             .build();
     }
 
-    private MediaItem toCheckpointMediaItem(NativeTrack track) {
+    static MediaItem toCheckpointMediaItem(NativeTrack track) {
         androidx.media3.common.MediaMetadata.Builder metadata =
             new androidx.media3.common.MediaMetadata.Builder()
                 .setTitle(track.title)
@@ -942,6 +942,13 @@ public class CrateNativePlaybackService extends MediaSessionService {
         }
         return new MediaItem.Builder()
             .setMediaId(track.id)
+            .setUri(
+                new Uri.Builder()
+                    .scheme("crate-resume")
+                    .authority("pending")
+                    .appendPath(track.id)
+                    .build()
+            )
             .setMediaMetadata(metadata.build())
             .build();
     }

--- a/app/listen/src/components/artist/ArtistBioModal.tsx
+++ b/app/listen/src/components/artist/ArtistBioModal.tsx
@@ -17,6 +17,7 @@ import {
   type GenreProfileItem,
 } from "@crate/ui/domain/genres/GenrePill";
 import { api } from "@/lib/api";
+import { AuthenticatedMediaImage } from "@/components/player/AuthenticatedMediaImage";
 import { openExternalUrl } from "@/lib/external-links";
 import { formatCompact } from "@/lib/utils";
 import { Globe, ChevronDown, ChevronUp } from "@crate/ui/icons";
@@ -132,7 +133,7 @@ export function ArtistBioModal({
         <div className="flex items-start justify-between gap-4 px-5 py-5 sm:px-6">
           <div className="flex min-w-0 items-start gap-4">
             <div className="h-16 w-16 flex-shrink-0 overflow-hidden rounded-2xl bg-white/5 shadow-xl">
-              <img
+              <AuthenticatedMediaImage
                 src={photoUrl}
                 alt={artist.name}
                 className="h-full w-full object-cover"

--- a/app/listen/src/components/artist/ArtistHeroSection.tsx
+++ b/app/listen/src/components/artist/ArtistHeroSection.tsx
@@ -20,6 +20,7 @@ import {
   type ArtistInfo,
 } from "@/components/artist/artist-model";
 import { BandcampSupportButton } from "@/components/bandcamp/BandcampSupportButton";
+import { AuthenticatedMediaImage } from "@/components/player/AuthenticatedMediaImage";
 import { ContextMenu, type ContextMenuEntry } from "@crate/ui/domain/actions";
 import { useDismissibleLayer } from "@crate/ui/lib/use-dismissible-layer";
 import { useIsDesktop } from "@crate/ui/lib/use-breakpoint";
@@ -203,20 +204,20 @@ export function ArtistHeroSection({
         : null}
       <div className="relative h-[420px] overflow-hidden sm:h-[400px]">
         {photoUrl ? (
-          <img
+          <AuthenticatedMediaImage
             src={photoUrl}
             alt=""
             className="absolute inset-0 h-full w-full scale-[1.02] object-cover object-[right_20%] brightness-[0.72] contrast-110 opacity-[0.82] sm:hidden"
           />
         ) : heroBackgroundSrc ? (
-          <img
+          <AuthenticatedMediaImage
             src={heroBackgroundSrc}
             alt=""
             className="absolute inset-0 h-full w-full scale-[1.02] object-cover object-[right_20%] brightness-[0.72] contrast-110 opacity-[0.82] sm:hidden"
           />
         ) : null}
         {heroBackgroundSrc ? (
-          <img
+          <AuthenticatedMediaImage
             src={heroBackgroundSrc}
             alt=""
             className="absolute inset-0 h-full w-full scale-[1.02] object-cover object-[right_20%] grayscale brightness-[0.5] contrast-110 opacity-[0.45] hidden sm:block"
@@ -240,13 +241,10 @@ export function ArtistHeroSection({
         <div className="relative mx-auto flex h-full w-full max-w-[1480px] items-end px-4 pb-6 sm:px-6">
           <div className="flex w-full flex-col gap-5 sm:flex-row sm:items-end">
             <div className="hidden h-40 w-40 flex-shrink-0 overflow-hidden rounded-full bg-white/5 shadow-2xl ring-2 ring-white/10 sm:block">
-              <img
+              <AuthenticatedMediaImage
                 src={photoUrl}
                 alt={artist.name}
                 className="h-full w-full object-cover"
-                onError={(e) => {
-                  (e.target as HTMLImageElement).style.display = "none";
-                }}
               />
             </div>
             <div className="max-w-3xl pb-1">

--- a/app/listen/src/components/artist/ArtistModals.test.tsx
+++ b/app/listen/src/components/artist/ArtistModals.test.tsx
@@ -7,9 +7,15 @@ import { ArtistBioModal } from "./ArtistBioModal";
 import { ArtistSetlistModal } from "./ArtistSetlistSection";
 import { I18nProvider } from "@/i18n";
 
-vi.mock("@/lib/api", () => ({
-  api: vi.fn(() => Promise.reject(new Error("skip enrichment in modal tests"))),
-}));
+vi.mock("@/lib/api", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/api")>();
+  return {
+    ...actual,
+    api: vi.fn(() =>
+      Promise.reject(new Error("skip enrichment in modal tests")),
+    ),
+  };
+});
 
 describe("artist mobile modals", () => {
   it("renders probable setlist as a native bottom sheet instead of a floating panel", () => {

--- a/app/listen/src/components/artist/ArtistPageSections.test.tsx
+++ b/app/listen/src/components/artist/ArtistPageSections.test.tsx
@@ -23,6 +23,39 @@ vi.mock("@/components/playlists/PlaylistCard", () => ({
 }));
 
 describe("ArtistPageSections", () => {
+  it("uses authenticated responsive artwork for global album cards", () => {
+    render(
+      <MemoryRouter>
+        <I18nProvider initialLocale="en">
+          <ArtistAlbumsSection
+            artistName="Pearl Jam"
+            artistSlug="pearl-jam"
+            albums={[
+              {
+                id: "global-album-1",
+                entity_uid: "11111111-1111-4111-8111-111111111111",
+                global_album_uid: "global-album-1",
+                name: "Ten",
+                display_name: "Ten",
+                slug: "ten",
+                year: "1991",
+                tracks: 11,
+                formats: ["FLAC"],
+                size_mb: 420,
+                has_cover: true,
+              },
+            ]}
+          />
+        </I18nProvider>
+      </MemoryRouter>,
+    );
+
+    const artwork = screen.getByRole("img", { name: "Ten" });
+    expect(artwork.tagName).toBe("IMG");
+    expect(artwork).toHaveAttribute("sizes");
+    expect(artwork.getAttribute("srcset")).toContain("size=320");
+  });
+
   it("uses the API-provided canonical artist slug for album links", () => {
     render(
       <MemoryRouter>

--- a/app/listen/src/components/artist/ArtistPageSections.tsx
+++ b/app/listen/src/components/artist/ArtistPageSections.tsx
@@ -4,6 +4,7 @@ import { Link, useNavigate } from "react-router";
 
 import { AlbumCard } from "@/components/cards/AlbumCard";
 import { ArtistCard } from "@/components/cards/ArtistCard";
+import { AuthenticatedMediaImage } from "@/components/player/AuthenticatedMediaImage";
 import { PlaylistCard } from "@/components/playlists/PlaylistCard";
 import { useMemo } from "react";
 import { TrackRow, type TrackRowData } from "@/components/cards/TrackRow";
@@ -22,10 +23,14 @@ import {
   type UpcomingItem,
 } from "@/components/upcoming/UpcomingRows";
 import {
+  albumCoverApiUrl,
   albumPagePath,
   artistPagePath,
   artistTopTracksPath,
+  responsiveImageSrcSet,
 } from "@/lib/library-routes";
+
+const ARTIST_ALBUM_IMAGE_WIDTHS = [160, 256, 320, 480] as const;
 
 interface ArtistTopTracksSectionProps {
   artistId?: number;
@@ -185,7 +190,22 @@ function ArtistAlbumItem({
       localAlbumId,
       album.slug,
       globalAlbumUid,
+      album.entity_uid,
     );
+  const coverRouteInput = {
+    albumId: localAlbumId,
+    albumEntityUid: album.entity_uid ?? undefined,
+    globalAlbumUid: album.entity_uid ? undefined : globalAlbumUid,
+    albumSlug: album.slug,
+    artistSlug,
+    artistName,
+    albumName: album.display_name || album.name,
+  };
+  const coverSrcSet = album.cover_url
+    ? undefined
+    : responsiveImageSrcSet(ARTIST_ALBUM_IMAGE_WIDTHS, (size) =>
+        albumCoverApiUrl(coverRouteInput, { size }),
+      );
 
   if (globalAlbumUid) {
     return (
@@ -202,14 +222,14 @@ function ArtistAlbumItem({
       >
         <div className="relative mb-2 aspect-square overflow-hidden rounded-lg bg-white/5">
           {cover ? (
-            <img
+            <AuthenticatedMediaImage
               src={cover}
+              srcSet={coverSrcSet}
+              sizes="(max-width: 639px) 50vw, (max-width: 1023px) 33vw, 20vw"
               alt={album.display_name || album.name}
               loading="lazy"
+              decoding="async"
               className="h-full w-full object-cover"
-              onError={(event) => {
-                (event.target as HTMLImageElement).style.display = "none";
-              }}
             />
           ) : (
             <div className="flex h-full w-full items-center justify-center">

--- a/app/listen/src/components/artist/artist-model.ts
+++ b/app/listen/src/components/artist/artist-model.ts
@@ -181,9 +181,17 @@ export function buildArtistAlbumCover(
   albumId?: number | null,
   albumSlug?: string,
   globalAlbumUid?: string | null,
+  albumEntityUid?: string | null,
 ) {
   return albumCoverApiUrl(
-    { albumId, globalAlbumUid, albumSlug, artistName, albumName },
+    {
+      albumId,
+      albumEntityUid,
+      globalAlbumUid: albumEntityUid ? undefined : globalAlbumUid,
+      albumSlug,
+      artistName,
+      albumName,
+    },
     { size: 512 },
   );
 }

--- a/app/listen/src/components/cards/AlbumCard.test.tsx
+++ b/app/listen/src/components/cards/AlbumCard.test.tsx
@@ -18,6 +18,16 @@ vi.mock("@/lib/api", async (importOriginal) => ({
   resolveMaybeApiAssetUrl: apiMocks.resolveMaybeApiAssetUrl,
 }));
 
+vi.mock("@/components/player/AuthenticatedMediaImage", () => ({
+  AuthenticatedMediaImage: ({
+    src,
+    srcSet,
+    ...props
+  }: React.ImgHTMLAttributes<HTMLImageElement>) => (
+    <img {...props} src={src} srcSet={srcSet} data-authenticated-media="true" />
+  ),
+}));
+
 vi.mock("@/contexts/SavedAlbumsContext", () => ({
   useSavedAlbums: () => ({
     isSaved: () => false,
@@ -69,6 +79,10 @@ describe("AlbumCard", () => {
     expect(screen.getByAltText("Inlet")).toHaveAttribute(
       "src",
       "https://api.example.test/api/catalog/albums/album-global-1/cover?size=256&token=native-token",
+    );
+    expect(screen.getByAltText("Inlet")).toHaveAttribute(
+      "data-authenticated-media",
+      "true",
     );
   });
 

--- a/app/listen/src/components/cards/AlbumCard.tsx
+++ b/app/listen/src/components/cards/AlbumCard.tsx
@@ -11,6 +11,7 @@ import {
 
 import { ItemActionMenu, useItemActionMenu } from "@crate/ui/domain/actions";
 import { useAlbumActionEntries } from "@/components/actions/album-actions";
+import { AuthenticatedMediaImage } from "@/components/player/AuthenticatedMediaImage";
 import { OfflineBadge } from "@crate/ui/domain/offline/OfflineBadge";
 import { useOffline } from "@/contexts/OfflineContext";
 import { usePlayerActions, type Track } from "@/contexts/PlayerContext";
@@ -219,7 +220,7 @@ export const AlbumCard = memo(function AlbumCard({
       }}
     >
       <div className="relative aspect-square rounded-lg overflow-hidden bg-white/5 mb-2">
-        <img
+        <AuthenticatedMediaImage
           src={coverUrl}
           srcSet={coverSrcSet}
           sizes={coverSrcSet ? coverSizes : undefined}
@@ -227,9 +228,6 @@ export const AlbumCard = memo(function AlbumCard({
           loading="lazy"
           decoding="async"
           className="w-full h-full object-cover"
-          onError={(e) => {
-            (e.target as HTMLImageElement).style.display = "none";
-          }}
         />
         {(albumId != null || globalAlbumUid) && (
           <ActionIconButton

--- a/app/listen/src/components/cards/ArtistCard.tsx
+++ b/app/listen/src/components/cards/ArtistCard.tsx
@@ -15,6 +15,7 @@ import { ItemActionMenu, useItemActionMenu } from "@crate/ui/domain/actions";
 import { useHoverCapability } from "@crate/ui/lib/use-hover-capability";
 import { fetchArtistTopTracks } from "@/components/actions/shared";
 import { useArtistActionEntries } from "@/components/actions/artist-actions";
+import { AuthenticatedMediaImage } from "@/components/player/AuthenticatedMediaImage";
 import { useArtistFollows } from "@/contexts/ArtistFollowsContext";
 import { usePlayerActions } from "@/contexts/PlayerContext";
 import { resolveMaybeApiAssetUrl } from "@/lib/api";
@@ -194,7 +195,7 @@ export function ArtistCard({
           </span>
         </div>
         {renderedPhotoUrl ? (
-          <img
+          <AuthenticatedMediaImage
             src={renderedPhotoUrl}
             srcSet={photoSrcSet}
             sizes={photoSrcSet ? `${imageSize}px` : undefined}
@@ -208,7 +209,7 @@ export function ArtistCard({
                 "grayscale saturate-0 brightness-[0.52] contrast-125 transition duration-300 group-hover:brightness-[0.72]",
             )}
             onLoad={() => setLoadedPhotoUrl(renderedPhotoUrl ?? null)}
-            onError={(e) => {
+            onError={() => {
               setLoadedPhotoUrl(null);
               if (
                 isPendingExternalArtwork &&
@@ -222,7 +223,6 @@ export function ArtistCard({
                 }
                 return;
               }
-              (e.target as HTMLImageElement).style.display = "none";
             }}
           />
         ) : null}

--- a/app/listen/src/components/explore/ExploreViews.tsx
+++ b/app/listen/src/components/explore/ExploreViews.tsx
@@ -26,6 +26,7 @@ import { AlbumCard } from "@/components/cards/AlbumCard";
 import { ArtistCard } from "@/components/cards/ArtistCard";
 import { TrackRow, type TrackRowData } from "@/components/cards/TrackRow";
 import { PlaylistCard } from "@/components/playlists/PlaylistCard";
+import { AuthenticatedMediaImage } from "@/components/player/AuthenticatedMediaImage";
 import { CrateLoader } from "@/components/ui/CrateLoader";
 import {
   itemKey,
@@ -421,7 +422,7 @@ export function GenreDetailView({
       <div className="space-y-6">
         <section className="relative -mx-4 -mt-4 h-[420px] overflow-hidden sm:-mx-6 sm:-mt-6 sm:h-[400px] lg:-mx-8 lg:-mt-8">
           {heroCoverUrl ? (
-            <img
+            <AuthenticatedMediaImage
               key={heroCoverUrl}
               src={heroCoverUrl}
               alt={t("genre.coverAlt", { name: data.name })}
@@ -713,7 +714,7 @@ function RelatedGenreCard({
       className="group relative isolate min-h-[132px] overflow-hidden rounded-lg border border-white/10 bg-white/[0.045] p-3 text-left shadow-[0_18px_46px_rgba(0,0,0,0.22)] transition-[border-color,filter,transform] hover:-translate-y-px hover:border-primary/35 hover:drop-shadow-[0_0_14px_rgba(34,211,238,0.18)]"
     >
       {coverUrl ? (
-        <img
+        <AuthenticatedMediaImage
           src={coverUrl}
           alt=""
           className="absolute inset-0 -z-10 h-full w-full scale-[1.04] object-cover opacity-35 saturate-125 transition duration-300 group-hover:opacity-45"

--- a/app/listen/src/components/home/HomeDiscoverySections.tsx
+++ b/app/listen/src/components/home/HomeDiscoverySections.tsx
@@ -32,6 +32,7 @@ import { useArtistActionEntries } from "@/components/actions/artist-actions";
 import { usePlaylistActionEntries } from "@/components/actions/playlist-actions";
 import { AlbumCard } from "@/components/cards/AlbumCard";
 import { ArtistCard } from "@/components/cards/ArtistCard";
+import { AuthenticatedMediaImage } from "@/components/player/AuthenticatedMediaImage";
 import { TrackRow, type TrackRowData } from "@/components/cards/TrackRow";
 import { CoreTracksArtwork } from "@/components/home/CoreTracksArtwork";
 import { MixArtwork } from "@/components/home/MixArtwork";
@@ -665,7 +666,7 @@ function HeroSlide({
     >
       <div className="absolute inset-0 bg-[linear-gradient(140deg,rgba(6,10,14,0.98)_0%,rgba(10,16,22,0.96)_52%,rgba(4,9,13,0.98)_100%)]" />
       {backgroundSrc ? (
-        <img
+        <AuthenticatedMediaImage
           src={backgroundSrc}
           alt=""
           aria-hidden="true"
@@ -922,7 +923,7 @@ function RecentEntityRowFrame({
             className="h-full w-full rounded-xl"
           />
         ) : artworkUrl ? (
-          <img
+          <AuthenticatedMediaImage
             src={artworkUrl}
             alt=""
             loading="lazy"
@@ -1361,12 +1362,15 @@ export function RadioStationCard({
         layout === "grid" ? "w-full min-w-0" : "w-full min-w-0 snap-start",
       )}
     >
-      <div
-        className="aspect-square bg-cover bg-center transition-transform duration-300 group-hover:scale-[1.04]"
-        style={{
-          backgroundImage: artworkUrl ? `url(${artworkUrl})` : undefined,
-        }}
-      />
+      {artworkUrl ? (
+        <AuthenticatedMediaImage
+          src={artworkUrl}
+          alt=""
+          className="aspect-square h-full w-full object-cover object-center transition-transform duration-300 group-hover:scale-[1.04]"
+        />
+      ) : (
+        <div className="aspect-square" />
+      )}
       <div className="absolute inset-0 bg-[linear-gradient(180deg,transparent_30%,rgba(6,8,12,0.92)_100%)]" />
       <div className="absolute left-3 top-3 inline-flex items-center gap-1.5 rounded-full border border-primary/20 bg-black/35 px-2 py-1 text-[10px] font-semibold uppercase tracking-[0.16em] text-primary shadow-[0_0_18px_rgba(6,182,212,0.16)] backdrop-blur-md">
         <Radio size={12} className="inline-block" /> {seedTypeLabel}

--- a/app/listen/src/components/home/HomeUpcomingSections.tsx
+++ b/app/listen/src/components/home/HomeUpcomingSections.tsx
@@ -18,6 +18,7 @@ import {
   artistPhotoApiUrl,
 } from "@/lib/library-routes";
 import { resolveMaybeApiAssetUrl } from "@/lib/api";
+import { AuthenticatedMediaImage } from "@/components/player/AuthenticatedMediaImage";
 
 import type {
   HomeUpcomingInsight,
@@ -118,7 +119,7 @@ export function HomeUpcomingSection({
         <div className="relative min-h-[270px] overflow-hidden rounded-[28px] border border-white/10 bg-[#101218] p-5 sm:p-6">
           <div className="absolute inset-0 bg-[radial-gradient(circle_at_18%_20%,rgba(6,182,212,0.34),transparent_35%),linear-gradient(120deg,rgba(255,255,255,0.08),rgba(255,255,255,0.02))]" />
           {artistImage ? (
-            <img
+            <AuthenticatedMediaImage
               src={artistImage}
               alt=""
               loading="lazy"

--- a/app/listen/src/components/home/MixArtwork.tsx
+++ b/app/listen/src/components/home/MixArtwork.tsx
@@ -1,4 +1,5 @@
 import { artistPhotoApiUrl } from "@/lib/library-routes";
+import { AuthenticatedMediaImage } from "@/components/player/AuthenticatedMediaImage";
 import { cn } from "@/lib/utils";
 
 import type {
@@ -49,7 +50,7 @@ export function MixArtwork({
               className="relative overflow-hidden bg-[linear-gradient(145deg,rgba(30,16,22,0.96),rgba(10,12,16,1))]"
             >
               {photoUrl ? (
-                <img
+                <AuthenticatedMediaImage
                   src={photoUrl}
                   alt={artist?.artist_name || ""}
                   className="h-full w-full object-cover"

--- a/app/listen/src/components/layout/topbar/TopBarSearch.tsx
+++ b/app/listen/src/components/layout/topbar/TopBarSearch.tsx
@@ -21,6 +21,7 @@ import { useTranslation } from "react-i18next";
 import { AppPopover } from "@crate/ui/primitives/AppPopover";
 import { useIsDesktop } from "@crate/ui/lib/use-breakpoint";
 import { usePlayerActions } from "@/contexts/PlayerContext";
+import { AuthenticatedMediaImage } from "@/components/player/AuthenticatedMediaImage";
 import { useHoverCapability } from "@/hooks/use-hover-capability";
 import { useDismissibleLayer } from "@crate/ui/lib/use-dismissible-layer";
 import { api, ApiError } from "@/lib/api";
@@ -39,7 +40,7 @@ import {
 function SearchResultThumb({ item }: { item: TopBarSearchItem }) {
   if (item.imageUrl) {
     return (
-      <img
+      <AuthenticatedMediaImage
         src={item.imageUrl}
         alt=""
         className={`h-8 w-8 shrink-0 object-cover bg-white/5 ${

--- a/app/listen/src/components/layout/topbar/TopBarUserMenu.tsx
+++ b/app/listen/src/components/layout/topbar/TopBarUserMenu.tsx
@@ -23,6 +23,7 @@ import {
   ModalFooter,
   ModalHeader,
 } from "@crate/ui/primitives/AppModal";
+import { AuthenticatedMediaImage } from "@/components/player/AuthenticatedMediaImage";
 import {
   ContextMenu,
   type ContextMenuEntry,
@@ -167,7 +168,7 @@ export function TopBarUserMenu() {
           {...actionMenu.longPressHandlers}
         >
           {avatarUrl ? (
-            <img
+            <AuthenticatedMediaImage
               src={avatarUrl}
               alt=""
               onError={handleAvatarError}

--- a/app/listen/src/components/player/AuthenticatedMediaImage.test.tsx
+++ b/app/listen/src/components/player/AuthenticatedMediaImage.test.tsx
@@ -12,6 +12,10 @@ vi.mock("@/hooks/use-media-access-version", () => ({
 
 vi.mock("@/lib/api", () => ({
   ensureMediaAccessUrl: ensureMediaAccessUrlMock,
+  isUsableMediaAssetUrl: (url: string | null | undefined) =>
+    Boolean(url?.includes("ticket-version") || url?.includes("media_ticket")),
+  requiresMediaAccessTicket: (url: string | null | undefined) =>
+    Boolean(url?.startsWith("/api/")),
   resolveMaybeApiAssetUrl: (url: string | null | undefined) =>
     url ? `${url}?ticket-version=${mediaVersion.value}` : null,
 }));
@@ -27,7 +31,7 @@ describe("AuthenticatedMediaImage", () => {
     );
   });
 
-  it("re-resolves the source when media tickets change", () => {
+  it("keeps a loaded source stable when media tickets rotate", () => {
     const { rerender } = render(
       <AuthenticatedMediaImage src="/api/albums/1/cover" alt="Cover" />,
     );
@@ -41,11 +45,53 @@ describe("AuthenticatedMediaImage", () => {
 
     expect(screen.getByRole("img", { name: "Cover" })).toHaveAttribute(
       "src",
-      "/api/albums/1/cover?ticket-version=2",
+      "/api/albums/1/cover?ticket-version=1",
     );
   });
 
-  it("renews a failed protected image once", async () => {
+  it("keeps a loaded source stable when bearer credentials rotate", () => {
+    const { rerender } = render(
+      <AuthenticatedMediaImage
+        src="/api/albums/1/cover?token=old"
+        alt="Cover"
+      />,
+    );
+    expect(screen.getByRole("img", { name: "Cover" })).toHaveAttribute(
+      "src",
+      "/api/albums/1/cover?token=old?ticket-version=1",
+    );
+
+    mediaVersion.value = 2;
+    rerender(
+      <AuthenticatedMediaImage
+        src="/api/albums/1/cover?token=new"
+        alt="Cover"
+      />,
+    );
+
+    expect(screen.getByRole("img", { name: "Cover" })).toHaveAttribute(
+      "src",
+      "/api/albums/1/cover?token=old?ticket-version=1",
+    );
+  });
+
+  it("resolves every responsive candidate with the same ticket lifecycle", () => {
+    render(
+      <AuthenticatedMediaImage
+        src="/api/albums/1/cover?size=256"
+        srcSet="/api/albums/1/cover?size=160 160w, /api/albums/1/cover?size=320 320w"
+        sizes="50vw"
+        alt="Cover"
+      />,
+    );
+
+    expect(screen.getByRole("img", { name: "Cover" })).toHaveAttribute(
+      "srcset",
+      "/api/albums/1/cover?size=160?ticket-version=1 160w, /api/albums/1/cover?size=320?ticket-version=1 320w",
+    );
+  });
+
+  it("renews a protected credential again after the replacement loaded", async () => {
     render(<AuthenticatedMediaImage src="/api/albums/1/cover" alt="Cover" />);
 
     fireEvent.error(screen.getByRole("img", { name: "Cover" }));
@@ -62,7 +108,31 @@ describe("AuthenticatedMediaImage", () => {
       "/api/albums/1/cover?media_ticket=renewed",
     );
 
+    fireEvent.load(screen.getByRole("img", { name: "Cover" }));
     fireEvent.error(screen.getByRole("img", { name: "Cover" }));
+    await waitFor(() =>
+      expect(ensureMediaAccessUrlMock).toHaveBeenCalledTimes(2),
+    );
+  });
+
+  it("delegates a persistent protected failure after one bounded retry", async () => {
+    const onError = vi.fn();
+    render(
+      <AuthenticatedMediaImage
+        src="/api/albums/1/cover"
+        alt="Cover"
+        onError={onError}
+      />,
+    );
+
+    fireEvent.error(screen.getByRole("img", { name: "Cover" }));
+    await waitFor(() =>
+      expect(ensureMediaAccessUrlMock).toHaveBeenCalledTimes(1),
+    );
+    expect(onError).not.toHaveBeenCalled();
+
+    fireEvent.error(screen.getByRole("img", { name: "Cover" }));
+    expect(onError).toHaveBeenCalledTimes(1);
     expect(ensureMediaAccessUrlMock).toHaveBeenCalledTimes(1);
   });
 });

--- a/app/listen/src/components/player/AuthenticatedMediaImage.tsx
+++ b/app/listen/src/components/player/AuthenticatedMediaImage.tsx
@@ -7,47 +7,162 @@ import {
 } from "react";
 
 import { useMediaAccessVersion } from "@/hooks/use-media-access-version";
-import { ensureMediaAccessUrl, resolveMaybeApiAssetUrl } from "@/lib/api";
+import {
+  ensureMediaAccessUrl,
+  isUsableMediaAssetUrl,
+  requiresMediaAccessTicket,
+  resolveMaybeApiAssetUrl,
+} from "@/lib/api";
 
 interface AuthenticatedMediaImageProps
   extends Omit<ImgHTMLAttributes<HTMLImageElement>, "src"> {
   src: string | null | undefined;
 }
 
+function canonicalSourceIdentity(source: string | null | undefined): string {
+  if (!source) return "";
+  if (!requiresMediaAccessTicket(source)) return source;
+  if (/^(?:data|blob|file|capacitor):/i.test(source)) return source;
+  try {
+    const absolute = /^https?:\/\//i.test(source);
+    const parsed = new URL(source, "https://crate.local");
+    parsed.searchParams.delete("token");
+    parsed.searchParams.delete("media_ticket");
+    return absolute
+      ? parsed.toString()
+      : `${parsed.pathname}${parsed.search}${parsed.hash}`;
+  } catch {
+    return source
+      .replace(/([?&])(token|media_ticket)=[^&]*&?/g, "$1")
+      .replace(/[?&]$/, "");
+  }
+}
+
+function canonicalSourceSetIdentity(sourceSet: string | undefined): string {
+  if (!sourceSet) return "";
+  return sourceSet
+    .split(",")
+    .map((candidate) => {
+      const match = candidate.trim().match(/^(\S+)(\s+.+)?$/);
+      if (!match?.[1]) return candidate.trim();
+      return `${canonicalSourceIdentity(match[1])}${match[2] ?? ""}`;
+    })
+    .join(", ");
+}
+
 export function AuthenticatedMediaImage({
   src,
+  srcSet,
   onError,
+  onLoad,
   ...props
 }: AuthenticatedMediaImageProps) {
   const ticketVersion = useMediaAccessVersion();
+  const sourceKey = `${canonicalSourceIdentity(
+    src,
+  )}\u0000${canonicalSourceSetIdentity(srcSet)}`;
   const resolvedSource = useMemo(
     () => resolveMaybeApiAssetUrl(src),
     [src, ticketVersion],
   );
-  const [recoveredSource, setRecoveredSource] = useState<string | null>(null);
+  const resolvedSourceSet = useMemo(() => {
+    if (!srcSet) return undefined;
+    const candidates = srcSet.split(",").map((candidate) => {
+      const match = candidate.trim().match(/^(\S+)(\s+.+)?$/);
+      if (!match?.[1]) return null;
+      const resolved = resolveMaybeApiAssetUrl(match[1]);
+      if (!resolved || !isUsableMediaAssetUrl(resolved)) return null;
+      return `${resolved}${match[2] ?? ""}`;
+    });
+    return candidates.every(Boolean) ? candidates.join(", ") : undefined;
+  }, [srcSet, ticketVersion]);
+  const usableSource =
+    resolvedSource && isUsableMediaAssetUrl(resolvedSource)
+      ? resolvedSource
+      : null;
+  const [active, setActive] = useState(() => ({
+    key: sourceKey,
+    source: usableSource,
+    sourceSet: resolvedSourceSet,
+  }));
   const recoveryAttemptedFor = useRef<string | null>(null);
 
   useEffect(() => {
-    setRecoveredSource(null);
     recoveryAttemptedFor.current = null;
-  }, [src, ticketVersion]);
+  }, [sourceKey]);
 
-  if (!resolvedSource && !recoveredSource) return null;
+  useEffect(() => {
+    setActive((current) => {
+      if (current.key !== sourceKey) {
+        return {
+          key: sourceKey,
+          source: usableSource,
+          sourceSet: resolvedSourceSet,
+        };
+      }
+      if (current.source || !usableSource) return current;
+      return {
+        key: sourceKey,
+        source: usableSource,
+        sourceSet: resolvedSourceSet,
+      };
+    });
+  }, [resolvedSourceSet, sourceKey, usableSource]);
+
+  const rendered =
+    active.key === sourceKey
+      ? active
+      : {
+          key: sourceKey,
+          source: usableSource,
+          sourceSet: resolvedSourceSet,
+        };
+  if (!rendered.source) return null;
 
   return (
     <img
       {...props}
-      src={recoveredSource || resolvedSource || undefined}
+      data-authenticated-media="true"
+      src={rendered.source}
+      srcSet={rendered.sourceSet}
+      onLoad={(event) => {
+        recoveryAttemptedFor.current = null;
+        onLoad?.(event);
+      }}
       onError={(event) => {
-        onError?.(event);
-        if (!src || recoveryAttemptedFor.current === src) return;
-        recoveryAttemptedFor.current = src;
+        if (!src || !requiresMediaAccessTicket(src)) {
+          onError?.(event);
+          return;
+        }
+        if (recoveryAttemptedFor.current === sourceKey) {
+          onError?.(event);
+          return;
+        }
+        recoveryAttemptedFor.current = sourceKey;
         void ensureMediaAccessUrl(src, "artwork", {
           forceRefresh: true,
         })
-          .then(setRecoveredSource)
+          .then((source) => {
+            const refreshedCandidates = srcSet?.split(",").map((candidate) => {
+              const match = candidate.trim().match(/^(\S+)(\s+.+)?$/);
+              if (!match?.[1]) return null;
+              const resolved = resolveMaybeApiAssetUrl(match[1]);
+              return resolved && isUsableMediaAssetUrl(resolved)
+                ? `${resolved}${match[2] ?? ""}`
+                : null;
+            });
+            setActive({
+              key: sourceKey,
+              source,
+              sourceSet:
+                refreshedCandidates?.every(Boolean) &&
+                refreshedCandidates.length
+                  ? refreshedCandidates.join(", ")
+                  : undefined,
+            });
+          })
           .catch(() => {
-            // The caller's placeholder remains visible after one bounded retry.
+            onError?.(event);
           });
       }}
     />

--- a/app/listen/src/components/player/AuthenticatedMediaImageCoverage.test.ts
+++ b/app/listen/src/components/player/AuthenticatedMediaImageCoverage.test.ts
@@ -1,0 +1,37 @@
+import { readdirSync, readFileSync } from "node:fs";
+import { join, relative } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+function sourceFiles(directory: string): string[] {
+  return readdirSync(directory, { withFileTypes: true }).flatMap((entry) => {
+    const path = join(directory, entry.name);
+    if (entry.isDirectory()) return sourceFiles(path);
+    if (!entry.name.endsWith(".tsx") || entry.name.endsWith(".test.tsx")) {
+      return [];
+    }
+    return [path];
+  });
+}
+
+describe("authenticated media image coverage", () => {
+  it("keeps dynamic image URLs behind the credential-aware component", () => {
+    const root = join(process.cwd(), "src");
+    const violations: string[] = [];
+
+    for (const file of sourceFiles(root)) {
+      const source = readFileSync(file, "utf8");
+      for (const match of source.matchAll(/<img\b[\s\S]*?\/>/g)) {
+        const element = match[0];
+        const isStaticAsset = /\bsrc\s*=\s*["']/.test(element);
+        const isCredentialAware = /\bdata-authenticated-media\b/.test(element);
+        const isExplicitlyPublic = /\bdata-public-media\b/.test(element);
+        if (!isStaticAsset && !isCredentialAware && !isExplicitlyPublic) {
+          violations.push(relative(root, file));
+        }
+      }
+    }
+
+    expect(violations).toEqual([]);
+  });
+});

--- a/app/listen/src/components/player/ExtendedPlayer.tsx
+++ b/app/listen/src/components/player/ExtendedPlayer.tsx
@@ -4,6 +4,7 @@ import { useTranslation } from "react-i18next";
 import { ChevronDown, Settings, SlidersHorizontal } from "@crate/ui/icons";
 
 import { EqualizerPanel } from "@/components/player/EqualizerPanel";
+import { AuthenticatedMediaImage } from "@/components/player/AuthenticatedMediaImage";
 import { PlayerSurfaceModeSwitch } from "@/components/player/PlayerSurfaceModeSwitch";
 import { PlayerSeekBar } from "@/components/player/bar/PlayerSeekBar";
 import { PlayerTrackIdentity } from "@/components/player/PlayerTrackIdentity";
@@ -309,7 +310,7 @@ export function ExtendedPlayer({ open, onClose }: ExtendedPlayerProps) {
               {crossfadeTransition ? (
                 <>
                   {crossfadeTransition.outgoing.albumCover ? (
-                    <img
+                    <AuthenticatedMediaImage
                       src={crossfadeTransition.outgoing.albumCover}
                       alt=""
                       className="absolute inset-0 h-full w-full rounded-xl object-cover shadow-[0_28px_100px_rgba(0,0,0,0.75),0_10px_28px_rgba(0,0,0,0.45)]"
@@ -322,7 +323,7 @@ export function ExtendedPlayer({ open, onClose }: ExtendedPlayerProps) {
                     />
                   ) : null}
                   {crossfadeTransition.incoming.albumCover ? (
-                    <img
+                    <AuthenticatedMediaImage
                       src={crossfadeTransition.incoming.albumCover}
                       alt=""
                       className="absolute inset-0 h-full w-full rounded-xl object-cover shadow-[0_28px_100px_rgba(0,0,0,0.75),0_10px_28px_rgba(0,0,0,0.45)]"
@@ -336,7 +337,7 @@ export function ExtendedPlayer({ open, onClose }: ExtendedPlayerProps) {
                   ) : null}
                 </>
               ) : currentTrack.albumCover ? (
-                <img
+                <AuthenticatedMediaImage
                   src={currentTrack.albumCover}
                   alt=""
                   className="absolute inset-0 h-full w-full rounded-xl object-cover shadow-[0_28px_100px_rgba(0,0,0,0.75),0_10px_28px_rgba(0,0,0,0.45)]"

--- a/app/listen/src/components/player/FullscreenPlayer.test.tsx
+++ b/app/listen/src/components/player/FullscreenPlayer.test.tsx
@@ -29,6 +29,8 @@ vi.mock("@/lib/api", () => ({
   api: apiMock,
   AUTH_TOKEN_EVENT: "crate:auth-token-updated",
   ensureMediaAccessUrl: vi.fn(async (url: string) => url),
+  isUsableMediaAssetUrl: (url: string | null | undefined) => Boolean(url),
+  requiresMediaAccessTicket: () => false,
   resolveMaybeApiAssetUrl: (url: string | null | undefined) => url ?? null,
 }));
 

--- a/app/listen/src/components/player/FullscreenPlayer.test.tsx
+++ b/app/listen/src/components/player/FullscreenPlayer.test.tsx
@@ -28,6 +28,8 @@ const apiMock = vi.hoisted(() => vi.fn(() => Promise.resolve({})));
 vi.mock("@/lib/api", () => ({
   api: apiMock,
   AUTH_TOKEN_EVENT: "crate:auth-token-updated",
+  ensureMediaAccessUrl: vi.fn(async (url: string) => url),
+  resolveMaybeApiAssetUrl: (url: string | null | undefined) => url ?? null,
 }));
 
 const androidNativeEngineMock = vi.hoisted(() => ({

--- a/app/listen/src/components/player/FullscreenPlayer.tsx
+++ b/app/listen/src/components/player/FullscreenPlayer.tsx
@@ -14,15 +14,12 @@ import { SpectrumPlayButton } from "@/components/player/SpectrumPlayButton";
 import { getPlaySourceLabel } from "@/components/player/player-source";
 import { useResolvedPlayerArtist } from "@/components/player/useResolvedPlayerArtist";
 import { EqualizerPanel } from "@/components/player/EqualizerPanel";
+import { AuthenticatedMediaImage } from "@/components/player/AuthenticatedMediaImage";
 import { InfoTab } from "@/components/player/extended/InfoTab";
 import { PlayerTrackMenu } from "@/components/player/bar/PlayerTrackMenu";
 import { api } from "@/lib/api";
 import { shouldUseAndroidNativePlayer } from "@/lib/android-native-engine";
-import {
-  canUseWebAudioEffects,
-  isMobileAudioRuntime,
-  stableMobileAudioPipeline,
-} from "@/lib/mobile-audio-mode";
+import { canUseWebAudioEffects } from "@/lib/mobile-audio-mode";
 import {
   getPlayerSurfaceModePreference,
   PLAYER_VIZ_PREFS_EVENT,
@@ -133,7 +130,7 @@ function FullscreenQueueRow({
       className="flex items-center gap-3 w-full py-2 text-left active:bg-white/5 rounded-lg transition-colors focus-visible:bg-white/5 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40"
     >
       {track.albumCover ? (
-        <img
+        <AuthenticatedMediaImage
           src={track.albumCover}
           alt=""
           loading="lazy"
@@ -218,8 +215,10 @@ export function FullscreenPlayer({ open, onClose }: FullscreenPlayerProps) {
     duration,
   );
   const navigate = useNavigate();
-  const allowMobileEqualizer = canUseWebAudioEffects;
-  const spinningDiscJogSeekMode = shouldUseAndroidNativePlayer()
+  const androidNativePlayerEnabled = shouldUseAndroidNativePlayer();
+  const allowMobileEqualizer =
+    canUseWebAudioEffects || androidNativePlayerEnabled;
+  const spinningDiscJogSeekMode = androidNativePlayerEnabled
     ? "commit"
     : "live";
 
@@ -705,7 +704,7 @@ export function FullscreenPlayer({ open, onClose }: FullscreenPlayerProps) {
                   {crossfadeTransition ? (
                     <>
                       {crossfadeTransition.outgoing.albumCover ? (
-                        <img
+                        <AuthenticatedMediaImage
                           src={crossfadeTransition.outgoing.albumCover}
                           alt=""
                           className="absolute inset-0 h-full w-full object-cover shadow-2xl shadow-black/60"
@@ -715,7 +714,7 @@ export function FullscreenPlayer({ open, onClose }: FullscreenPlayerProps) {
                         />
                       ) : null}
                       {crossfadeTransition.incoming.albumCover ? (
-                        <img
+                        <AuthenticatedMediaImage
                           src={crossfadeTransition.incoming.albumCover}
                           alt=""
                           className="absolute inset-0 h-full w-full object-cover shadow-2xl shadow-black/60"
@@ -726,7 +725,7 @@ export function FullscreenPlayer({ open, onClose }: FullscreenPlayerProps) {
                       ) : null}
                     </>
                   ) : currentTrack.albumCover ? (
-                    <img
+                    <AuthenticatedMediaImage
                       src={currentTrack.albumCover}
                       alt=""
                       className="h-full w-full object-cover shadow-2xl shadow-black/60"
@@ -868,22 +867,6 @@ export function FullscreenPlayer({ open, onClose }: FullscreenPlayerProps) {
                       ? "text-primary"
                       : "text-white/55 active:text-white"
                   }`}
-                >
-                  <SlidersHorizontal size={CRATE_ICON_SIZE.lg} />
-                </button>
-              ) : isMobileAudioRuntime ? (
-                <button
-                  type="button"
-                  onClick={() => {
-                    triggerHaptic("warning");
-                    toast.info(
-                      stableMobileAudioPipeline
-                        ? "Enable Enhanced mobile audio in Settings, then restart Listen to use EQ on mobile."
-                        : "Restart Listen to apply the mobile audio mode change.",
-                    );
-                  }}
-                  aria-label="Equalizer is disabled in stable mobile audio mode"
-                  className="flex h-12 w-12 touch-manipulation items-center justify-center rounded-full border border-white/10 bg-white/[0.03] text-white/20"
                 >
                   <SlidersHorizontal size={CRATE_ICON_SIZE.lg} />
                 </button>

--- a/app/listen/src/components/player/PlayerBar.tsx
+++ b/app/listen/src/components/player/PlayerBar.tsx
@@ -44,6 +44,7 @@ import {
   type PlaybackDeliveryPreference,
 } from "@/lib/player-playback-prefs";
 import { canUseWebAudioEffects } from "@/lib/mobile-audio-mode";
+import { shouldUseAndroidNativePlayer } from "@/lib/android-native-engine";
 import { triggerHaptic } from "@/lib/haptics";
 import { useLikedTracks } from "@/contexts/LikedTracksContext";
 import { useAudioVisualizer } from "@/hooks/use-audio-visualizer";
@@ -176,7 +177,8 @@ export function PlayerBar() {
   const connectEnabled = useCrateConnectEnabled();
   const legacyConnectEnabled =
     connectEnabled && !CRATE_CONNECT_V2_TRANSPORT_ENABLED;
-  const allowEqualizer = canUseWebAudioEffects;
+  const allowEqualizer =
+    canUseWebAudioEffects || shouldUseAndroidNativePlayer();
   const showPlayerBarAnalyzer =
     SHOW_PLAYER_BAR_ANALYZER && isDesktop && allowEqualizer;
 

--- a/app/listen/src/components/player/PlayerTrackIdentity.tsx
+++ b/app/listen/src/components/player/PlayerTrackIdentity.tsx
@@ -1,5 +1,6 @@
 import { cn } from "@crate/ui/lib/cn";
 
+import { AuthenticatedMediaImage } from "@/components/player/AuthenticatedMediaImage";
 import type { CrossfadeTransition } from "@/contexts/player-context";
 import type { Track } from "@/contexts/player-types";
 
@@ -118,7 +119,7 @@ export function PlayerTrackIdentity({
           )}
         >
           {artistAvatarUrl ? (
-            <img
+            <AuthenticatedMediaImage
               src={artistAvatarUrl}
               alt={currentTrack.artist}
               className="h-7 w-7 rounded-full object-cover"

--- a/app/listen/src/components/player/QueuePanel.tsx
+++ b/app/listen/src/components/player/QueuePanel.tsx
@@ -14,6 +14,7 @@ import { trackToMenuData } from "@/components/actions/shared";
 import { useTrackActionEntries } from "@/components/actions/track-actions";
 import type { Track } from "@/contexts/PlayerContext";
 import { usePlayerActions, usePlayerState } from "@/contexts/PlayerContext";
+import { AuthenticatedMediaImage } from "@/components/player/AuthenticatedMediaImage";
 
 interface QueuePanelProps {
   open: boolean;
@@ -83,7 +84,7 @@ function QueuePanelRow({
         {indexLabel}
       </span>
       {track.albumCover ? (
-        <img
+        <AuthenticatedMediaImage
           src={track.albumCover}
           alt=""
           loading="lazy"
@@ -176,7 +177,7 @@ export function QueuePanel({ open, onClose }: QueuePanelProps) {
           </p>
           <div className="flex items-center gap-3">
             {currentTrack.albumCover ? (
-              <img
+              <AuthenticatedMediaImage
                 src={currentTrack.albumCover}
                 alt=""
                 className="w-10 h-10 rounded object-cover shrink-0"

--- a/app/listen/src/components/player/SpinningDisc.test.tsx
+++ b/app/listen/src/components/player/SpinningDisc.test.tsx
@@ -1,6 +1,15 @@
 import { fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
+vi.mock("@/components/player/AuthenticatedMediaImage", () => ({
+  AuthenticatedMediaImage: ({
+    src,
+    ...props
+  }: React.ImgHTMLAttributes<HTMLImageElement>) => (
+    <img data-testid="authenticated-disc-artwork" src={src} {...props} />
+  ),
+}));
+
 import { SpinningDisc } from "@/components/player/SpinningDisc";
 
 const bounds = {
@@ -54,6 +63,15 @@ describe("SpinningDisc", () => {
 
   afterEach(() => {
     vi.restoreAllMocks();
+  });
+
+  it("renders album artwork through the authenticated media image", () => {
+    renderDisc({ albumCover: "/api/albums/1/cover" });
+
+    expect(screen.getByTestId("authenticated-disc-artwork")).toHaveAttribute(
+      "src",
+      "/api/albums/1/cover",
+    );
   });
 
   it("seeks while dragging in live jog mode", () => {

--- a/app/listen/src/components/player/SpinningDisc.tsx
+++ b/app/listen/src/components/player/SpinningDisc.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import { Disc3, Loader2, Pause, Play } from "@crate/ui/icons";
 
 import { cn } from "@crate/ui/lib/cn";
+import { AuthenticatedMediaImage } from "@/components/player/AuthenticatedMediaImage";
 
 const DISC_DEGREES_PER_SECOND = 120;
 const JOG_SECONDS_PER_ROTATION = 2.5;
@@ -401,13 +402,13 @@ export function SpinningDisc({
         >
           {showCrossfade ? (
             <>
-              <img
+              <AuthenticatedMediaImage
                 src={crossfadeOutgoingCover!}
                 alt=""
                 className="absolute inset-0 h-full w-full object-cover"
                 style={{ opacity: 1 - crossfadeProgress }}
               />
-              <img
+              <AuthenticatedMediaImage
                 src={crossfadeIncomingCover!}
                 alt=""
                 className="absolute inset-0 h-full w-full object-cover"
@@ -415,7 +416,7 @@ export function SpinningDisc({
               />
             </>
           ) : albumCover ? (
-            <img
+            <AuthenticatedMediaImage
               src={albumCover}
               alt=""
               className="absolute inset-0 h-full w-full object-cover"

--- a/app/listen/src/components/player/extended/InfoTab.tsx
+++ b/app/listen/src/components/player/extended/InfoTab.tsx
@@ -15,6 +15,7 @@ import {
 } from "@crate/ui/icons";
 
 import { usePlayerActions } from "@/contexts/PlayerContext";
+import { AuthenticatedMediaImage } from "@/components/player/AuthenticatedMediaImage";
 import { useTrackInfo } from "@/hooks/use-track-info";
 import { albumPagePath, artistPagePath } from "@/lib/library-routes";
 import { extractPalette } from "@/lib/palette";
@@ -330,7 +331,7 @@ export function InfoTab({ className }: { className?: string }) {
           <div className="relative flex items-start gap-4">
             <div className="relative h-24 w-24 shrink-0 overflow-hidden rounded-[22px] border border-white/10 bg-white/5 shadow-[0_12px_30px_rgba(0,0,0,0.4)] sm:h-28 sm:w-28">
               {currentTrack.albumCover ? (
-                <img
+                <AuthenticatedMediaImage
                   src={currentTrack.albumCover}
                   alt={t("player.info.albumCoverAlt", {
                     name:

--- a/app/listen/src/components/player/extended/QueueTab.tsx
+++ b/app/listen/src/components/player/extended/QueueTab.tsx
@@ -12,6 +12,7 @@ import {
 import { trackToMenuData } from "@/components/actions/shared";
 import { useTrackActionEntries } from "@/components/actions/track-actions";
 import { getPlaySourceLabel } from "@/components/player/player-source";
+import { AuthenticatedMediaImage } from "@/components/player/AuthenticatedMediaImage";
 import {
   usePlayerActions,
   usePlayerState,
@@ -217,7 +218,7 @@ export function QueueTab() {
               {currentIndex + 1}
             </span>
             {currentTrack.albumCover ? (
-              <img
+              <AuthenticatedMediaImage
                 src={currentTrack.albumCover}
                 alt=""
                 loading="lazy"

--- a/app/listen/src/components/playlists/EditorialPlaylistArtwork.tsx
+++ b/app/listen/src/components/playlists/EditorialPlaylistArtwork.tsx
@@ -1,5 +1,6 @@
 import { PlaylistArtwork, type PlaylistArtworkTrack } from "./PlaylistArtwork";
 
+import { AuthenticatedMediaImage } from "@/components/player/AuthenticatedMediaImage";
 import { cn } from "@/lib/utils";
 
 type EditorialVariant = "core" | "history" | "crate";
@@ -73,7 +74,7 @@ export function EditorialPlaylistArtwork({
     >
       <div className="absolute inset-0 z-0 opacity-55 transition duration-500 group-hover:scale-[1.035] group-hover:opacity-70">
         {backgroundImageUrl ? (
-          <img
+          <AuthenticatedMediaImage
             src={backgroundImageUrl}
             alt={title}
             loading="lazy"

--- a/app/listen/src/components/share/ShareSheet.tsx
+++ b/app/listen/src/components/share/ShareSheet.tsx
@@ -4,6 +4,7 @@ import { useTranslation } from "react-i18next";
 import { toast } from "sonner";
 
 import { AppModal } from "@crate/ui/primitives/AppModal";
+import { AuthenticatedMediaImage } from "@/components/player/AuthenticatedMediaImage";
 import {
   buildShareText,
   buildTelegramShareUrl,
@@ -162,7 +163,7 @@ export function ShareSheetHost() {
 function SharePreviewImage({ payload }: { payload: SharePayload }) {
   if (payload.imageUrl) {
     return (
-      <img
+      <AuthenticatedMediaImage
         src={payload.imageUrl}
         alt=""
         className="h-14 w-14 shrink-0 rounded-xl border border-white/10 object-cover shadow-[0_16px_40px_rgba(0,0,0,0.35)]"

--- a/app/listen/src/components/social/ProfileHoverCard.tsx
+++ b/app/listen/src/components/social/ProfileHoverCard.tsx
@@ -8,6 +8,7 @@ import { AppPopover } from "@crate/ui/primitives/AppPopover";
 import { cn } from "@crate/ui/lib/cn";
 import { useIsDesktop } from "@crate/ui/lib/use-breakpoint";
 import { useUserAvatarUrl } from "@/hooks/use-user-avatar-url";
+import { AuthenticatedMediaImage } from "@/components/player/AuthenticatedMediaImage";
 import { api } from "@/lib/api";
 
 type AffinityBand = "low" | "medium" | "high" | "very_high" | string;
@@ -112,7 +113,7 @@ function ProfileAvatar({ card }: { card: ProfileCardPayload }) {
 
   if (avatarUrl) {
     return (
-      <img
+      <AuthenticatedMediaImage
         src={avatarUrl}
         alt=""
         onError={handleAvatarError}

--- a/app/listen/src/components/upcoming/UpcomingEventRow.tsx
+++ b/app/listen/src/components/upcoming/UpcomingEventRow.tsx
@@ -13,6 +13,7 @@ import {
   artistPagePath,
   artistPhotoApiUrl,
 } from "@/lib/library-routes";
+import { AuthenticatedMediaImage } from "@/components/player/AuthenticatedMediaImage";
 import { resolveMaybeApiAssetUrl } from "@/lib/api";
 
 import { canOpenUpcomingRelease, type UpcomingItem } from "./upcoming-model";
@@ -86,7 +87,7 @@ export function UpcomingEventRow({
     >
       <div className="absolute inset-0 bg-[radial-gradient(circle_at_16%_20%,rgba(6,182,212,0.22),transparent_34%),linear-gradient(90deg,rgba(255,255,255,0.06),transparent_58%)]" />
       {coverUrl ? (
-        <img
+        <AuthenticatedMediaImage
           src={coverUrl}
           alt=""
           loading="lazy"
@@ -102,7 +103,7 @@ export function UpcomingEventRow({
         <div className="flex min-w-0 items-center gap-4">
           <div className="relative h-16 w-16 flex-shrink-0 overflow-hidden rounded-2xl border border-white/10 bg-white/5">
             {coverUrl ? (
-              <img
+              <AuthenticatedMediaImage
                 src={coverUrl}
                 alt=""
                 loading="lazy"

--- a/app/listen/src/components/upcoming/UpcomingShowCardViews.tsx
+++ b/app/listen/src/components/upcoming/UpcomingShowCardViews.tsx
@@ -13,6 +13,7 @@ import {
 } from "@crate/ui/icons";
 
 import { ItemActionMenuButton } from "@crate/ui/domain/actions";
+import { AuthenticatedMediaImage } from "@/components/player/AuthenticatedMediaImage";
 import {
   artistBackgroundApiUrl,
   artistPagePath,
@@ -32,7 +33,7 @@ function PreloadBackground({ item }: { item: UpcomingItem }) {
     { size: 1280 },
   );
   if (!url) return null;
-  return <img src={url} alt="" className="hidden" />;
+  return <AuthenticatedMediaImage src={url} alt="" className="hidden" />;
 }
 
 import type { UpcomingItem } from "./upcoming-model";
@@ -186,7 +187,7 @@ export function UpcomingShowCollapsedView({
       {/* Artist photo */}
       <div className="h-full w-[88px] flex-shrink-0 bg-white/5">
         {artistImageUrl && (
-          <img
+          <AuthenticatedMediaImage
             src={artistImageUrl}
             alt=""
             loading="lazy"
@@ -335,7 +336,7 @@ export function UpcomingShowExpandedView({
       {/* Hero — artist background covers the entire card, gradient fades to black at bottom */}
       <div className="absolute inset-0 overflow-hidden">
         {backgroundUrl && (
-          <img
+          <AuthenticatedMediaImage
             src={backgroundUrl}
             alt=""
             className="absolute inset-0 h-full w-full object-cover brightness-[0.4] saturate-[0.7]"
@@ -379,7 +380,7 @@ export function UpcomingShowExpandedView({
         <div className="absolute bottom-3 left-3 right-3 z-10">
           <div className="flex items-center gap-2">
             {artistPhotoUrl && (
-              <img
+              <AuthenticatedMediaImage
                 src={artistPhotoUrl}
                 alt=""
                 className="h-9 w-9 flex-shrink-0 rounded-full object-cover ring-2 ring-primary/25"

--- a/app/listen/src/contexts/player-engine-adapter.test.ts
+++ b/app/listen/src/contexts/player-engine-adapter.test.ts
@@ -5,12 +5,16 @@ const {
   authState,
   ensureFreshAuthTokenMock,
   ensureMediaAccessUrlMock,
+  refreshMediaAccessTicketsMock,
+  artworkTicketState,
   offlineUrlState,
 } = vi.hoisted(() => ({
   apiMock: vi.fn(),
   authState: { token: "listen-token" },
   ensureFreshAuthTokenMock: vi.fn(),
   ensureMediaAccessUrlMock: vi.fn(),
+  refreshMediaAccessTicketsMock: vi.fn(),
+  artworkTicketState: { fresh: false },
   offlineUrlState: { url: null as string | null },
 }));
 
@@ -20,12 +24,17 @@ vi.mock("@/lib/api", () => ({
   getAuthToken: () => authState.token,
   ensureFreshAuthToken: ensureFreshAuthTokenMock,
   ensureMediaAccessUrl: ensureMediaAccessUrlMock,
+  refreshMediaAccessTickets: refreshMediaAccessTicketsMock,
   apiStreamUrl: (url: string) => url,
   resolveMaybeApiStreamUrl: (url: string | null | undefined) =>
     url?.startsWith("/api/") ? `https://listen.example${url}` : url ?? null,
   resolveMaybeApiAssetUrl: (url: string | null | undefined) =>
     url?.startsWith("/api/")
-      ? `https://listen.example${url}?token=${authState.token}`
+      ? artworkTicketState.fresh
+        ? `https://listen.example${url}${
+            url.includes("?") ? "&" : "?"
+          }media_ticket=fresh-artwork`
+        : `https://listen.example${url}?token=${authState.token}`
       : url ?? null,
 }));
 
@@ -54,6 +63,12 @@ describe("player engine adapter", () => {
     ensureFreshAuthTokenMock.mockResolvedValue(true);
     ensureMediaAccessUrlMock.mockReset();
     ensureMediaAccessUrlMock.mockImplementation(async (url: string) => url);
+    artworkTicketState.fresh = false;
+    refreshMediaAccessTicketsMock.mockReset();
+    refreshMediaAccessTicketsMock.mockImplementation(async () => {
+      artworkTicketState.fresh = true;
+      return true;
+    });
     offlineUrlState.url = null;
   });
 
@@ -276,5 +291,37 @@ describe("player engine adapter", () => {
       "https://listen.example/api/federation/remote/streams/ticket-next",
       "stream",
     );
+  });
+
+  it("refreshes queue artwork tickets before restoring the native player", async () => {
+    const queue = [
+      {
+        id: "track-current",
+        entityUid: "entity-current",
+        title: "Current Song",
+        artist: "Band",
+        albumCover: "/api/albums/1/cover?size=512",
+      },
+      {
+        id: "track-next",
+        entityUid: "entity-next",
+        title: "Next Song",
+        artist: "Band",
+        albumCover: "/api/albums/2/cover?size=512",
+      },
+    ];
+
+    const tracks = await toStartupEngineTracks(queue, 0, undefined, {
+      target: "android-native",
+    });
+
+    expect(refreshMediaAccessTicketsMock).toHaveBeenCalledWith([
+      { audience: "artwork", path: "/api/albums/1/cover" },
+      { audience: "artwork", path: "/api/albums/2/cover" },
+    ]);
+    expect(tracks.map((track) => track.artwork)).toEqual([
+      "https://listen.example/api/albums/1/cover?size=512&media_ticket=fresh-artwork",
+      "https://listen.example/api/albums/2/cover?size=512&media_ticket=fresh-artwork",
+    ]);
   });
 });

--- a/app/listen/src/contexts/player-engine-adapter.ts
+++ b/app/listen/src/contexts/player-engine-adapter.ts
@@ -9,6 +9,7 @@ import {
   ensureMediaAccessUrl,
   getApiBase,
   getAuthToken,
+  refreshMediaAccessTickets,
   resolveMaybeApiAssetUrl,
   resolveMaybeApiStreamUrl,
 } from "@/lib/api";
@@ -145,6 +146,9 @@ export async function toStartupEngineTracks(
   options: StreamUrlOptions = {},
 ): Promise<EngineTrack[]> {
   await ensureFreshAuthToken();
+  if (options.target === "android-native") {
+    await refreshNativeArtworkTickets(tracks);
+  }
   const engineTracks = toEngineTracks(tracks, eqGainsByTrackId, options);
   const normalizedIndex = Math.max(
     0,
@@ -167,6 +171,43 @@ export async function toStartupEngineTracks(
     }),
   );
   return engineTracks;
+}
+
+async function refreshNativeArtworkTickets(tracks: Track[]): Promise<void> {
+  const apiBase = getApiBase();
+  if (!apiBase) return;
+  let apiOrigin: string;
+  try {
+    apiOrigin = new URL(apiBase).origin;
+  } catch {
+    return;
+  }
+
+  const targets = new Map<string, { audience: "artwork"; path: string }>();
+  for (const track of tracks) {
+    if (!track.albumCover) continue;
+    try {
+      const artwork = new URL(track.albumCover, apiBase);
+      if (
+        artwork.origin === apiOrigin &&
+        artwork.pathname.startsWith("/api/")
+      ) {
+        targets.set(artwork.pathname, {
+          audience: "artwork",
+          path: artwork.pathname,
+        });
+      }
+    } catch {
+      // Invalid artwork is left to the visual placeholder.
+    }
+  }
+
+  const pending = Array.from(targets.values());
+  for (let index = 0; index < pending.length; index += 128) {
+    await refreshMediaAccessTickets(pending.slice(index, index + 128)).catch(
+      () => false,
+    );
+  }
 }
 
 function hasFreshRemoteStream(track: Track): boolean {

--- a/app/listen/src/contexts/player-utils.test.ts
+++ b/app/listen/src/contexts/player-utils.test.ts
@@ -112,6 +112,26 @@ describe("getStoredQueue / saveQueue round-trip", () => {
     expect(stored.savedAt).toEqual(expect.any(String));
   });
 
+  it("persists canonical artwork URLs without expiring credentials", () => {
+    saveQueue(
+      [
+        {
+          ...TRACK_A,
+          albumCover:
+            "https://listen.example/api/albums/1/cover?size=512&media_ticket=expired&token=secret",
+        },
+      ],
+      0,
+    );
+
+    const raw = localStorage.getItem(STORAGE_KEY);
+    expect(raw).not.toContain("expired");
+    expect(raw).not.toContain("secret");
+    expect(getStoredQueue().queue[0]?.albumCover).toBe(
+      "https://listen.example/api/albums/1/cover?size=512",
+    );
+  });
+
   it("persists shuffle flag + unshuffledQueue snapshot", () => {
     // User started with [A, B] then activated shuffle; current order
     // is [B, A]. The original [A, B] is preserved so toggling shuffle

--- a/app/listen/src/contexts/player-utils.ts
+++ b/app/listen/src/contexts/player-utils.ts
@@ -1,5 +1,5 @@
 import type { PlaySource, RepeatMode, Track } from "@/contexts/player-types";
-import { apiStreamUrl, getApiBase, resolveMaybeApiAssetUrl } from "@/lib/api";
+import { apiStreamUrl, getApiBase } from "@/lib/api";
 import { isNative } from "@/lib/capacitor-runtime";
 import { recordDevLog, redactUrl } from "@/lib/dev-logs";
 import { trackStreamApiPath } from "@/lib/library-routes";
@@ -111,11 +111,10 @@ export function getStoredQueue(): StoredQueue {
 }
 
 function normalizeStoredTrack(track: Track): Track {
-  const albumCover = resolveMaybeApiAssetUrl(track.albumCover);
-  const normalized =
-    albumCover && albumCover !== track.albumCover
-      ? { ...track, albumCover }
-      : { ...track };
+  const normalized = {
+    ...track,
+    albumCover: canonicalMediaUrl(track.albumCover),
+  };
   // Strip remote stream URL on restore — always request fresh playback resolution
   if (normalized.remote) {
     normalized.remote = {
@@ -162,9 +161,13 @@ export function saveQueue(
 }
 
 function sanitizeTrackForPersistence(track: Track): Track {
-  if (!track.remote) return track;
-  return {
+  const safeTrack = {
     ...track,
+    albumCover: canonicalMediaUrl(track.albumCover),
+  };
+  if (!track.remote) return safeTrack;
+  return {
+    ...safeTrack,
     path: undefined,
     remote: {
       ...track.remote,
@@ -172,6 +175,25 @@ function sanitizeTrackForPersistence(track: Track): Track {
       streamUrlExpiresAt: undefined,
     },
   };
+}
+
+function canonicalMediaUrl(url: string | null | undefined): string | undefined {
+  if (!url) return undefined;
+  try {
+    const parsed = new URL(url, "https://crate.local");
+    parsed.searchParams.delete("token");
+    parsed.searchParams.delete("media_ticket");
+    if (parsed.origin === "https://crate.local") {
+      return `${parsed.pathname}${parsed.search}${parsed.hash}`;
+    }
+    return parsed.toString();
+  } catch {
+    return url
+      .replace(/([?&])(token|media_ticket)=[^&]*&?/g, (_match, separator) =>
+        separator === "?" ? "?" : "",
+      )
+      .replace(/[?&]$/, "");
+  }
 }
 
 export function getStoredRecentlyPlayed(): Track[] {

--- a/app/listen/src/lib/api.test.ts
+++ b/app/listen/src/lib/api.test.ts
@@ -943,6 +943,35 @@ describe("native (configurable server) mode", () => {
   });
 
   describe("apiAssetUrl", () => {
+    it("marks protected URLs usable only after a credential is attached", () => {
+      setupServer();
+      mediaAccess.clearMediaAccessTickets();
+
+      expect(
+        apiMod.isUsableMediaAssetUrl(
+          "https://api.example.com/api/albums/1/cover?size=256",
+        ),
+      ).toBe(false);
+      expect(
+        apiMod.isUsableMediaAssetUrl(
+          "https://api.example.com/api/albums/1/cover?size=256&media_ticket=fresh",
+        ),
+      ).toBe(true);
+      expect(
+        apiMod.isUsableMediaAssetUrl("https://cdn.example.net/cover.webp"),
+      ).toBe(true);
+      expect(
+        apiMod.requiresMediaAccessTicket(
+          "https://api.example.com/api/albums/1/cover?size=256",
+        ),
+      ).toBe(true);
+      expect(
+        apiMod.requiresMediaAccessTicket(
+          "https://cdn.example.net/api/albums/1/cover",
+        ),
+      ).toBe(false);
+    });
+
     it("never reuses an artwork ticket for another API path", () => {
       setupServer();
 
@@ -959,6 +988,65 @@ describe("native (configurable server) mode", () => {
 
       expect(apiMod.apiAssetUrl("https://cdn.example.net/api/cover.jpg")).toBe(
         "https://cdn.example.net/api/cover.jpg",
+      );
+    });
+
+    it("waits until its own ticket batch completes during concurrent recovery", async () => {
+      setupServer();
+      mediaAccess.clearMediaAccessTickets();
+      let releaseFirst: (() => void) | undefined;
+      const firstRequestPending = new Promise<void>((resolve) => {
+        releaseFirst = resolve;
+      });
+      let releaseSecond: (() => void) | undefined;
+      const secondRequestPending = new Promise<void>((resolve) => {
+        releaseSecond = resolve;
+      });
+      const requestedBatches: Array<
+        Array<{ audience: "artwork"; path: string }>
+      > = [];
+      vi.spyOn(globalThis, "fetch").mockImplementation(async (_input, init) => {
+        const body = JSON.parse(String(init?.body)) as {
+          targets: Array<{ audience: "artwork"; path: string }>;
+        };
+        requestedBatches.push(body.targets);
+        if (requestedBatches.length === 1) await firstRequestPending;
+        if (requestedBatches.length === 2) await secondRequestPending;
+        return mockJsonResponse({
+          tickets: body.targets.map((target) => ({
+            ...target,
+            ticket: `ticket:${target.path}`,
+            expires_at: new Date(Date.now() + 60_000).toISOString(),
+          })),
+        });
+      });
+
+      const first = apiMod.ensureMediaAccessUrl(
+        "/api/albums/1/cover",
+        "artwork",
+        { forceRefresh: true },
+      );
+      await vi.waitFor(() => expect(requestedBatches).toHaveLength(1));
+      const second = apiMod.ensureMediaAccessUrl(
+        "/api/albums/2/cover",
+        "artwork",
+        { forceRefresh: true },
+      );
+      releaseFirst?.();
+      await vi.waitFor(() => expect(requestedBatches).toHaveLength(2));
+      releaseSecond?.();
+
+      await expect(first).resolves.toContain(
+        "media_ticket=ticket%3A%2Fapi%2Falbums%2F1%2Fcover",
+      );
+      await expect(second).resolves.toContain(
+        "media_ticket=ticket%3A%2Fapi%2Falbums%2F2%2Fcover",
+      );
+      expect(requestedBatches.flat()).toEqual(
+        expect.arrayContaining([
+          { audience: "artwork", path: "/api/albums/1/cover" },
+          { audience: "artwork", path: "/api/albums/2/cover" },
+        ]),
       );
     });
 

--- a/app/listen/src/lib/api.ts
+++ b/app/listen/src/lib/api.ts
@@ -27,6 +27,7 @@ import {
   clearMediaAccessTickets,
   getMediaAccessTicket,
   getMediaAccessTargets,
+  invalidateMediaAccessTicket,
   setMediaAccessTickets,
   type MediaAccessAudience,
   type MediaAccessTarget,
@@ -196,6 +197,48 @@ export function resolveMaybeApiAssetUrl(
   return url;
 }
 
+export function requiresMediaAccessTicket(
+  url: string | null | undefined,
+): boolean {
+  if (!url || !usesConfigurableServer || !isApiUrl(url)) return false;
+  try {
+    const server = getCurrentServer();
+    const parsed = new URL(url, server?.url || "https://crate.local");
+    if (server?.url && parsed.origin !== new URL(server.url).origin) {
+      return false;
+    }
+    return parsed.pathname.startsWith("/api/");
+  } catch {
+    return url.startsWith("/api/") || url.startsWith("api/");
+  }
+}
+
+export function isUsableMediaAssetUrl(url: string | null | undefined): boolean {
+  if (!url) return false;
+  if (
+    url.startsWith("data:") ||
+    url.startsWith("blob:") ||
+    url.startsWith("file:") ||
+    url.startsWith("capacitor:")
+  ) {
+    return true;
+  }
+  if (!requiresMediaAccessTicket(url)) return true;
+
+  try {
+    const parsed = new URL(
+      url,
+      getCurrentServer()?.url || "https://crate.local",
+    );
+    return (
+      parsed.searchParams.has("media_ticket") ||
+      parsed.searchParams.has("token")
+    );
+  } catch {
+    return false;
+  }
+}
+
 export function resolveMaybeApiStreamUrl(
   url: string | null | undefined,
 ): string | null {
@@ -350,6 +393,7 @@ const queuedMediaAccessTargets = new Map<
 >();
 const scheduledMediaAccessScopes = new Set<string>();
 const mediaAccessRefreshPromises = new Map<string, Promise<boolean>>();
+const inFlightMediaAccessTargets = new Map<string, Set<string>>();
 const ensuredMediaAccessPromises = new Map<string, Promise<string>>();
 
 export class MediaAccessTicketError extends Error {
@@ -387,9 +431,11 @@ function queueMediaAccessTarget(
   path: string,
   scope: string,
 ): void {
+  const key = mediaAccessTargetKey({ audience, path });
+  if (inFlightMediaAccessTargets.get(scope)?.has(key)) return;
   const targets = queuedMediaAccessTargets.get(scope) ?? new Map();
   const target = { audience, path };
-  targets.set(mediaAccessTargetKey(target), target);
+  targets.set(key, target);
   queuedMediaAccessTargets.set(scope, targets);
   scheduleMediaAccessFlush(scope);
 }
@@ -426,8 +472,13 @@ async function flushMediaAccessTargets(scope: string): Promise<boolean> {
   if (!queued?.size) return true;
   const targets = Array.from(queued.values()).slice(0, MEDIA_ACCESS_BATCH_SIZE);
   for (const target of targets) queued.delete(mediaAccessTargetKey(target));
+  const inFlight = inFlightMediaAccessTargets.get(scope) ?? new Set<string>();
+  for (const target of targets) inFlight.add(mediaAccessTargetKey(target));
+  inFlightMediaAccessTargets.set(scope, inFlight);
 
   const promise = requestMediaAccessTickets(server, targets).finally(() => {
+    for (const target of targets) inFlight.delete(mediaAccessTargetKey(target));
+    if (inFlight.size === 0) inFlightMediaAccessTargets.delete(scope);
     mediaAccessRefreshPromises.delete(scope);
     if (queued.size > 0) scheduleMediaAccessFlush(scope);
   });
@@ -492,12 +543,15 @@ export async function ensureMediaAccessUrl(
   ) {
     return parsed.toString();
   }
+  if (options.forceRefresh) {
+    invalidateMediaAccessTicket(audience, parsed.pathname, server.id);
+  }
   const currentTicket = getMediaAccessTicket(
     audience,
     parsed.pathname,
     server.id,
   );
-  if (currentTicket && !options.forceRefresh) {
+  if (currentTicket) {
     parsed.searchParams.set("media_ticket", currentTicket);
     return parsed.toString();
   }
@@ -509,19 +563,21 @@ export async function ensureMediaAccessUrl(
   if (existing) return existing;
 
   const pending = (async () => {
-    const refreshed = await refreshMediaAccessTickets([
-      { audience, path: parsed.pathname },
-    ]);
-    const currentServer = getCurrentServer();
-    const ticket =
-      refreshed && currentServer?.id === server.id
-        ? getMediaAccessTicket(audience, parsed.pathname, server.id)
-        : null;
-    if (!ticket) {
-      throw new MediaAccessTicketError(audience, parsed.pathname);
+    const target = { audience, path: parsed.pathname };
+    for (let attempt = 0; attempt < 5; attempt += 1) {
+      const refreshed = await refreshMediaAccessTickets([target]);
+      const currentServer = getCurrentServer();
+      const ticket =
+        refreshed && currentServer?.id === server.id
+          ? getMediaAccessTicket(audience, parsed.pathname, server.id)
+          : null;
+      if (ticket) {
+        parsed.searchParams.set("media_ticket", ticket);
+        return parsed.toString();
+      }
+      if (!refreshed) break;
     }
-    parsed.searchParams.set("media_ticket", ticket);
-    return parsed.toString();
+    throw new MediaAccessTicketError(audience, parsed.pathname);
   })().finally(() => {
     ensuredMediaAccessPromises.delete(key);
   });

--- a/app/listen/src/lib/equalizer-prefs.ts
+++ b/app/listen/src/lib/equalizer-prefs.ts
@@ -4,6 +4,7 @@ import {
   type EqGains,
   type EqPresetName,
 } from "@/lib/equalizer";
+import { isAndroidNative } from "@/lib/capacitor-runtime";
 
 export const EQ_PREFS_EVENT = "listen-equalizer-prefs";
 
@@ -34,11 +35,14 @@ export interface EqualizerSnapshot {
   genreAdaptive: boolean;
 }
 
-export function getEqualizerEnabled(): boolean {
+export function getEqualizerEnabled(
+  defaultEnabled: boolean = isAndroidNative,
+): boolean {
   try {
-    return localStorage.getItem(ENABLED_KEY) === "true";
+    const value = localStorage.getItem(ENABLED_KEY);
+    return value == null ? defaultEnabled : value === "true";
   } catch {
-    return false;
+    return defaultEnabled;
   }
 }
 

--- a/app/listen/src/lib/media-access.ts
+++ b/app/listen/src/lib/media-access.ts
@@ -112,6 +112,16 @@ export function getMediaAccessTicket(
   return current.ticket;
 }
 
+export function invalidateMediaAccessTicket(
+  audience: MediaAccessAudience,
+  path: string,
+  scope: string,
+): void {
+  const normalized = normalizedPath(path);
+  if (!normalized) return;
+  ticketsByScope.get(scope)?.delete(ticketKey(audience, normalized));
+}
+
 export function getMediaAccessTargets(scope: string): MediaAccessTarget[] {
   const scoped = targetsByScope.get(scope);
   if (!scoped) return [];

--- a/app/listen/src/pages/Album.tsx
+++ b/app/listen/src/pages/Album.tsx
@@ -47,6 +47,7 @@ import { usePlayerActions, type Track } from "@/contexts/PlayerContext";
 import { useSavedAlbums } from "@/contexts/SavedAlbumsContext";
 import { useLikedTracks } from "@/contexts/LikedTracksContext";
 import { QualityBadge } from "@/components/player/bar/QualityBadge";
+import { AuthenticatedMediaImage } from "@/components/player/AuthenticatedMediaImage";
 import { CrateLoader } from "@/components/ui/CrateLoader";
 import { ContextMenu, type ContextMenuEntry } from "@crate/ui/domain/actions";
 import { TrackRow, type TrackRowData } from "@/components/cards/TrackRow";
@@ -1262,7 +1263,7 @@ export function Album() {
       {/* Header */}
       <div className="relative min-h-[520px] overflow-hidden sm:h-[430px] sm:min-h-0 lg:h-[460px]">
         {data.has_cover || data.cover_url ? (
-          <img
+          <AuthenticatedMediaImage
             data-testid="album-hero-background"
             src={coverUrl}
             alt=""
@@ -1304,7 +1305,7 @@ export function Album() {
                 className="hidden aspect-square overflow-hidden rounded-2xl bg-white/5 shadow-2xl ring-1 ring-white/10 sm:block"
               >
                 {data.has_cover || data.cover_url ? (
-                  <img
+                  <AuthenticatedMediaImage
                     src={coverUrl}
                     alt={displayName}
                     className="h-full w-full object-cover"
@@ -1358,7 +1359,7 @@ export function Album() {
                 }
               >
                 <span className="h-6 w-6 flex-shrink-0 overflow-hidden rounded-full bg-white/5">
-                  <img
+                  <AuthenticatedMediaImage
                     src={artistPhotoUrl}
                     alt={data.artist}
                     className="h-full w-full object-cover"
@@ -1415,7 +1416,7 @@ export function Album() {
                 <div className="mt-3 flex items-center gap-2 text-xs text-muted-foreground">
                   <span className="inline-flex h-6 w-6 items-center justify-center overflow-hidden rounded-full bg-white/8 ring-1 ring-white/10">
                     {visibleContributor.user_avatar ? (
-                      <img
+                      <AuthenticatedMediaImage
                         src={visibleContributor.user_avatar}
                         alt=""
                         className="h-full w-full object-cover"

--- a/app/listen/src/pages/Bandcamp.tsx
+++ b/app/listen/src/pages/Bandcamp.tsx
@@ -522,6 +522,7 @@ function Cover({
     >
       {coverUrl ? (
         <img
+          data-public-media="true"
           src={coverUrl}
           alt=""
           loading="lazy"

--- a/app/listen/src/pages/Explore.tsx
+++ b/app/listen/src/pages/Explore.tsx
@@ -23,6 +23,7 @@ import { api, resolveMaybeApiAssetUrl } from "@/lib/api";
 import { albumCoverApiUrl } from "@/lib/library-routes";
 import { toPlayableTrack } from "@/lib/playable-track";
 import { PlaylistCard } from "@/components/playlists/PlaylistCard";
+import { AuthenticatedMediaImage } from "@/components/player/AuthenticatedMediaImage";
 import { usePlayerActions } from "@/contexts/PlayerContext";
 
 export function Explore() {
@@ -326,7 +327,7 @@ function GenreExplorer({
               className="group relative min-h-36 overflow-hidden rounded-3xl border border-white/10 bg-white/[0.035] p-4 text-left transition hover:border-primary/30 hover:bg-white/[0.06]"
             >
               {resolvedCoverUrl ? (
-                <img
+                <AuthenticatedMediaImage
                   src={resolvedCoverUrl}
                   alt=""
                   aria-hidden="true"

--- a/app/listen/src/pages/JamSession.tsx
+++ b/app/listen/src/pages/JamSession.tsx
@@ -33,6 +33,7 @@ import { useTranslation } from "react-i18next";
 import { toast } from "sonner";
 
 import { ActionIconButton } from "@crate/ui/primitives/ActionIconButton";
+import { AuthenticatedMediaImage } from "@/components/player/AuthenticatedMediaImage";
 import {
   AppModal,
   ModalBody,
@@ -223,7 +224,7 @@ function AvatarBubble({
   const { avatarUrl, handleAvatarError } = useUserAvatarUrl(avatar, userId);
   if (avatarUrl) {
     return (
-      <img
+      <AuthenticatedMediaImage
         src={avatarUrl}
         alt=""
         onError={handleAvatarError}
@@ -1510,7 +1511,7 @@ export function JamSession() {
                       className="flex w-full items-center gap-3 px-3 py-2.5 text-left hover:bg-white/[0.05]"
                     >
                       {playable.albumCover ? (
-                        <img
+                        <AuthenticatedMediaImage
                           src={playable.albumCover}
                           alt=""
                           className="h-10 w-10 rounded-lg object-cover"
@@ -1547,7 +1548,7 @@ export function JamSession() {
                   {index + 1}
                 </div>
                 {track.albumCover ? (
-                  <img
+                  <AuthenticatedMediaImage
                     src={track.albumCover}
                     alt=""
                     className="h-10 w-10 rounded-lg object-cover"
@@ -1667,7 +1668,7 @@ export function JamSession() {
                         {track ? (
                           <div className="mt-2 flex items-center gap-2 rounded-xl bg-black/20 p-2">
                             {track.albumCover ? (
-                              <img
+                              <AuthenticatedMediaImage
                                 src={track.albumCover}
                                 alt=""
                                 className="h-9 w-9 rounded-lg object-cover"

--- a/app/listen/src/pages/Library.tsx
+++ b/app/listen/src/pages/Library.tsx
@@ -32,6 +32,7 @@ import { useLikedTracks } from "@/contexts/LikedTracksContext";
 import { usePlaylistComposer } from "@/contexts/PlaylistComposerContext";
 import { ArtistCard } from "@/components/cards/ArtistCard";
 import { AlbumCard } from "@/components/cards/AlbumCard";
+import { AuthenticatedMediaImage } from "@/components/player/AuthenticatedMediaImage";
 import { TrackRow, type TrackRowData } from "@/components/cards/TrackRow";
 import { PlaylistListRow } from "@/components/playlists/PlaylistListRow";
 import {
@@ -943,7 +944,7 @@ function BandcampTab() {
               >
                 <div className="h-14 w-14 shrink-0 overflow-hidden rounded-xl border border-white/8 bg-white/6">
                   {contribution.album_id ? (
-                    <img
+                    <AuthenticatedMediaImage
                       src={albumCoverApiUrl(
                         {
                           albumId: contribution.album_id,
@@ -1015,7 +1016,7 @@ function BandcampTab() {
               >
                 <div className="flex h-16 w-16 shrink-0 items-center justify-center overflow-hidden rounded-xl border border-white/8 bg-white/6">
                   {coverUrl ? (
-                    <img
+                    <AuthenticatedMediaImage
                       src={coverUrl}
                       alt=""
                       loading="lazy"
@@ -1123,7 +1124,7 @@ function ContributionArtwork({
   return (
     <div className="h-14 w-14 shrink-0 overflow-hidden rounded-xl border border-white/8 bg-white/6">
       {contribution.album_id ? (
-        <img
+        <AuthenticatedMediaImage
           src={albumCoverApiUrl(
             {
               albumId: contribution.album_id,

--- a/app/listen/src/pages/PathDetail.tsx
+++ b/app/listen/src/pages/PathDetail.tsx
@@ -14,6 +14,7 @@ import { toast } from "sonner";
 import { useApi } from "@/hooks/use-api";
 import { api } from "@/lib/api";
 import { CrateLoader } from "@/components/ui/CrateLoader";
+import { AuthenticatedMediaImage } from "@/components/player/AuthenticatedMediaImage";
 import { usePlayerActions, type Track } from "@/contexts/PlayerContext";
 import { albumCoverApiUrl } from "@/lib/library-routes";
 import { toPlayableTrack } from "@/lib/playable-track";
@@ -235,7 +236,7 @@ export function PathDetail() {
           <div className="rounded-xl border border-primary/20 bg-primary/5 p-3">
             <div className="flex items-center gap-3">
               {path.tracks[activeStep]!.album_id && (
-                <img
+                <AuthenticatedMediaImage
                   src={albumCoverApiUrl(
                     {
                       albumId: path.tracks[activeStep]!.album_id!,
@@ -320,7 +321,7 @@ export function PathDetail() {
               </div>
 
               {t.album_id ? (
-                <img
+                <AuthenticatedMediaImage
                   src={albumCoverApiUrl(
                     {
                       albumId: t.album_id,

--- a/app/listen/src/pages/Paths.tsx
+++ b/app/listen/src/pages/Paths.tsx
@@ -15,6 +15,7 @@ import { toast } from "sonner";
 import { useApi } from "@/hooks/use-api";
 import { api } from "@/lib/api";
 import { usePlayerActions, type Track } from "@/contexts/PlayerContext";
+import { AuthenticatedMediaImage } from "@/components/player/AuthenticatedMediaImage";
 import { albumCoverApiUrl, artistPhotoApiUrl } from "@/lib/library-routes";
 import { toPlayableTrack } from "@/lib/playable-track";
 
@@ -221,7 +222,7 @@ function EndpointPanel({
       {/* Background cover */}
       {coverUrl && (
         <div className="absolute inset-0">
-          <img
+          <AuthenticatedMediaImage
             src={coverUrl}
             alt=""
             className="h-full w-full object-cover opacity-20 blur-sm"
@@ -240,7 +241,7 @@ function EndpointPanel({
           <div>
             {coverUrl && (
               <div className="mb-3 h-24 w-24 overflow-hidden rounded-xl bg-white/5 shadow-lg">
-                <img
+                <AuthenticatedMediaImage
                   src={coverUrl}
                   alt=""
                   className="h-full w-full object-cover"
@@ -292,7 +293,7 @@ function EndpointPanel({
                     className="flex w-full items-center gap-2.5 rounded-lg px-2.5 py-2 text-left text-sm text-white/70 transition hover:bg-white/5 hover:text-white"
                   >
                     {r.imageUrl ? (
-                      <img
+                      <AuthenticatedMediaImage
                         src={r.imageUrl}
                         alt=""
                         className={`h-8 w-8 flex-shrink-0 bg-white/5 object-cover ${

--- a/app/listen/src/pages/People.tsx
+++ b/app/listen/src/pages/People.tsx
@@ -7,6 +7,7 @@ import { useAuth } from "@/contexts/AuthContext";
 import { useApi } from "@/hooks/use-api";
 import { useUserAvatarUrl } from "@/hooks/use-user-avatar-url";
 import { UserProfileLink } from "@/components/social/UserProfileLink";
+import { AuthenticatedMediaImage } from "@/components/player/AuthenticatedMediaImage";
 import { api } from "@/lib/api";
 
 interface SocialSummary {
@@ -45,7 +46,7 @@ function UserAvatar({
   const { avatarUrl, handleAvatarError } = useUserAvatarUrl(avatar, userId);
   if (avatarUrl) {
     return (
-      <img
+      <AuthenticatedMediaImage
         src={avatarUrl}
         alt={name}
         onError={handleAvatarError}

--- a/app/listen/src/pages/Radio.tsx
+++ b/app/listen/src/pages/Radio.tsx
@@ -17,6 +17,7 @@ import {
   SectionRail,
 } from "@/components/home/HomeSections";
 import { usePlayerActions } from "@/contexts/PlayerContext";
+import { AuthenticatedMediaImage } from "@/components/player/AuthenticatedMediaImage";
 import { useApi } from "@/hooks/use-api";
 import { api, resolveMaybeApiAssetUrl } from "@/lib/api";
 import { albumCoverApiUrl, artistPhotoApiUrl } from "@/lib/library-routes";
@@ -117,7 +118,7 @@ function StationCard({
       className="group relative aspect-square snap-start overflow-hidden rounded-xl border border-white/8 bg-white/[0.03] text-left shadow-[0_18px_70px_rgba(0,0,0,0.24)] transition duration-300 hover:border-primary/30 hover:shadow-[0_18px_80px_rgba(10,209,241,0.12)] disabled:cursor-not-allowed disabled:opacity-50"
     >
       {imageUrl ? (
-        <img
+        <AuthenticatedMediaImage
           src={imageUrl}
           alt=""
           className="absolute inset-0 h-full w-full object-cover opacity-85 transition duration-500 group-hover:scale-[1.04] group-hover:opacity-100"
@@ -461,7 +462,7 @@ export function RadioPage() {
                 className="flex w-full items-center gap-2.5 rounded-lg px-3 py-2.5 text-left text-sm text-white/70 transition hover:bg-white/5 hover:text-white disabled:opacity-50"
               >
                 {r.imageUrl ? (
-                  <img
+                  <AuthenticatedMediaImage
                     src={r.imageUrl}
                     alt=""
                     className={`h-9 w-9 flex-shrink-0 bg-white/5 object-cover ${

--- a/app/listen/src/pages/SearchResults.tsx
+++ b/app/listen/src/pages/SearchResults.tsx
@@ -13,6 +13,7 @@ import { toTrackRowData } from "@/lib/track-row-data";
 import { ArtistCard } from "@/components/cards/ArtistCard";
 import { AlbumCard } from "@/components/cards/AlbumCard";
 import { TrackRow } from "@/components/cards/TrackRow";
+import { AuthenticatedMediaImage } from "@/components/player/AuthenticatedMediaImage";
 import { CrateLoader } from "@/components/ui/CrateLoader";
 import { usePlayerActions, type Track } from "@/contexts/PlayerContext";
 
@@ -305,7 +306,7 @@ export function SearchResults() {
                 >
                   <div className="relative mb-2 aspect-square overflow-hidden rounded-lg bg-white/5">
                     {a.has_cover ? (
-                      <img
+                      <AuthenticatedMediaImage
                         src={
                           globalUid
                             ? albumCoverApiUrl(

--- a/app/listen/src/pages/Settings.test.tsx
+++ b/app/listen/src/pages/Settings.test.tsx
@@ -5,6 +5,14 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { Settings } from "@/pages/Settings";
 import { renderWithListenProviders } from "@/test/render-with-listen-providers";
 
+const { androidNativePlayerState } = vi.hoisted(() => ({
+  androidNativePlayerState: { enabled: false },
+}));
+
+vi.mock("@/lib/android-native-engine", () => ({
+  shouldUseAndroidNativePlayer: () => androidNativePlayerState.enabled,
+}));
+
 vi.mock("@/components/settings/ServersSection", () => ({
   ServersSection: () => <section>Servers</section>,
 }));
@@ -37,6 +45,7 @@ vi.mock("@/lib/api", async (importOriginal) => {
 describe("Settings", () => {
   beforeEach(() => {
     localStorage.clear();
+    androidNativePlayerState.enabled = false;
     Object.defineProperty(window, "innerWidth", {
       configurable: true,
       value: 1024,
@@ -103,6 +112,24 @@ describe("Settings", () => {
     expect(
       screen.queryByText("Enhanced mobile audio (EQ)"),
     ).not.toBeInTheDocument();
+  });
+
+  it("shows the native equalizer toggle on Android and defaults it on", async () => {
+    Object.defineProperty(window, "innerWidth", {
+      configurable: true,
+      value: 390,
+    });
+    androidNativePlayerState.enabled = true;
+    const user = userEvent.setup();
+
+    renderWithListenProviders(<Settings />, { locale: "en" });
+
+    const toggle = screen.getByRole("button", { name: "Equalizer" });
+    expect(toggle).toHaveAttribute("aria-pressed", "true");
+
+    await user.click(toggle);
+    expect(localStorage.getItem("listen-eq-enabled")).toBe("false");
+    expect(toggle).toHaveAttribute("aria-pressed", "false");
   });
 
   it("keeps crossfade controls on desktop", () => {

--- a/app/listen/src/pages/Settings.tsx
+++ b/app/listen/src/pages/Settings.tsx
@@ -1001,6 +1001,7 @@ function BandcampSection() {
           <div className="flex min-w-0 items-center gap-3">
             {status?.image_url ? (
               <img
+                data-public-media="true"
                 src={status.image_url}
                 alt=""
                 className="h-11 w-11 rounded-full object-cover"

--- a/app/listen/src/pages/Settings.tsx
+++ b/app/listen/src/pages/Settings.tsx
@@ -63,6 +63,11 @@ import {
   type SleepTimerMode,
   type SleepTimerState,
 } from "@/lib/sleep-timer";
+import {
+  getEqualizerEnabled,
+  setEqualizerEnabled,
+} from "@/lib/equalizer-prefs";
+import { shouldUseAndroidNativePlayer } from "@/lib/android-native-engine";
 
 interface AuthProviderState {
   enabled: boolean;
@@ -316,6 +321,10 @@ export function Settings() {
     getPlaybackDeliveryPolicyPreference,
   );
   const mobilePlaybackRuntime = isMobilePlaybackRuntime();
+  const androidNativePlayerEnabled = shouldUseAndroidNativePlayer();
+  const [equalizerEnabled, setEqualizerEnabledState] = useState(() =>
+    getEqualizerEnabled(androidNativePlayerEnabled),
+  );
   const publicProfilePath = useMemo(() => {
     return user?.username ? `/users/${user.username}` : "/people";
   }, [user?.username]);
@@ -418,6 +427,16 @@ export function Settings() {
               }}
             />
           </>
+        ) : null}
+        {!mobilePlaybackRuntime || androidNativePlayerEnabled ? (
+          <ToggleRow
+            label={t("player.equalizer")}
+            checked={equalizerEnabled}
+            onChange={(value) => {
+              setEqualizerEnabledState(value);
+              setEqualizerEnabled(value);
+            }}
+          />
         ) : null}
         <ToggleRow
           label={t("settings.playback.smartPlaylistSuggestions")}

--- a/app/listen/src/pages/Stats.tsx
+++ b/app/listen/src/pages/Stats.tsx
@@ -16,6 +16,7 @@ import {
 import { Link, useLocation, useParams, useSearchParams } from "react-router";
 
 import { WindowPicker } from "@/components/stats/StatsPanels";
+import { AuthenticatedMediaImage } from "@/components/player/AuthenticatedMediaImage";
 import {
   buildRecapHighlights,
   formatStatsMinutes,
@@ -619,7 +620,7 @@ function StatsCoverMosaic({ tracks }: { tracks: StatsTrack[] }) {
             )}
           >
             {cover ? (
-              <img
+              <AuthenticatedMediaImage
                 src={cover}
                 alt=""
                 className="h-full w-full object-cover grayscale-[35%] saturate-[0.85]"
@@ -1338,7 +1339,7 @@ function TopArtistCard({ item, index }: { item: StatsArtist; index: number }) {
       className="group relative min-h-40 overflow-hidden rounded-[1.35rem] border border-white/10 bg-white/[0.04] p-4 transition hover:border-primary/35"
     >
       {photo ? (
-        <img
+        <AuthenticatedMediaImage
           src={photo}
           alt=""
           className="absolute inset-0 h-full w-full object-cover grayscale opacity-55 transition duration-500 group-hover:scale-105 group-hover:opacity-70"
@@ -1413,7 +1414,7 @@ function TopAlbumsPanel({
                   },
                   { size: 384 },
                 ) ? (
-                  <img
+                  <AuthenticatedMediaImage
                     src={albumCoverApiUrl(
                       {
                         albumId: item.album_id,
@@ -1513,7 +1514,7 @@ function TrackCover({
       )}
     >
       {cover ? (
-        <img
+        <AuthenticatedMediaImage
           src={cover}
           alt=""
           className="h-full w-full object-cover"

--- a/app/listen/src/pages/UserConnections.tsx
+++ b/app/listen/src/pages/UserConnections.tsx
@@ -5,6 +5,7 @@ import { useTranslation } from "react-i18next";
 import { useApi } from "@/hooks/use-api";
 import { useUserAvatarUrl } from "@/hooks/use-user-avatar-url";
 import { UserProfileLink } from "@/components/social/UserProfileLink";
+import { AuthenticatedMediaImage } from "@/components/player/AuthenticatedMediaImage";
 
 interface UserListItem {
   id: number;
@@ -28,7 +29,7 @@ function UserAvatar({
   const { avatarUrl, handleAvatarError } = useUserAvatarUrl(avatar, userId);
   if (avatarUrl) {
     return (
-      <img
+      <AuthenticatedMediaImage
         src={avatarUrl}
         alt={name}
         onError={handleAvatarError}

--- a/app/listen/src/pages/UserProfile.tsx
+++ b/app/listen/src/pages/UserProfile.tsx
@@ -19,6 +19,7 @@ import { useAuth } from "@/contexts/AuthContext";
 import { useApi } from "@/hooks/use-api";
 import { useUserAvatarUrl } from "@/hooks/use-user-avatar-url";
 import { UserProfileLink } from "@/components/social/UserProfileLink";
+import { AuthenticatedMediaImage } from "@/components/player/AuthenticatedMediaImage";
 import { CrateLoader } from "@/components/ui/CrateLoader";
 import { api, resolveMaybeApiAssetUrl } from "@/lib/api";
 import { contributionSourceLabel } from "@/lib/contributions";
@@ -119,7 +120,7 @@ function UserAvatar({
   const { avatarUrl, handleAvatarError } = useUserAvatarUrl(avatar, userId);
   if (avatarUrl) {
     return (
-      <img
+      <AuthenticatedMediaImage
         src={avatarUrl}
         alt={name}
         onError={handleAvatarError}
@@ -246,7 +247,7 @@ function ContributionCard({
   const card = (
     <>
       {coverUrl ? (
-        <img
+        <AuthenticatedMediaImage
           src={coverUrl}
           alt=""
           className="h-14 w-14 rounded-xl object-cover"
@@ -640,7 +641,7 @@ export function UserProfile() {
                       className="flex items-center gap-4 rounded-2xl border border-white/10 bg-white/[0.02] px-4 py-3 hover:bg-white/[0.05] transition-colors"
                     >
                       {coverUrl ? (
-                        <img
+                        <AuthenticatedMediaImage
                           src={coverUrl}
                           alt={playlist.name}
                           className="h-14 w-14 rounded-xl object-cover"

--- a/app/readplane/internal/routes/artwork.go
+++ b/app/readplane/internal/routes/artwork.go
@@ -45,12 +45,7 @@ func (s *Server) serveAlbumArtworkByID(w http.ResponseWriter, r *http.Request, i
 }
 
 func (s *Server) serveAlbumArtworkByEntityUID(w http.ResponseWriter, r *http.Request, uid string) {
-	if s.artworkCatalog == nil {
-		s.fallbackOrRouteMiss(w, r)
-		return
-	}
-	key, err := s.artworkCatalog.AlbumArtworkKeyByEntityUID(r.Context(), uid)
-	s.serveMaterializedArtwork(w, r, "album-cover", key, err)
+	s.serveMaterializedArtwork(w, r, "album-cover", uid, nil)
 }
 
 func (s *Server) serveArtistArtworkByID(w http.ResponseWriter, r *http.Request, id int64, action string) {

--- a/app/readplane/internal/routes/artwork_test.go
+++ b/app/readplane/internal/routes/artwork_test.go
@@ -92,6 +92,31 @@ func TestServeMaterializedAlbumArtwork(t *testing.T) {
 	assert.Equal(t, "hit", rec.Header().Get("X-Crate-Readplane"))
 }
 
+func TestServeMaterializedAlbumArtworkByEntityUIDAvoidsCatalogLookup(t *testing.T) {
+	root := t.TempDir()
+	entityUID := "11111111-1111-4111-8111-111111111111"
+	writeRouteArtworkFixture(t, root, "album-cover", entityUID)
+	server := &Server{
+		artworkCatalog:  stubArtworkCatalog{err: assert.AnError},
+		artworkResolver: media.NewArtworkResolver(root),
+	}
+	rec := httptest.NewRecorder()
+
+	server.serveAlbumArtworkByEntityUID(
+		rec,
+		httptest.NewRequest(
+			http.MethodGet,
+			"/api/albums/by-entity/"+entityUID+"/cover?size=256",
+			nil,
+		),
+		entityUID,
+	)
+
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.Equal(t, "webp", rec.Body.String())
+	assert.Equal(t, "variant", rec.Header().Get("X-Crate-Artwork"))
+}
+
 func TestNewServerResolvesArtworkFromCacheRoot(t *testing.T) {
 	cacheRoot := t.TempDir()
 	writeRouteArtworkFixture(t, cacheRoot, "album-cover", "album-uid")

--- a/app/tests/test_android_release_workflow.py
+++ b/app/tests/test_android_release_workflow.py
@@ -1,0 +1,33 @@
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+WORKFLOW = ROOT / ".github/workflows/build-android.yml"
+
+
+def test_android_ci_only_builds_and_publishes_end_user_artifacts_for_tags() -> None:
+    workflow = WORKFLOW.read_text()
+
+    assert "assembleDebug" not in workflow
+    assert "assembleDebugAndroidTest" not in workflow
+    assert "outputs/apk/debug" not in workflow
+    assert "Build debug APK" not in workflow
+
+    for step_name in (
+        "Locate Android release artifacts",
+        "Prepare published release artifacts",
+        "Upload signed APK build artifact",
+    ):
+        step = workflow[workflow.index(f"- name: {step_name}") :]
+        step = step[: step.index("\n      - name:", 1)]
+        assert "if: startsWith(github.ref, 'refs/tags/v')" in step
+
+
+def test_android_tag_build_keeps_signed_apk_and_aab_release_outputs() -> None:
+    workflow = WORKFLOW.read_text()
+
+    assert "Build signed release APK and AAB" in workflow
+    assert "bundleRelease assembleRelease lintRelease" in workflow
+    assert "app/build/outputs/apk/release" in workflow
+    assert "app/build/outputs/bundle/release" in workflow
+    assert "Attach signed Android artifacts to GitHub Release" in workflow

--- a/app/tests/test_artwork_bootstrap.py
+++ b/app/tests/test_artwork_bootstrap.py
@@ -36,3 +36,26 @@ def test_artwork_backfill_bootstrap_skips_completed_version(monkeypatch):
     )
 
     _queue_artwork_variant_backfill()
+
+
+def test_artwork_manifest_permission_repair_is_queued_once(monkeypatch):
+    from crate.api import _queue_artwork_manifest_permission_repair
+
+    queued = []
+    monkeypatch.setattr("crate.db.cache_settings.get_setting", lambda _key: None)
+    monkeypatch.setattr(
+        "crate.db.repositories.tasks.create_task_dedup",
+        lambda task_type, params, dedup_key: queued.append(
+            (task_type, params, dedup_key)
+        ),
+    )
+
+    _queue_artwork_manifest_permission_repair()
+
+    assert queued == [
+        (
+            "repair_artwork_variants",
+            {"max_assets": 100_000, "repair_manifest_permissions": True},
+            "bootstrap:artwork-manifest-permissions:v1",
+        )
+    ]

--- a/app/tests/test_artwork_variant_cleanup.py
+++ b/app/tests/test_artwork_variant_cleanup.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import os
+import stat
 import time
 from io import BytesIO
 
@@ -56,6 +57,25 @@ def test_cleanup_removes_only_expired_temporary_directories(monkeypatch, tmp_pat
     assert result["temporary_removed"] == 1
 
 
+def test_repair_manifest_permissions_makes_existing_assets_readplane_readable(
+    monkeypatch, tmp_path
+):
+    from crate.artwork_maintenance import repair_artwork_manifest_permissions
+    from crate.artwork_variants import ArtworkAsset, artwork_asset_root
+
+    monkeypatch.setenv("DATA_DIR", str(tmp_path))
+    root = artwork_asset_root(ArtworkAsset("album-cover", "album-entity"))
+    root.mkdir(parents=True)
+    manifest = root / "current.json"
+    manifest.write_text("{}")
+    manifest.chmod(0o600)
+
+    result = repair_artwork_manifest_permissions(max_assets=10)
+
+    assert result == {"assets_checked": 1, "permissions_repaired": 1}
+    assert stat.S_IMODE(manifest.stat().st_mode) == 0o644
+
+
 def test_integrity_sample_reports_invalid_manifests_and_missing_files(
     monkeypatch, tmp_path
 ):
@@ -108,6 +128,36 @@ def test_repair_handler_requeues_corrupt_assets(monkeypatch):
 
     assert result == {"assets_checked": 100, "requeued": 1}
     assert queued == [(ArtworkAsset("album-cover", "album-entity"), "integrity-repair")]
+
+
+def test_repair_handler_fixes_manifest_modes_and_marks_upgrade_complete(monkeypatch):
+    from crate.worker_handlers import artwork
+
+    completed = []
+    monkeypatch.setattr(artwork, "find_corrupt_artwork_assets", lambda **_kwargs: [])
+    monkeypatch.setattr(
+        artwork,
+        "repair_artwork_manifest_permissions",
+        lambda **_kwargs: {"assets_checked": 42, "permissions_repaired": 41},
+    )
+    monkeypatch.setattr(
+        "crate.db.cache_settings.set_setting",
+        lambda key, value: completed.append((key, value)),
+    )
+
+    result = artwork._handle_repair_artwork_variants(
+        "task-1",
+        {"max_assets": 100_000, "repair_manifest_permissions": True},
+        {},
+    )
+
+    assert result == {
+        "assets_checked": 100_000,
+        "requeued": 0,
+        "manifest_assets_checked": 42,
+        "permissions_repaired": 41,
+    }
+    assert completed == [("artwork_manifest_permissions_version", "1")]
 
 
 def test_normal_health_uses_a_bounded_artwork_integrity_sample(monkeypatch):

--- a/app/tests/test_artwork_variants.py
+++ b/app/tests/test_artwork_variants.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import stat
 from pathlib import Path
 
 import pytest
@@ -104,6 +105,33 @@ def test_resolve_materialized_variant_reads_only_current_revision(
     assert resolved.media_type == "image/webp"
     assert resolved.source_revision == "revision-a"
     assert (resolved.width, resolved.height) == (256, 256)
+
+
+def test_publish_manifest_is_readable_by_the_readplane(monkeypatch, tmp_path):
+    from crate.artwork_variants import (
+        ArtworkAsset,
+        artwork_asset_root,
+        publish_manifest_atomically,
+    )
+
+    monkeypatch.setenv("DATA_DIR", str(tmp_path))
+    asset = ArtworkAsset("album-cover", "album-entity")
+
+    publish_manifest_atomically(
+        asset,
+        {
+            "version": 1,
+            "kind": asset.kind,
+            "entity_key": asset.entity_key,
+            "source_revision": "revision-a",
+            "variants": {"256": "revision-a/256.webp"},
+        },
+    )
+
+    manifest_mode = stat.S_IMODE(
+        (artwork_asset_root(asset) / "current.json").stat().st_mode
+    )
+    assert manifest_mode == 0o644
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

- Prevent CrateNativePlaybackService from crashing when Android recreates it from a persisted playback checkpoint.
- Restore checkpoint entries with an opaque non-network media URI until authenticated playback sources are rebound.
- Stop CI from building or publishing debug APKs; only version tags produce signed APK/AAB end-user artifacts.

## Root cause

Checkpoint restoration created metadata-only MediaItems. Media3 requires a local configuration when the restored queue is assigned to ExoPlayer, so service creation threw a NullPointerException after the app was killed during playback.

## Validation

- Reproduced the crash by injecting a persisted checkpoint and restarting the service.
- Connected Android instrumentation regression test passed on the emulator.
- Gradle unit tests and Android lint passed.
- Listen typecheck and ESLint passed.
- 12 focused mobile playback tests passed.
- Android workflow contract tests: 2 passed.
- Local sideload APK verified manually by the user.