### PR TITLE
fix(android): refresh artwork immediately after resume

### DIFF
--- a/app/listen/src/components/player/AuthenticatedMediaImage.test.tsx
+++ b/app/listen/src/components/player/AuthenticatedMediaImage.test.tsx
@@ -1,13 +1,26 @@
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const { mediaVersion, ensureMediaAccessUrlMock } = vi.hoisted(() => ({
-  mediaVersion: { value: 1 },
-  ensureMediaAccessUrlMock: vi.fn(),
-}));
+const {
+  mediaVersion,
+  mediaResumeVersion,
+  ensureMediaAccessUrlMock,
+  resolveMaybeApiAssetUrlMock,
+} = vi.hoisted(() => {
+  const mediaVersionState = { value: 1 };
+  return {
+    mediaVersion: mediaVersionState,
+    mediaResumeVersion: { value: 0 },
+    ensureMediaAccessUrlMock: vi.fn(),
+    resolveMaybeApiAssetUrlMock: vi.fn((url: string | null | undefined) =>
+      url ? `${url}?ticket-version=${mediaVersionState.value}` : null,
+    ),
+  };
+});
 
 vi.mock("@/hooks/use-media-access-version", () => ({
   useMediaAccessVersion: () => mediaVersion.value,
+  useMediaAccessResumeVersion: () => mediaResumeVersion.value,
 }));
 
 vi.mock("@/lib/api", () => ({
@@ -16,8 +29,7 @@ vi.mock("@/lib/api", () => ({
     Boolean(url?.includes("ticket-version") || url?.includes("media_ticket")),
   requiresMediaAccessTicket: (url: string | null | undefined) =>
     Boolean(url?.startsWith("/api/")),
-  resolveMaybeApiAssetUrl: (url: string | null | undefined) =>
-    url ? `${url}?ticket-version=${mediaVersion.value}` : null,
+  resolveMaybeApiAssetUrl: resolveMaybeApiAssetUrlMock,
 }));
 
 import { AuthenticatedMediaImage } from "./AuthenticatedMediaImage";
@@ -25,7 +37,9 @@ import { AuthenticatedMediaImage } from "./AuthenticatedMediaImage";
 describe("AuthenticatedMediaImage", () => {
   beforeEach(() => {
     mediaVersion.value = 1;
+    mediaResumeVersion.value = 0;
     ensureMediaAccessUrlMock.mockReset();
+    resolveMaybeApiAssetUrlMock.mockClear();
     ensureMediaAccessUrlMock.mockResolvedValue(
       "/api/albums/1/cover?media_ticket=renewed",
     );
@@ -46,6 +60,44 @@ describe("AuthenticatedMediaImage", () => {
     expect(screen.getByRole("img", { name: "Cover" })).toHaveAttribute(
       "src",
       "/api/albums/1/cover?ticket-version=1",
+    );
+  });
+
+  it("proactively replaces an expired source after the app resumes", async () => {
+    const { rerender } = render(
+      <AuthenticatedMediaImage src="/api/albums/1/cover" alt="Cover" />,
+    );
+    const image = screen.getByRole("img", { name: "Cover" });
+    fireEvent.load(image);
+
+    mediaResumeVersion.value = 1;
+    rerender(<AuthenticatedMediaImage src="/api/albums/1/cover" alt="Cover" />);
+
+    await waitFor(() =>
+      expect(ensureMediaAccessUrlMock).toHaveBeenCalledWith(
+        "/api/albums/1/cover",
+        "artwork",
+        { forceRefresh: true },
+      ),
+    );
+    expect(image).toHaveAttribute(
+      "src",
+      "/api/albums/1/cover?media_ticket=renewed",
+    );
+  });
+
+  it("re-registers the protected path during the resume render for batching", async () => {
+    const { rerender } = render(
+      <AuthenticatedMediaImage src="/api/albums/1/cover" alt="Cover" />,
+    );
+    expect(resolveMaybeApiAssetUrlMock).toHaveBeenCalledTimes(1);
+
+    mediaResumeVersion.value = 1;
+    rerender(<AuthenticatedMediaImage src="/api/albums/1/cover" alt="Cover" />);
+
+    expect(resolveMaybeApiAssetUrlMock).toHaveBeenCalledTimes(2);
+    await waitFor(() =>
+      expect(ensureMediaAccessUrlMock).toHaveBeenCalledTimes(1),
     );
   });
 

--- a/app/listen/src/components/player/AuthenticatedMediaImage.tsx
+++ b/app/listen/src/components/player/AuthenticatedMediaImage.tsx
@@ -6,7 +6,10 @@ import {
   type ImgHTMLAttributes,
 } from "react";
 
-import { useMediaAccessVersion } from "@/hooks/use-media-access-version";
+import {
+  useMediaAccessResumeVersion,
+  useMediaAccessVersion,
+} from "@/hooks/use-media-access-version";
 import {
   ensureMediaAccessUrl,
   isUsableMediaAssetUrl,
@@ -50,6 +53,20 @@ function canonicalSourceSetIdentity(sourceSet: string | undefined): string {
     .join(", ");
 }
 
+function resolveAuthenticatedSourceSet(
+  sourceSet: string | undefined,
+): string | undefined {
+  if (!sourceSet) return undefined;
+  const candidates = sourceSet.split(",").map((candidate) => {
+    const match = candidate.trim().match(/^(\S+)(\s+.+)?$/);
+    if (!match?.[1]) return null;
+    const resolved = resolveMaybeApiAssetUrl(match[1]);
+    if (!resolved || !isUsableMediaAssetUrl(resolved)) return null;
+    return `${resolved}${match[2] ?? ""}`;
+  });
+  return candidates.every(Boolean) ? candidates.join(", ") : undefined;
+}
+
 export function AuthenticatedMediaImage({
   src,
   srcSet,
@@ -58,24 +75,18 @@ export function AuthenticatedMediaImage({
   ...props
 }: AuthenticatedMediaImageProps) {
   const ticketVersion = useMediaAccessVersion();
+  const resumeVersion = useMediaAccessResumeVersion();
   const sourceKey = `${canonicalSourceIdentity(
     src,
   )}\u0000${canonicalSourceSetIdentity(srcSet)}`;
   const resolvedSource = useMemo(
     () => resolveMaybeApiAssetUrl(src),
-    [src, ticketVersion],
+    [resumeVersion, src, ticketVersion],
   );
-  const resolvedSourceSet = useMemo(() => {
-    if (!srcSet) return undefined;
-    const candidates = srcSet.split(",").map((candidate) => {
-      const match = candidate.trim().match(/^(\S+)(\s+.+)?$/);
-      if (!match?.[1]) return null;
-      const resolved = resolveMaybeApiAssetUrl(match[1]);
-      if (!resolved || !isUsableMediaAssetUrl(resolved)) return null;
-      return `${resolved}${match[2] ?? ""}`;
-    });
-    return candidates.every(Boolean) ? candidates.join(", ") : undefined;
-  }, [srcSet, ticketVersion]);
+  const resolvedSourceSet = useMemo(
+    () => resolveAuthenticatedSourceSet(srcSet),
+    [resumeVersion, srcSet, ticketVersion],
+  );
   const usableSource =
     resolvedSource && isUsableMediaAssetUrl(resolvedSource)
       ? resolvedSource
@@ -86,6 +97,7 @@ export function AuthenticatedMediaImage({
     sourceSet: resolvedSourceSet,
   }));
   const recoveryAttemptedFor = useRef<string | null>(null);
+  const handledResumeVersion = useRef(resumeVersion);
 
   useEffect(() => {
     recoveryAttemptedFor.current = null;
@@ -108,6 +120,31 @@ export function AuthenticatedMediaImage({
       };
     });
   }, [resolvedSourceSet, sourceKey, usableSource]);
+
+  useEffect(() => {
+    if (handledResumeVersion.current === resumeVersion) return;
+    handledResumeVersion.current = resumeVersion;
+    if (!src || !requiresMediaAccessTicket(src)) return;
+
+    let cancelled = false;
+    void ensureMediaAccessUrl(src, "artwork", {
+      forceRefresh: true,
+    })
+      .then((source) => {
+        if (cancelled) return;
+        setActive({
+          key: sourceKey,
+          source,
+          sourceSet: resolveAuthenticatedSourceSet(srcSet),
+        });
+      })
+      .catch(() => {
+        // Keep the previously rendered bitmap while normal error recovery runs.
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [resumeVersion, sourceKey, src, srcSet]);
 
   const rendered =
     active.key === sourceKey
@@ -143,22 +180,10 @@ export function AuthenticatedMediaImage({
           forceRefresh: true,
         })
           .then((source) => {
-            const refreshedCandidates = srcSet?.split(",").map((candidate) => {
-              const match = candidate.trim().match(/^(\S+)(\s+.+)?$/);
-              if (!match?.[1]) return null;
-              const resolved = resolveMaybeApiAssetUrl(match[1]);
-              return resolved && isUsableMediaAssetUrl(resolved)
-                ? `${resolved}${match[2] ?? ""}`
-                : null;
-            });
             setActive({
               key: sourceKey,
               source,
-              sourceSet:
-                refreshedCandidates?.every(Boolean) &&
-                refreshedCandidates.length
-                  ? refreshedCandidates.join(", ")
-                  : undefined,
+              sourceSet: resolveAuthenticatedSourceSet(srcSet),
             });
           })
           .catch(() => {

--- a/app/listen/src/hooks/use-media-access-version.ts
+++ b/app/listen/src/hooks/use-media-access-version.ts
@@ -1,7 +1,9 @@
 import { useSyncExternalStore } from "react";
 
 import {
+  getMediaAccessResumeVersion,
   getMediaAccessTicketsVersion,
+  subscribeMediaAccessResumes,
   subscribeMediaAccessTickets,
 } from "@/lib/media-access";
 
@@ -10,5 +12,13 @@ export function useMediaAccessVersion(): number {
     subscribeMediaAccessTickets,
     getMediaAccessTicketsVersion,
     getMediaAccessTicketsVersion,
+  );
+}
+
+export function useMediaAccessResumeVersion(): number {
+  return useSyncExternalStore(
+    subscribeMediaAccessResumes,
+    getMediaAccessResumeVersion,
+    getMediaAccessResumeVersion,
   );
 }

--- a/app/listen/src/lib/api.test.ts
+++ b/app/listen/src/lib/api.test.ts
@@ -1096,6 +1096,51 @@ describe("native (configurable server) mode", () => {
   });
 
   describe("media access refresh", () => {
+    it("starts immediate artwork recovery without refreshing historical targets", async () => {
+      setupServer();
+      const initialResumeVersion = mediaAccess.getMediaAccessResumeVersion();
+      const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+        mockJsonResponse({
+          tickets: [],
+        }),
+      );
+      const stop = apiMod.startMediaAccessTicketRefresh();
+
+      window.dispatchEvent(new CustomEvent("crate:app-resumed"));
+
+      await vi.waitFor(() =>
+        expect(mediaAccess.getMediaAccessResumeVersion()).toBe(
+          initialResumeVersion + 1,
+        ),
+      );
+      await Promise.resolve();
+      expect(fetchMock).not.toHaveBeenCalled();
+
+      stop();
+    });
+
+    it("invalidates cached artwork credentials before mounted images resume", async () => {
+      setupServer();
+      const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+        mockJsonResponse({
+          tickets: [],
+        }),
+      );
+      const stop = apiMod.startMediaAccessTicketRefresh();
+      expect(apiMod.apiAssetUrl("/api/cover.jpg")).toContain(
+        "media_ticket=artwork-ticket",
+      );
+
+      window.dispatchEvent(new CustomEvent("crate:app-resumed"));
+
+      expect(apiMod.apiAssetUrl("/api/cover.jpg")).toBe(
+        "https://api.example.com/api/cover.jpg",
+      );
+      await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
+
+      stop();
+    });
+
     it("requests a missing ticket for the exact path without blocking URL generation", async () => {
       const server = setupServer();
       mediaAccess.clearMediaAccessTickets();

--- a/app/listen/src/lib/api.ts
+++ b/app/listen/src/lib/api.ts
@@ -7,6 +7,7 @@ import {
 } from "@/lib/auth-route-policy";
 import {
   getListenAppId,
+  isCapacitorRuntime,
   isTauriRuntime,
   usesConfigurableServer,
 } from "@/lib/platform";
@@ -27,7 +28,9 @@ import {
   clearMediaAccessTickets,
   getMediaAccessTicket,
   getMediaAccessTargets,
+  invalidateMediaAccessAudience,
   invalidateMediaAccessTicket,
+  signalMediaAccessResume,
   setMediaAccessTickets,
   type MediaAccessAudience,
   type MediaAccessTarget,
@@ -587,10 +590,15 @@ export async function ensureMediaAccessUrl(
 
 export function startMediaAccessTicketRefresh(): () => void {
   if (!usesConfigurableServer || typeof window === "undefined") return () => {};
-  const refresh = () => {
-    if (document.visibilityState === "visible") {
-      void refreshMediaAccessTickets();
-    }
+  const recoverAfterResume = () => {
+    const server = getCurrentServer();
+    if (server?.id) invalidateMediaAccessAudience("artwork", server.id);
+    signalMediaAccessResume();
+  };
+  const handleVisibilityChange = () => {
+    if (document.visibilityState !== "visible") return;
+    if (isCapacitorRuntime) return;
+    recoverAfterResume();
   };
   const interval = window.setInterval(
     () => void refreshMediaAccessTickets(),
@@ -600,11 +608,15 @@ export function startMediaAccessTicketRefresh(): () => void {
     clearMediaAccessTickets();
     void refreshMediaAccessTickets();
   };
-  document.addEventListener("visibilitychange", refresh);
+  document.addEventListener("visibilitychange", handleVisibilityChange);
+  window.addEventListener("crate:app-resumed", recoverAfterResume);
+  window.addEventListener("crate:network-restored", recoverAfterResume);
   window.addEventListener(SERVER_STORE_EVENT, handleServerChange);
   return () => {
     window.clearInterval(interval);
-    document.removeEventListener("visibilitychange", refresh);
+    document.removeEventListener("visibilitychange", handleVisibilityChange);
+    window.removeEventListener("crate:app-resumed", recoverAfterResume);
+    window.removeEventListener("crate:network-restored", recoverAfterResume);
     window.removeEventListener(SERVER_STORE_EVENT, handleServerChange);
   };
 }

--- a/app/listen/src/lib/media-access.test.ts
+++ b/app/listen/src/lib/media-access.test.ts
@@ -2,10 +2,14 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import {
   clearMediaAccessTickets,
+  getMediaAccessResumeVersion,
   getMediaAccessTargets,
   getMediaAccessTicketsVersion,
   getMediaAccessTicket,
+  invalidateMediaAccessAudience,
   setMediaAccessTickets,
+  signalMediaAccessResume,
+  subscribeMediaAccessResumes,
   subscribeMediaAccessTickets,
 } from "@/lib/media-access";
 
@@ -97,6 +101,36 @@ describe("media access ticket cache", () => {
     ).toBeNull();
   });
 
+  it("invalidates only the selected audience for a server", () => {
+    const expiresAt = new Date(Date.now() + 60_000).toISOString();
+    setMediaAccessTickets(
+      [
+        {
+          audience: "artwork",
+          path: "/api/albums/12/cover",
+          ticket: "artwork-ticket",
+          expires_at: expiresAt,
+        },
+        {
+          audience: "stream",
+          path: "/api/tracks/12/stream",
+          ticket: "stream-ticket",
+          expires_at: expiresAt,
+        },
+      ],
+      "server-a",
+    );
+
+    invalidateMediaAccessAudience("artwork", "server-a");
+
+    expect(
+      getMediaAccessTicket("artwork", "/api/albums/12/cover", "server-a"),
+    ).toBeNull();
+    expect(
+      getMediaAccessTicket("stream", "/api/tracks/12/stream", "server-a"),
+    ).toBe("stream-ticket");
+  });
+
   it("remembers requested paths so short-lived tickets can be refreshed", () => {
     expect(
       getMediaAccessTicket("sse", "/api/events/task/task-1", "server-a"),
@@ -122,6 +156,21 @@ describe("media access ticket cache", () => {
 
     unsubscribe();
     clearMediaAccessTickets();
+    expect(listener).toHaveBeenCalledTimes(1);
+  });
+
+  it("notifies mounted media when the app resumes", () => {
+    const listener = vi.fn();
+    const initialVersion = getMediaAccessResumeVersion();
+    const unsubscribe = subscribeMediaAccessResumes(listener);
+
+    signalMediaAccessResume();
+
+    expect(listener).toHaveBeenCalledTimes(1);
+    expect(getMediaAccessResumeVersion()).toBe(initialVersion + 1);
+
+    unsubscribe();
+    signalMediaAccessResume();
     expect(listener).toHaveBeenCalledTimes(1);
   });
 });

--- a/app/listen/src/lib/media-access.ts
+++ b/app/listen/src/lib/media-access.ts
@@ -18,7 +18,9 @@ const MAX_TARGETS_PER_SCOPE = 512;
 const ticketsByScope = new Map<string, Map<string, MediaAccessTicket>>();
 const targetsByScope = new Map<string, Map<string, MediaAccessTarget>>();
 const ticketListeners = new Set<() => void>();
+const resumeListeners = new Set<() => void>();
 let ticketVersion = 0;
+let resumeVersion = 0;
 
 function normalizedPath(path: string): string | null {
   try {
@@ -66,6 +68,20 @@ export function subscribeMediaAccessTickets(listener: () => void): () => void {
 
 export function getMediaAccessTicketsVersion(): number {
   return ticketVersion;
+}
+
+export function subscribeMediaAccessResumes(listener: () => void): () => void {
+  resumeListeners.add(listener);
+  return () => resumeListeners.delete(listener);
+}
+
+export function getMediaAccessResumeVersion(): number {
+  return resumeVersion;
+}
+
+export function signalMediaAccessResume(): void {
+  resumeVersion += 1;
+  for (const listener of resumeListeners) listener();
 }
 
 export function setMediaAccessTickets(
@@ -120,6 +136,17 @@ export function invalidateMediaAccessTicket(
   const normalized = normalizedPath(path);
   if (!normalized) return;
   ticketsByScope.get(scope)?.delete(ticketKey(audience, normalized));
+}
+
+export function invalidateMediaAccessAudience(
+  audience: MediaAccessAudience,
+  scope: string,
+): void {
+  const tickets = ticketsByScope.get(scope);
+  if (!tickets) return;
+  for (const [key, ticket] of tickets) {
+    if (ticket.audience === audience) tickets.delete(key);
+  }
 }
 
 export function getMediaAccessTargets(scope: string): MediaAccessTarget[] {


### PR DESCRIPTION
## Summary

- recover protected artwork immediately from the Capacitor `crate:app-resumed` lifecycle event
- invalidate only cached artwork tickets before waking mounted image components
- re-register all mounted image paths during the resume render so ticket requests are batched
- replace expired image and `srcSet` credentials proactively without waiting for WebView `error` or the 45-second refresh interval
- preserve the previously rendered bitmap until the renewed URL is ready

## Root cause

Playback already listened to the native Capacitor resume event, but media ticket refresh only observed `visibilitychange`, which Android WebView does not emit reliably. After sleep, WebView could evict decoded bitmaps while the DOM still held URLs containing expired 60-second media tickets. `AuthenticatedMediaImage` intentionally kept those URLs stable during normal ticket rotation, so recovery waited for a delayed image error or periodic refresh.

## Impact

Artwork recovery after Android sleep now begins synchronously with the native resume lifecycle. Mounted image paths are collected into the existing ticket batch and swapped as soon as the batch resolves, without globally refreshing historical artwork targets or disturbing stream/SSE/WebSocket credentials.

## Validation

- TDD regressions for native resume, proactive source replacement, exact audience invalidation, and resume batching
- Listen: 200 files, 1,628 passed, 4 skipped
- Listen typecheck and ESLint
- Capacitor production build and Android/iOS sync
- mobile build-script tests and secure release config validation
- initial JS bundle: 163,503 gzip bytes / 307,200-byte budget
- pre-commit Prettier and ESLint

Local Gradle was unavailable because the host has no JDK; the PR Android workflow remains the required native lint/unit-test gate before merge.