### PR TITLE
fix(listen): prevent native artwork flicker

### DIFF
--- a/app/listen/src/app-shell/AuthenticatedApp.test.tsx
+++ b/app/listen/src/app-shell/AuthenticatedApp.test.tsx
@@ -34,7 +34,7 @@ describe("AuthenticatedApp", () => {
     shellRender.mockClear();
   });
 
-  it("rebuilds protected media URLs after ticket refresh", () => {
+  it("does not rebuild the app shell after ticket refresh", () => {
     render(<AuthenticatedApp />);
     expect(shellRender).toHaveBeenCalledTimes(1);
 
@@ -42,6 +42,6 @@ describe("AuthenticatedApp", () => {
       setMediaAccessTickets([], "server-a");
     });
 
-    expect(shellRender).toHaveBeenCalledTimes(2);
+    expect(shellRender).toHaveBeenCalledTimes(1);
   });
 });

--- a/app/listen/src/app-shell/AuthenticatedApp.tsx
+++ b/app/listen/src/app-shell/AuthenticatedApp.tsx
@@ -2,11 +2,8 @@ import { AppProviders } from "@/app-shell/AppProviders";
 import { TauriDevLogPanel } from "@/components/dev/TauriDevLogPanel";
 import { Shell } from "@/components/layout/Shell";
 import { ShareSheetHost } from "@/components/share/ShareSheet";
-import { useMediaAccessVersion } from "@/hooks/use-media-access-version";
 
 export function AuthenticatedApp() {
-  useMediaAccessVersion();
-
   return (
     <AppProviders>
       <Shell />

--- a/app/listen/src/components/artwork/CrateImage.test.tsx
+++ b/app/listen/src/components/artwork/CrateImage.test.tsx
@@ -20,6 +20,7 @@ const versions = vi.hoisted(() => ({
   requiresTicket: true,
   resume: 0,
   tickets: 1,
+  usable: true,
 }));
 
 vi.mock("@/lib/artwork-manager", async (importOriginal) => {
@@ -67,11 +68,14 @@ describe("CrateImage", () => {
     versions.resume = 0;
     versions.requiresTicket = true;
     versions.tickets = 1;
+    versions.usable = true;
     managerMocks.preloadArtwork.mockReset();
     managerMocks.preloadResolvedArtwork.mockReset();
     managerMocks.refreshArtworkCandidate.mockReset();
     managerMocks.resolveArtworkCandidate.mockReset();
-    managerMocks.resolveArtworkCandidate.mockImplementation(candidate);
+    managerMocks.resolveArtworkCandidate.mockImplementation((value) =>
+      versions.usable ? candidate(value) : null,
+    );
     managerMocks.preloadArtwork.mockImplementation(
       async (value: ArtworkSource) => candidate(value),
     );
@@ -104,6 +108,35 @@ describe("CrateImage", () => {
       "src",
       "/api/artists/high-vis/photo?v=one&media_ticket=1",
     );
+  });
+
+  it("keeps ready artwork visible while credentials are temporarily absent", async () => {
+    const artwork = source("high-vis", "one");
+    const { rerender } = render(<CrateImage source={artwork} alt="High Vis" />);
+    const image = screen.getByRole("img", { name: "High Vis" });
+    fireEvent.load(image);
+
+    versions.usable = false;
+    versions.tickets = 2;
+    rerender(<CrateImage source={artwork} alt="High Vis" />);
+
+    expect(screen.getByRole("img", { name: "High Vis" })).toBe(image);
+    expect(image).toHaveAttribute(
+      "src",
+      "/api/artists/high-vis/photo?v=one&media_ticket=1",
+    );
+    expect(image).toHaveAttribute("data-artwork-state", "ready");
+
+    versions.usable = true;
+    versions.tickets = 3;
+    rerender(<CrateImage source={artwork} alt="High Vis" />);
+
+    expect(screen.getByRole("img", { name: "High Vis" })).toBe(image);
+    expect(image).toHaveAttribute(
+      "src",
+      "/api/artists/high-vis/photo?v=one&media_ticket=1",
+    );
+    expect(image).toHaveAttribute("data-artwork-state", "ready");
   });
 
   it("updates responsive sizes without replacing the visible bitmap", () => {

--- a/app/listen/src/components/artwork/CrateImage.tsx
+++ b/app/listen/src/components/artwork/CrateImage.tsx
@@ -154,6 +154,7 @@ export function CrateImage({
     desiredRef.current = desired;
     const current = activeRef.current;
     if (!resolved) {
+      if (current?.ready && artwork.retryPolicy === "credentials") return;
       commit(null);
       return;
     }
@@ -220,7 +221,9 @@ export function CrateImage({
   }, [artwork, loading, resumeVersion]);
 
   const displayed = !resolved
-    ? null
+    ? active?.ready && artwork.retryPolicy === "credentials"
+      ? active
+      : null
     : !active || active.candidate.logicalKey !== resolved.logicalKey
       ? { candidate: resolved, ready: false }
       : active;

--- a/app/listen/src/lib/api.test.ts
+++ b/app/listen/src/lib/api.test.ts
@@ -1096,6 +1096,26 @@ describe("native (configurable server) mode", () => {
   });
 
   describe("media access refresh", () => {
+    it("keeps media tickets when only the current access token changes", () => {
+      setupServer();
+      vi.spyOn(globalThis, "fetch").mockResolvedValue(
+        mockJsonResponse({
+          tickets: [],
+        }),
+      );
+      const stop = apiMod.startMediaAccessTicketRefresh();
+      expect(apiMod.apiAssetUrl("/api/cover.jpg")).toContain(
+        "media_ticket=artwork-ticket",
+      );
+
+      serverStore.setCurrentServerToken("rotated-access-token");
+
+      expect(apiMod.apiAssetUrl("/api/cover.jpg")).toContain(
+        "media_ticket=artwork-ticket",
+      );
+      stop();
+    });
+
     it("starts immediate artwork recovery without refreshing historical targets", async () => {
       setupServer();
       const initialResumeVersion = mediaAccess.getMediaAccessResumeVersion();

--- a/app/listen/src/lib/api.ts
+++ b/app/listen/src/lib/api.ts
@@ -628,6 +628,11 @@ export async function ensureMediaAccessUrl(
 
 export function startMediaAccessTicketRefresh(): () => void {
   if (!usesConfigurableServer || typeof window === "undefined") return () => {};
+  const serverIdentity = () => {
+    const server = getCurrentServer();
+    return server ? `${server.id}\u0000${server.url}` : "";
+  };
+  let activeServerIdentity = serverIdentity();
   const recoverAfterResume = () => {
     const server = getCurrentServer();
     if (server?.id) invalidateMediaAccessAudience("artwork", server.id);
@@ -643,7 +648,11 @@ export function startMediaAccessTicketRefresh(): () => void {
     45_000,
   );
   const handleServerChange = () => {
-    clearMediaAccessTickets();
+    const nextServerIdentity = serverIdentity();
+    if (nextServerIdentity !== activeServerIdentity) {
+      clearMediaAccessTickets();
+      activeServerIdentity = nextServerIdentity;
+    }
     void refreshMediaAccessTickets();
   };
   document.addEventListener("visibilitychange", handleVisibilityChange);


### PR DESCRIPTION
## Resumen

Corrige la desaparición sincronizada y el parpadeo de artwork interno en la app Android. El problema no dependía de backfill: la renovación de credenciales invalidaba globalmente los tickets de media y provocaba que todas las imágenes protegidas cayesen al placeholder a la vez.

## Causa raíz

- `AuthenticatedApp` estaba suscrito a cada batch de tickets de media y rerenderizaba todo el shell.
- Cada evento del store de servidores vaciaba los tickets, incluso cuando solo rotaba el access token del mismo servidor.
- `CrateImage` descartaba una imagen ya cargada si la resolución de la URL quedaba temporalmente sin ticket.

## Cambios

- Mantiene el bitmap listo durante huecos transitorios de credenciales.
- Elimina la suscripción global del shell a la versión de tickets; cada imagen conserva su propia actualización.
- Solo vacía tickets al cambiar realmente de servidor, no al rotar el token del servidor actual.
- Añade cobertura de regresión para los tres comportamientos.

## Validación

- Listen: 1.656 tests passed, 4 skipped.
- TypeScript typecheck: OK.
- ESLint: OK.
- Pre-commit: OK.
- APK debug: build correcto, firma APK Signature Scheme v2 válida.

## Riesgo

Acotado a la resolución de artwork autenticado en Listen. Los tickets siguen expirando en servidor y se renuevan ante error/reanudación; únicamente se evita borrar credenciales todavía válidas durante una rotación del access token.
